### PR TITLE
refactor: replace all aur-malware-check strings with archcanary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,17 @@
 # Changelog
 
 ## 3.0 (2026-06-16)
-- New: `aur_check_py/` — Python 3.14+ port of `aur_check-v2.sh`, stdlib only
+- New: `archcanary_py/` — Python 3.14+ port of `archcanary.sh`, stdlib only
 - All 6 checks preserved, `--merge` mode, compressed log support (gzip/xz/bz2/zstd)
 - 75 unit tests, `unittest` + `unittest.mock`, laufen ohne Arch-System
 - `developing.md` — coding conventions, `README.md` — use-case map
 - Bash scripts remain at 2.3.x for legacy use
 
 ## 2.12.1 (2026-06-18) — personal fork
-- Fix: the desktop notifier (`aur-malware-check-notify.path`) wedged into a permanent `failed` (`start-limit-hit`) state, silently disabling detection alerts. The path unit used `PathModified=`, which fires on **every write** to `last-scan.log`; since the scan streams that file line-by-line via `tee`, a single scan triggered the oneshot notifier dozens of times in seconds and tripped systemd's default start limit. Switched to `PathChanged=` (fires once when the writer closes the file) and set `StartLimitIntervalSec=0` on both the `.path` and `.service` so a transient burst can never permanently wedge the watcher. Recover an already-failed unit with `systemctl --user reset-failed aur-malware-check-notify.path && systemctl --user restart aur-malware-check-notify.path` (or re-run `install.sh --system`). Surfaced by the new `--doctor` systemd state check.
+- Fix: the desktop notifier (`archcanary-notify.path`) wedged into a permanent `failed` (`start-limit-hit`) state, silently disabling detection alerts. The path unit used `PathModified=`, which fires on **every write** to `last-scan.log`; since the scan streams that file line-by-line via `tee`, a single scan triggered the oneshot notifier dozens of times in seconds and tripped systemd's default start limit. Switched to `PathChanged=` (fires once when the writer closes the file) and set `StartLimitIntervalSec=0` on both the `.path` and `.service` so a transient burst can never permanently wedge the watcher. Recover an already-failed unit with `systemctl --user reset-failed archcanary-notify.path && systemctl --user restart archcanary-notify.path` (or re-run `install.sh --system`). Surfaced by the new `--doctor` systemd state check.
 
 ## 2.12.0 (2026-06-18) — personal fork
-- Change: `--doctor` Automation (systemd) section now checks **real unit state**, not just whether the unit file exists. It queries `systemctl is-enabled`/`is-active` (no root needed) for the four units the installer enables — system `aur-malware-check.timer` + `.path`, and **user** `aur-malware-check-user.timer` + `notify.path` (the user scan timer was previously not checked at all) — and gives a **state-appropriate fix**: not installed → re-run the installer; present but disabled → `systemctl enable --now`; enabled but failed/inactive → `systemctl restart` + a `status` hint. The user bus being unavailable (over SSH/sudo) is reported, not flagged as missing.
+- Change: `--doctor` Automation (systemd) section now checks **real unit state**, not just whether the unit file exists. It queries `systemctl is-enabled`/`is-active` (no root needed) for the four units the installer enables — system `archcanary.timer` + `.path`, and **user** `archcanary-user.timer` + `notify.path` (the user scan timer was previously not checked at all) — and gives a **state-appropriate fix**: not installed → re-run the installer; present but disabled → `systemctl enable --now`; enabled but failed/inactive → `systemctl restart` + a `status` hint. The user bus being unavailable (over SSH/sudo) is reported, not flagged as missing.
 - New: a third status marker **`[WARN]`** (yellow) for elements that are present but not functioning (e.g. a unit installed-but-disabled or enabled-but-failed), distinct from `[MISS]` (red, absent) and `[ OK ]` (green). WARN and MISS both feed the next-step pointer and set a non-zero exit.
 
 ## 2.11.1 (2026-06-18) — personal fork
@@ -25,39 +25,39 @@
 - New: `--doctor` — a standalone setup health check that reports the install/config status of every element of the stack (dependencies, user install, system/root install, systemd automation, and the pre-install layer: aurscan/syay, the `yay=syay` alias, traur, yay `init.lua` hooks). Each missing item prints the exact command to fix it. It runs before the scan machinery (no log tee, no list loading) so it never errors on the very state it reports, and it auto-detects the platform (distro, AUR helpers present, `mhwd`). Exit 0 = all present, 1 = something missing. The alias check reads the resolved interactive alias rather than grepping a fixed file, so it works regardless of which file defines it or whether the value is quoted. The GUI will surface these fix commands as copyable / open-terminal actions (it never auto-runs installs).
 
 ## 2.9.9 (2026-06-17) — personal fork
-- Change: the DKMS allowlist is now a **single system-wide file** at `/etc/aur-malware-check/dkms_allowlist.conf`. After the system/user scan split the kmod audit only runs as root, so a per-user `~/.config` copy was vestigial and confusing (two files, only `/etc` authoritative). The script now reads only `/etc` (override with `DKMS_ALLOWLIST_FILE` for tests); `install.sh --system` seeds it (migrating any existing `~/.config` entries, then removing that per-user copy); base `install.sh` no longer creates a per-user allowlist; and the GUI **Edit DKMS allowlist** button now edits `/etc` and saves it back via pkexec. Edit it with the GUI button or `sudoedit /etc/aur-malware-check/dkms_allowlist.conf`.
+- Change: the DKMS allowlist is now a **single system-wide file** at `/etc/archcanary/dkms_allowlist.conf`. After the system/user scan split the kmod audit only runs as root, so a per-user `~/.config` copy was vestigial and confusing (two files, only `/etc` authoritative). The script now reads only `/etc` (override with `DKMS_ALLOWLIST_FILE` for tests); `install.sh --system` seeds it (migrating any existing `~/.config` entries, then removing that per-user copy); base `install.sh` no longer creates a per-user allowlist; and the GUI **Edit DKMS allowlist** button now edits `/etc` and saves it back via pkexec. Edit it with the GUI button or `sudoedit /etc/archcanary/dkms_allowlist.conf`.
 
 ## 2.9.8 (2026-06-17) — personal fork
 - Fix: the GUI no longer marks **every** check ❌ when a full scan finds one problem. `_propagate_full_scan` used to stamp the single overall verdict onto all rows, so one `INFECTED` check (e.g. an unallowlisted DKMS module) lit up the whole list. It now parses each check's own `--- [N] ---` section in the scan output and sets that row from its own result (WARNING/INFECTED → ❌, Skipped/needs-root → ?, otherwise ✅) — a finding points at the check that found it.
 
 ## 2.9.7 (2026-06-17) — personal fork
-- Change: automated scanning is split by context so neither half false-positives. The **root system** timer now runs only the system-level checks (`--check-systemd/--check-ebpf/--check-bpftool/--check-ldso/--check-kmod` + the always-on package/log checks); a new **user** timer (`aur-malware-check-user.{service,timer}`) runs the user-level checks (`--check-npm-cache/--check-bun-cache/--check-yarn-cache/--check-pnpm-cache/--check-pkgbuild/--check-autostart`) as your user, so they scan your real `~/.cache`/`~/.config` instead of `/root`. Fixes the root scan flagging root's own `/root/.config/autostart` session relics as a false `RESULT: INFECTED`. The user scan notifies itself (runs in your session); the root scan still uses the path-watched notifier. `install.sh --system` installs and enables both; `systemd.md` updated.
-- Fix: the DKMS allowlist loader used `[[ -f ]]` and aborted the whole scan (`Permission denied`, exit 1, under `set -e`) when `/etc/aur-malware-check/dkms_allowlist.conf` existed but was not readable. It now tests `[[ -r ]]` and skips unreadable files, and `install.sh --system` installs the system allowlist mode `644` (the user-level scan reads it too, even if your `~/.config` copy is `600`).
+- Change: automated scanning is split by context so neither half false-positives. The **root system** timer now runs only the system-level checks (`--check-systemd/--check-ebpf/--check-bpftool/--check-ldso/--check-kmod` + the always-on package/log checks); a new **user** timer (`archcanary-user.{service,timer}`) runs the user-level checks (`--check-npm-cache/--check-bun-cache/--check-yarn-cache/--check-pnpm-cache/--check-pkgbuild/--check-autostart`) as your user, so they scan your real `~/.cache`/`~/.config` instead of `/root`. Fixes the root scan flagging root's own `/root/.config/autostart` session relics as a false `RESULT: INFECTED`. The user scan notifies itself (runs in your session); the root scan still uses the path-watched notifier. `install.sh --system` installs and enables both; `systemd.md` updated.
+- Fix: the DKMS allowlist loader used `[[ -f ]]` and aborted the whole scan (`Permission denied`, exit 1, under `set -e`) when `/etc/archcanary/dkms_allowlist.conf` existed but was not readable. It now tests `[[ -r ]]` and skips unreadable files, and `install.sh --system` installs the system allowlist mode `644` (the user-level scan reads it too, even if your `~/.config` copy is `600`).
 
 ## 2.9.6 (2026-06-17) — personal fork
-- Fix: the root **system** scan flagged allowlisted DKMS modules (e.g. `tuxedo-drivers`) as "untracked source" → false `RESULT: INFECTED`. The DKMS allowlist lived only in the user's `~/.config`, which the root service (`HOME=/root`) can't see. The script now also reads a **system-wide** `/etc/aur-malware-check/dkms_allowlist.conf` (merged with the per-user file), and `install.sh --system` seeds it from your user allowlist. Re-run `install.sh --system` (or edit `/etc/...`) after changing the allowlist.
+- Fix: the root **system** scan flagged allowlisted DKMS modules (e.g. `tuxedo-drivers`) as "untracked source" → false `RESULT: INFECTED`. The DKMS allowlist lived only in the user's `~/.config`, which the root service (`HOME=/root`) can't see. The script now also reads a **system-wide** `/etc/archcanary/dkms_allowlist.conf` (merged with the per-user file), and `install.sh --system` seeds it from your user allowlist. Re-run `install.sh --system` (or edit `/etc/...`) after changing the allowlist.
 
 ## 2.9.5 (2026-06-17) — personal fork
 - Fix: the root **system** service failed with `HOME: unbound variable` (exit 1) at the cache-dir line. systemd system services start with no `$HOME`, and under `set -u` the `${XDG_CACHE_HOME:-$HOME/.cache}` fallback aborts. The script now defaults `$HOME` to the running user's home (`/root` for the system scan) when it is unset — complementing the `$SUDO_USER`/`$PKEXEC_UID` resolution, which only covers interactive sudo/pkexec. Regression from 2.9.1.
 
 ## 2.9.4 (2026-06-17) — personal fork
-- Fix: `check_systemd` no longer flags a persistent `.timer` (`OnBootSec=` + `Persistent=true`) just for existing — it now vets the **service the timer triggers** and only warns when that target service is itself suspicious (ExecStart outside a standard prefix, not pacman-owned). This stops the scanner from flagging its own `/etc/systemd/system/aur-malware-check.timer` (installed by `install.sh --system`) as a malicious persistence unit, which produced a false `RESULT: INFECTED` and desktop alert. A malicious timer pointing at `/tmp`, `$HOME`, etc. is still caught.
+- Fix: `check_systemd` no longer flags a persistent `.timer` (`OnBootSec=` + `Persistent=true`) just for existing — it now vets the **service the timer triggers** and only warns when that target service is itself suspicious (ExecStart outside a standard prefix, not pacman-owned). This stops the scanner from flagging its own `/etc/systemd/system/archcanary.timer` (installed by `install.sh --system`) as a malicious persistence unit, which produced a false `RESULT: INFECTED` and desktop alert. A malicious timer pointing at `/tmp`, `$HOME`, etc. is still caught.
 
 ## 2.9.3 (2026-06-17) — personal fork
-- New: the systemd units are now shipped under `systemd/` and `install.sh --system` installs and enables them — no more hand-creating files. It drops the root system scan units (`aur-malware-check.{service,timer,path}` + `-onchange.service`) into `/etc/systemd/system/`, the user notifier (`aur-malware-check-notify.{path,service}`) into `~/.config/systemd/user/`, pre-creates `/var/lib/aur-malware-check/`, enables the timer + pacman trigger + notifier, and migrates away the old user-scope scan units. `uninstall --system` reverses all of it.
-- Fix: the user notifier `.path` unit failed to start when `/var/lib/aur-malware-check/` did not exist yet (inotify watch on a missing directory). The install now pre-creates the directory.
+- New: the systemd units are now shipped under `systemd/` and `install.sh --system` installs and enables them — no more hand-creating files. It drops the root system scan units (`archcanary.{service,timer,path}` + `-onchange.service`) into `/etc/systemd/system/`, the user notifier (`archcanary-notify.{path,service}`) into `~/.config/systemd/user/`, pre-creates `/var/lib/archcanary/`, enables the timer + pacman trigger + notifier, and migrates away the old user-scope scan units. `uninstall --system` reverses all of it.
+- Fix: the user notifier `.path` unit failed to start when `/var/lib/archcanary/` did not exist yet (inotify watch on a missing directory). The install now pre-creates the directory.
 
 ## 2.9.2 (2026-06-17) — personal fork
 - Fix: a scan that skips root-requiring checks no longer reports a misleading `RESULT: CLEAN`. When `--check-kmod` / `--check-ebpf` / `--check-bpftool` (or `--full`) is run without root, those checks now return a dedicated "skipped" code; the run is reported as `INCOMPLETE: N root check(s) skipped` and the result escalates from CLEAN (0) to WARNINGS (exit 1) so automation and the systemd user service can detect that the scan was not complete. Run with `sudo` for the full picture. Genuine findings (exit 2) are unchanged.
-- Change: systemd model reworked so automated scans get the **full picture**. The scan now runs as a **root system** service+timer (writes `/var/lib/aur-malware-check/last-scan.log`), and a **user** `.path` unit watches that file and fires the desktop notification on a detection — replacing the old user-only service that silently skipped the root checks. `docs/systemd.md` rewritten with the new units and a migration note.
-- Change: `install.sh --system` now also seeds the bundled package lists (`package_list.txt`, `malicious_npm_packages.txt`, `chaos_rat_packages.txt`) into `/usr/lib/aur-malware-check/` so the root system scan finds them (root's `$HOME` is `/root`, which is not seeded).
+- Change: systemd model reworked so automated scans get the **full picture**. The scan now runs as a **root system** service+timer (writes `/var/lib/archcanary/last-scan.log`), and a **user** `.path` unit watches that file and fires the desktop notification on a detection — replacing the old user-only service that silently skipped the root checks. `docs/systemd.md` rewritten with the new units and a migration note.
+- Change: `install.sh --system` now also seeds the bundled package lists (`package_list.txt`, `malicious_npm_packages.txt`, `chaos_rat_packages.txt`) into `/usr/lib/archcanary/` so the root system scan finds them (root's `$HOME` is `/root`, which is not seeded).
 
 ## 2.9.1 (2026-06-17) — personal fork
-- Fix: `sudo aur-malware-check.sh --check-kmod` (and other root checks run directly with `sudo`) no longer fails with `Malicious npm package list not found: /root/.config/...`. When running as root via `sudo`, the script now resolves the invoking user's home from `$SUDO_USER` (and `$PKEXEC_UID` for the pkexec path) so package lists, the DKMS allowlist, and the log/cache dirs come from the user's `~/.config` / `~/.cache` instead of `/root`. Mirrors what the polkit root helper already did for the GUI.
+- Fix: `sudo archcanary.sh --check-kmod` (and other root checks run directly with `sudo`) no longer fails with `Malicious npm package list not found: /root/.config/...`. When running as root via `sudo`, the script now resolves the invoking user's home from `$SUDO_USER` (and `$PKEXEC_UID` for the pkexec path) so package lists, the DKMS allowlist, and the log/cache dirs come from the user's `~/.config` / `~/.cache` instead of `/root`. Mirrors what the polkit root helper already did for the GUI.
 
 ## 2.9.0 (2026-06-17) — personal fork
-- Removed: `aur_malware_menu.sh` (fzf TUI) — the yad GUI covers interactive desktop use and the CLI (`aur-malware-check.sh --full` / single `--check-*` flags) covers headless / SSH. The menu had drifted (missing yarn/pnpm checks) and its "View last log" used the abandoned journalctl path. Two surfaces now: GUI + CLI.
-- Removed: `notify-send.sh` dependency and the notification action button. The exit-code-2 alert now uses plain `notify-send` (libnotify) with no button; open AUR Malware Check from the app launcher to review and remediate.
+- Removed: `archcanary-menu.sh` (fzf TUI) — the yad GUI covers interactive desktop use and the CLI (`archcanary.sh --full` / single `--check-*` flags) covers headless / SSH. The menu had drifted (missing yarn/pnpm checks) and its "View last log" used the abandoned journalctl path. Two surfaces now: GUI + CLI.
+- Removed: `notify-send.sh` dependency and the notification action button. The exit-code-2 alert now uses plain `notify-send` (libnotify) with no button; open Archcanary from the app launcher to review and remediate.
 - Removed: "View last log" from the GUI — the per-session status column already shows pass/fail per check; re-run a check to see its detail.
 - Removed: orphaned `IS_FULL_SCAN` header marker (only ever fed the now-deleted GUI log picker).
 - Fix: `install.sh` used `local` outside a function in the uninstall path (runtime error on `bash`).
@@ -75,7 +75,7 @@
 - Fix: `check_systemd` now also skips services whose `ExecStart=` binary lives under a standard system prefix (`/usr/`, `/opt/`, `/bin/`, `/sbin/`, `/usr/local/`) and actually exists on disk — handles proprietary installers (piavpn, forgejo) that write a `.service` file without registering it with pacman. Malware still gets caught because it points to binaries in `/tmp/`, `$HOME/`, `/dev/shm/`, etc.
 
 ## 2.8.2 (2026-06-16) — personal fork
-- Fix: run logs now default to `~/.cache/aur-malware-check/` (`$XDG_CACHE_HOME`) instead of the current working directory — prevents log accumulation in the repo or install source dir
+- Fix: run logs now default to `~/.cache/archcanary/` (`$XDG_CACHE_HOME`) instead of the current working directory — prevents log accumulation in the repo or install source dir
 
 ## 2.8.1 (2026-06-16) — personal fork
 - Fix: `check_systemd` no longer flags pacman-owned `.service` / drop-in `.conf` files — legitimate system daemons from packages carry `Restart=on-failure` by design. Timer check is now skipped for user-space dirs (`~/.config/systemd/user/`) since `OnBootSec + Persistent=true` is standard for user timers (cron replacements, update schedulers).
@@ -112,13 +112,13 @@
 - Change: `install.sh` now prefers `~/.local/bin` (XDG) over `~/bin`
 
 ## 2.4.0 (2026-06-14) — personal fork
-- New: XDG config dir — package lists live in `~/.config/aur-malware-check/` (respects `$XDG_CONFIG_HOME`); created automatically on first run
+- New: XDG config dir — package lists live in `~/.config/archcanary/` (respects `$XDG_CONFIG_HOME`); created automatically on first run
 - New: auto-seed config dir from bundled txt files when running from a new install location
 - New: `--check-pkgbuild` (included in `--full`) — obfuscation-aware scan of AUR helper caches (`~/.cache/yay`, `~/.cache/paru`, etc.) for `bun add` / `npm install` of malicious packages; catches quote-split commands like `'b''u''n' 'a'"d""d"`
 - New: `nextfile-js` added to malicious npm package list (reported upstream issue #11 / PR #12)
-- New: `aur_malware_menu.sh` — fzf TUI menu to run individual checks or view the last log; loops back to menu after each action
+- New: `archcanary-menu.sh` — fzf TUI menu to run individual checks or view the last log; loops back to menu after each action
 - New: `--no-notify` flag — suppresses desktop notification when called as subprocess (e.g. from the menu)
-- Improved: notification prefers `notify-send.sh` (AUR) over plain `notify-send`; adds a **Show Menu** button that opens `aur_malware_menu.sh` in a terminal when clicked
+- Improved: notification prefers `notify-send.sh` (AUR) over plain `notify-send`; adds a **Show Menu** button that opens `archcanary-menu.sh` in a terminal when clicked
 - Package list refreshed to 1936 entries
 
 ## 2.3.3 (2026-06-13)
@@ -129,7 +129,7 @@
 ## 2.3.2 (2026-06-13)
 - New: `--all-time` flag (v2) — disable recency window for cross-campaign detection
 - New: `custom_list_merge_aur_scan.sh` — fetch HedgeDoc + merge custom lists +
-  dedup + run aur_check-v2.sh
+  dedup + run archcanary.sh
   - `-l/--list=URL|FILE`: additional AUR package lists (repeatable)
   - `-m/--malicious-npm=URL|FILE`: additional npm lists (repeatable)
   - `--skip-hedgedoc`: exclude official HedgeDoc list
@@ -180,7 +180,7 @@
 - New attacker accounts custodiatovar, veramagalhaes in iocs.txt
 
 ## 2.0.0 (2026-06-12)
-- `aur_check-v2.sh`: optimized log scanner (bash regex + O(1) assoc. array)
+- `archcanary.sh`: optimized log scanner (bash regex + O(1) assoc. array)
 - Same detection logic as v1, ~150x faster for large pacman.log files
 - v1 retained for completeness as reference implementation
 
@@ -194,7 +194,7 @@
 - Pipe-to-subshell fixed: `while read` now uses process substitution
 
 ## 1.0.0 (2026-06-12)
-- Consolidated aur_check.sh combining all 5 community forks
+- Consolidated archcanary.sh combining all 5 community forks
 - Package list: ~588 known compromised AUR packages
 - Detection: current install + pacman logs + date window
 - Optional checks: systemd, eBPF, npm cache

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# AUR Malware Check - June 2026 Campaign
+# Archcanary - June 2026 Campaign
 
-> **WARNING: Ultra personal fork for Manjaro Openbox (Mabox).** Tuned for this specific setup — false-positive thresholds, paths, and defaults reflect a Mabox system. For a general-purpose Arch/AUR scanner use [lenucksi/aur-malware-check](https://github.com/lenucksi/aur-malware-check) instead.
+> **WARNING: Ultra personal fork for Manjaro Openbox (Mabox).** Tuned for this specific setup — false-positive thresholds, paths, and defaults reflect a Mabox system. For a general-purpose Arch/AUR scanner use [lenucksi/archcanary](https://github.com/lenucksi/archcanary) instead.
 >
 > **Read-only by design.** The scanner detects and reports, and never deletes, quarantines, or disables anything it flags — remediation is left to you. The only files it writes are its own logs and config lists. Installation (`install.sh`), the `--refresh` package-list download, and the DKMS allowlist editor are the exceptions that touch the system or network, and all are explicit.
 >
@@ -10,10 +10,10 @@
 
 | Patch | Description |
 |-------|-------------|
-| XDG config dir | Package lists live in `~/.config/aur-malware-check/` instead of alongside the script |
+| XDG config dir | Package lists live in `~/.config/archcanary/` instead of alongside the script |
 | Auto-seed config | Config dir is populated from bundled txt files on first run — no manual copy needed |
 | Desktop alert | Fires a critical notification (`notify-send` / libnotify) on exit code 2. Open the GUI from your app launcher to review. `--no-notify` suppresses it |
-| `aur_malware_gui.sh` | yad GUI with grouped checks, per-session status column (✅/⚠/❌/?), and polkit auth for root-requiring checks (eBPF, bpftool, kmod). Live streaming output window. Install root helper with `./install.sh --system` |
+| `archcanary-gui.sh` | yad GUI with grouped checks, per-session status column (✅/⚠/❌/?), and polkit auth for root-requiring checks (eBPF, bpftool, kmod). Live streaming output window. Install root helper with `./install.sh --system` |
 | `--check-pkgbuild` | Obfuscation-aware scan of AUR helper caches for `bun add` / `npm install` of malicious packages — catches quote-split, base64-decode-to-shell, `eval+$(...)`, `printf` hex/octal, and variable-split command reassembly |
 | `--check-yarn-cache` / `--check-pnpm-cache` | Extends npm/bun cache scanning to yarn and pnpm; includes fnm per-version Node installs |
 | `--check-bpftool` | Enumerates **all** loaded eBPF programs via `bpftool` — complements `--check-ebpf` (which only globs pinned `/sys/fs/bpf/hidden_*` maps) by catching unpinned or differently-named programs; warns on stealth hook types (kprobe/tracing/lsm/tracepoint); suppresses LSM false positives from systemd/AppArmor |
@@ -36,11 +36,11 @@ This is a collection of all the scattered resources, especially the ones in the 
 
 > [!TIP]
 > **Questions, support, or general discussion?** Head over to
-> [Discussions](https://github.com/lenucksi/aur-malware-check/discussions/).
+> [Discussions](https://github.com/lenucksi/archcanary/discussions/).
 > Issues are reserved for bug reports and feature requests only.
 
 > [!TIP]
-> **Python 3.14+ version available?** See `aur_check_py/` — stdlib-only, typed,
+> **Python 3.14+ version available?** See `archcanary_py/` — stdlib-only, typed,
 > testable, should be functionally identical, please test and report back.
 
 > **1600+ AUR packages compromised** by attackers who injected `npm install atomic-lockfile`, `bun install js-digest`, or `lockfile-js` into PKGBUILD/install files. Two attack waves:
@@ -53,22 +53,22 @@ This is a collection of all the scattered resources, especially the ones in the 
 
 ```bash
 # Check if you have any infected packages
-./aur_check-v2.sh
+./archcanary.sh
 
 # Check bun cache specifically (for js-digest / atomic-lockfile)
-./aur_check-v2.sh --check-bun-cache
+./archcanary.sh --check-bun-cache
 
 # Safe one-liner (from quantenProjects) - just compare installed vs infected list
-comm -1 -2 <(pacman -Qq | sort) <(curl -s https://raw.githubusercontent.com/lenucksi/aur-malware-check/master/package_list.txt | sort)
+comm -1 -2 <(pacman -Qq | sort) <(curl -s https://raw.githubusercontent.com/lenucksi/archcanary/master/package_list.txt | sort)
 
 # Full scan with all optional checks
-./aur_check-v2.sh --full
+./archcanary.sh --full
 
 # Enumerate loaded eBPF programs (needs root) — flags stealth hook types
-sudo ./aur_check-v2.sh --check-bpftool
+sudo ./archcanary.sh --check-bpftool
 
 # Cross-campaign: scan all installed packages regardless of install date
-./aur_check-v2.sh --all-time
+./archcanary.sh --all-time
 
 # Merge multiple lists (HedgeDoc + historical + custom) and scan
 ./custom_list_merge_aur_scan.sh -l ./historical_packages.txt
@@ -77,19 +77,19 @@ sudo ./aur_check-v2.sh --check-bpftool
 ./custom_list_merge_aur_scan.sh -l ./historical_packages.txt -- --all-time
 
 # Refresh the package list from the official Arch Linux HedgeDoc, then scan
-./aur_check-v2.sh --refresh --full
+./archcanary.sh --refresh --full
 
 # Use custom package lists (also settable via env vars):
 #   PACKAGE_LIST_FILE=./my_list.txt
 #   MALICIOUS_NPM_LIST=./my_npm.txt
-./aur_check-v2.sh --package-list=my_list.txt --malicious-npm-list=my_npm.txt
+./archcanary.sh --package-list=my_list.txt --malicious-npm-list=my_npm.txt
 
 
 # Legacy scan (only use if v2 is broken)
-./archive/aur_check.sh
+./archive/archcanary.sh
 ```
 
-## Script: `aur_check.sh`
+## Script: `archcanary.sh`
 
 A consolidated detection script combining the best features from all community forks:
 
@@ -119,8 +119,8 @@ Two versions are maintained — v2 is optimized but functionally identical:
 
 | Version | File | Log Scanning | Speed (6.2 MB pacman.log) |
 |---------|------|-------------|--------------------------|
-| v1 | `aur_check.sh` | `echo \| sed` subprocesses + `grep -xF` tempfile | ~3-5 min |
-| v2 | `aur_check-v2.sh` | Bash regex (`[[ $line =~ $re ]]`) + O(1) assoc. array | ~1-2 s |
+| v1 | `archcanary.sh` | `echo \| sed` subprocesses + `grep -xF` tempfile | ~3-5 min |
+| v2 | `archcanary.sh` | Bash regex (`[[ $line =~ $re ]]`) + O(1) assoc. array | ~1-2 s |
 
 v2 verified against v1 by static analysis: **8/10 risk categories NONE, 2/10 LOW** (theoretical edge cases only, no real inputs affected). Use v2 for speed; v1 retained as reference for completeness.
 
@@ -133,10 +133,10 @@ v2 verified against v1 by static analysis: **8/10 risk categories NONE, 2/10 LOW
 ## Repository Structure
 
 ```
-aur-malware-check/
+archcanary/
 ├── README.md              # This file
-├── aur_check.sh           # v1: Consolidated detection script (sed+grep log scanner)
-├── aur_check-v2.sh        # v2: Optimized log scanner (bash regex + O(1) hash lookup)
+├── archcanary.sh           # v1: Consolidated detection script (sed+grep log scanner)
+├── archcanary.sh        # v2: Optimized log scanner (bash regex + O(1) hash lookup)
 ├── package_list.txt              # bundled compromised packages, same as --refresh one as of 6/17/26. (1619 via `--refresh`)
 ├── malicious_npm_packages.txt    # Malicious npm package names for cache checks
 ├── iocs.txt                      # Indicators of Compromise
@@ -165,7 +165,7 @@ This analysis aggregates information from the following sources:
 | Source | URL | Content Used |
 |--------|-----|-------------|
 | IFIN Discourse | https://discourse.ifin.network/t/400-aur-packages-compromised-with-infostealer-and-rootkit/577 | Attack summary, links, **bun/js-digest wave update (Jun 12)** |
-| ioctl.fail Analysis | https://ioctl.fail/preliminary-analysis-of-aur-malware/ | Detailed technical analysis, IOCs, eBPF rootkit details, C2 extraction |
+| ioctl.fail Analysis | https://ioctl.fail/preliminary-analysis-of-archcanary/ | Detailed technical analysis, IOCs, eBPF rootkit details, C2 extraction |
 | Arch ML: Main Thread | https://lists.archlinux.org/archives/list/aur-general@lists.archlinux.org/thread/FGXPCB3ZVCJIV7FX323SBAX2JHYB7ZS4/ | Master list of ~408 packages by Andre Herbst, additional reports by Rafal Lichwala, Nicolas Boichat, Damien |
 | Arch ML: HedgeDoc Package List | https://lists.archlinux.org/archives/list/aur-general@lists.archlinux.org/message/FCH7TT6IOVT7D477JKSVJALBKADAARSW/ | Jonathan Grotelüschen (Arch Staff) posts HedgeDoc link with updated affected package list |
 | Arch ML: ALVR Report | https://lists.archlinux.org/archives/list/aur-general@lists.archlinux.org/thread/2LGBF2AZBPVCCY4VTN6DOVUNNBURFJ2J/ | First report of suspicious commit on alvr package |
@@ -221,9 +221,9 @@ This analysis aggregates information from the following sources:
 
 | Source | URL | Content Used |
 |--------|-----|-------------|
-| **drbbgh** (PR #8) | https://github.com/lenucksi/aur-malware-check/pull/8 | `--refresh` flag: live package list fetch from Arch Linux HedgeDoc |
-| **liphiwolf** (PR #7) | https://github.com/lenucksi/aur-malware-check/pull/7 | `lockfile-js` detection, expanded package list from CSCS paste |
-| **0xf836** (PR #4) | https://github.com/lenucksi/aur-malware-check/pull/4 | Package list expansion (superseded by PR #8) |
+| **drbbgh** (PR #8) | https://github.com/lenucksi/archcanary/pull/8 | `--refresh` flag: live package list fetch from Arch Linux HedgeDoc |
+| **liphiwolf** (PR #7) | https://github.com/lenucksi/archcanary/pull/7 | `lockfile-js` detection, expanded package list from CSCS paste |
+| **0xf836** (PR #4) | https://github.com/lenucksi/archcanary/pull/4 | Package list expansion (superseded by PR #8) |
 
 ### Additional Data
 
@@ -277,10 +277,10 @@ This analysis aggregates information from the following sources:
 1. **Preserve the system**: Do not power off - use forensic acquisition with trusted media
 2. **Rotate ALL credentials**: Discord, GitHub, npm, Slack, Teams, SSH keys, Vault tokens, cloud provider keys
 3. **Check for persistence**: `systemctl list-units --type=service --state=running` (check for unknown services); also check drop-ins and timers with `--check-systemd`
-4. **Check for eBPF rootkit**: `ls -la /sys/fs/bpf/hidden_*`, and enumerate loaded programs with `sudo bpftool prog show` / `sudo bpftool link show` — look for `kprobe`/`tracing`/`lsm`/`tracepoint` hooks you didn't install (or run `sudo ./aur_check-v2.sh --check-bpftool`)
-4a. **Check for library injection**: `cat /etc/ld.so.preload` — any non-empty content means a `.so` is being injected into every process (or run `./aur_check-v2.sh --check-ldso`)
-4b. **Check for user-space persistence**: review `~/.config/autostart/`, `~/.config/systemd/user/`, and shell RC files for suspicious entries (or run `./aur_check-v2.sh --check-autostart`)
-4c. **Check for rogue kernel modules**: `lsmod` and `dkms status` — flag any module not from a known package (or run `sudo ./aur_check-v2.sh --check-kmod`)
+4. **Check for eBPF rootkit**: `ls -la /sys/fs/bpf/hidden_*`, and enumerate loaded programs with `sudo bpftool prog show` / `sudo bpftool link show` — look for `kprobe`/`tracing`/`lsm`/`tracepoint` hooks you didn't install (or run `sudo ./archcanary.sh --check-bpftool`)
+4a. **Check for library injection**: `cat /etc/ld.so.preload` — any non-empty content means a `.so` is being injected into every process (or run `./archcanary.sh --check-ldso`)
+4b. **Check for user-space persistence**: review `~/.config/autostart/`, `~/.config/systemd/user/`, and shell RC files for suspicious entries (or run `./archcanary.sh --check-autostart`)
+4c. **Check for rogue kernel modules**: `lsmod` and `dkms status` — flag any module not from a known package (or run `sudo ./archcanary.sh --check-kmod`)
 5. **Clean with trusted media**: Boot from Arch ISO, mount filesystem, remove malicious systemd units
 6. **Consider reinstallation**: The rootkit makes the system untrustworthy
 7. **Report findings**: https://lists.archlinux.org/archives/list/aur-general@lists.archlinux.org/
@@ -291,10 +291,10 @@ Community tools - no warranty. Use at your own risk.
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=lenucksi%2Faur-malware-check&type=date&legend=top-left">
+<a href="https://www.star-history.com/?repos=lenucksi%2Farchcanary&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=lenucksi/aur-malware-check&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=lenucksi/aur-malware-check&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=lenucksi/aur-malware-check&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=lenucksi/archcanary&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=lenucksi/archcanary&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=lenucksi/archcanary&type=date&legend=top-left" />
  </picture>
 </a>

--- a/SOURCES.md
+++ b/SOURCES.md
@@ -1,4 +1,4 @@
-# Sources — AUR Malware Check (June 2026)
+# Sources — Archcanary (June 2026)
 
 Numbered and structured references for the atomic-lockfile / js-digest supply-chain attack on the Arch User Repository.
 
@@ -25,7 +25,7 @@ Numbered and structured references for the atomic-lockfile / js-digest supply-ch
 ## 2. Technical Analysis
 
 ### 2.1 ioctl.fail — Preliminary Analysis
-- **URL:** https://ioctl.fail/preliminary-analysis-of-aur-malware/
+- **URL:** https://ioctl.fail/preliminary-analysis-of-archcanary/
 - **Date:** 2026-06-11
 - **Content:** Detailed technical analysis. IOCs, eBPF rootkit details (CAP_BPF, hides processes/files/socket inodes), C2 extraction via Tor onion service, systemd persistence, credential theft targeting Discord/GitHub/npm/Slack/SSH/Vault.
 - **Relevant for:** Malware capabilities, IoCs, persistence mechanisms.

--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -5,22 +5,22 @@ SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 MAIN_SCRIPT=""
 
 for candidate in \
-    "$SCRIPT_DIR/aur-malware-check.sh" \
-    "$SCRIPT_DIR/aur_check-v2.sh" \
-    "$(command -v aur-malware-check.sh 2>/dev/null || true)"; do
+    "$SCRIPT_DIR/archcanary.sh" \
+    "$SCRIPT_DIR/archcanary.sh" \
+    "$(command -v archcanary.sh 2>/dev/null || true)"; do
     [[ -n "${candidate:-}" && -x "$candidate" ]] && { MAIN_SCRIPT="$candidate"; break; }
 done
 
 if [[ -z "$MAIN_SCRIPT" ]]; then
     yad --error \
-        --title="AUR Malware Check" \
+        --title="Archcanary" \
         --window-icon=security-high \
-        --text="<b>aur-malware-check.sh not found.</b>\n\nRun <tt>./install.sh</tt> first." \
+        --text="<b>archcanary.sh not found.</b>\n\nRun <tt>./install.sh</tt> first." \
         --width=400
     exit 1
 fi
 
-ROOT_HELPER="/usr/lib/aur-malware-check/root-helper"
+ROOT_HELPER="/usr/lib/archcanary/root-helper"
 PKEXEC="$(command -v pkexec 2>/dev/null || true)"
 HAS_ROOT=false
 [[ -n "$PKEXEC" && -x "$ROOT_HELPER" ]] && HAS_ROOT=true
@@ -124,7 +124,7 @@ _propagate_full_scan() {
 
 _show_infected_dialog() {
     yad --error \
-        --title="Infected — AUR Malware Check" \
+        --title="Infected — Archcanary" \
         --window-icon=security-high \
         --width=520 \
         --text="<b>Infected or compromised packages detected.</b>\n\n<b>1.</b>  Remove the package:\n      <tt>paru -R &lt;package-name&gt;</tt>\n\n<b>2.</b>  Check persistence — run <i>Systemd persistence</i> and\n      <i>XDG autostart + shell RCs</i> from this menu.\n\n<b>3.</b>  Rotate credentials: SSH keys, GitHub PATs, Discord\n      tokens, npm tokens, browser sessions.\n\nSee README → <i>What to Do If Infected</i>" \
@@ -134,10 +134,10 @@ _show_infected_dialog() {
 edit_allowlist() {
     # Single system-wide allowlist (the kmod audit only runs as root). The file
     # is world-readable, so yad loads it directly; the save writes back as root.
-    local cfg="/etc/aur-malware-check/dkms_allowlist.conf"
+    local cfg="/etc/archcanary/dkms_allowlist.conf"
     if [[ ! -f "$cfg" ]]; then
         yad --warning \
-            --title="DKMS Allowlist — AUR Malware Check" \
+            --title="DKMS Allowlist — Archcanary" \
             --window-icon=security-high \
             --text="<b>$cfg</b> does not exist.\n\nRun <tt>sudo ./install.sh --system</tt> first to create it." \
             --width=440 2>/dev/null || true
@@ -146,7 +146,7 @@ edit_allowlist() {
     local tmpout
     tmpout="$(mktemp /tmp/aur-mc-XXXXXX.txt)"
     if yad --text-info \
-        --title="DKMS Allowlist (system) — AUR Malware Check" \
+        --title="DKMS Allowlist (system) — Archcanary" \
         --window-icon=security-high \
         --filename="$cfg" \
         --width=640 --height=380 \
@@ -157,7 +157,7 @@ edit_allowlist() {
         > "$tmpout" 2>/dev/null; then
         # Write back to /etc as root — pkexec prompts via the polkit agent.
         if [[ -z "$PKEXEC" ]] || ! "$PKEXEC" tee "$cfg" < "$tmpout" >/dev/null 2>&1; then
-            yad --error --title="AUR Malware Check" --window-icon=security-high \
+            yad --error --title="Archcanary" --window-icon=security-high \
                 --text="Could not save <tt>$cfg</tt>\n(root authorization failed or cancelled)." \
                 --width=420 2>/dev/null || true
         fi
@@ -176,7 +176,7 @@ show_output() {
     (tail --pid="$scan_pid" -f -n +1 "$tmpout" 2>/dev/null
      printf '\n─── done ───\n') \
         | yad --text-info \
-            --title="$title — AUR Malware Check" \
+            --title="$title — Archcanary" \
             --window-icon=security-high \
             --width=1000 --height=660 \
             --fontname="Monospace 10" \
@@ -241,7 +241,7 @@ run_action() {
             wait "$pkexec_pid" 2>/dev/null || pkexec_exit=$?
             rm -f "$tmpout"
             [[ $pkexec_exit -ne 0 && $pkexec_exit -ne 126 ]] && \
-                yad --error --title="AUR Malware Check" \
+                yad --error --title="Archcanary" \
                     --window-icon=security-high \
                     --text="pkexec failed (exit $pkexec_exit)" \
                     --width=360 2>/dev/null || true
@@ -261,7 +261,7 @@ run_action() {
         # When user clicks Close, yad exits → pipe breaks → tail exits.
         tail -f -n +1 "$tmpout" 2>/dev/null \
             | yad --text-info \
-                --title="$label — AUR Malware Check" \
+                --title="$label — Archcanary" \
                 --window-icon=security-high \
                 --width=1000 --height=660 \
                 --fontname="Monospace 10" \
@@ -312,7 +312,7 @@ while true; do
 
     selected=$(yad \
         --list \
-        --title="AUR Malware Check" \
+        --title="Archcanary" \
         --window-icon=security-high \
         --width=580 --height=560 \
         --column="" \

--- a/archcanary-merge-lists.sh
+++ b/archcanary-merge-lists.sh
@@ -3,7 +3,7 @@
 # custom_list_merge_aur_scan.sh — Fetch, merge, dedup, and scan
 #
 # Fetches the official HedgeDoc list (optional), merges with custom package
-# lists from URLs or files, deduplicates, and runs aur_check-v2.sh.
+# lists from URLs or files, deduplicates, and runs archcanary.sh.
 # By default the campaign date window applies.  Pass -- --all-time after
 # the options separator to scan regardless of install date.
 #
@@ -23,14 +23,14 @@
 #   --help                       Show this help
 #
 #   --    Separator — all following arguments are passed through to
-#         aur_check-v2.sh unchanged.
+#         archcanary.sh unchanged.
 #         Useful flags: --all-time (disable date window), --verbose,
 #         --check-systemd, --check-npm-cache, --check-bun-cache, --full.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-AUR_CHECK="$SCRIPT_DIR/aur_check-v2.sh"
+ARCHCANARY="$SCRIPT_DIR/archcanary.sh"
 HEDGEDOC_URL="https://md.archlinux.org/s/SxbqukK6IA/download"
 
 LISTS=()
@@ -109,9 +109,9 @@ if $SKIP_HEDGEDOC && [[ ${#LISTS[@]} -eq 0 ]]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Check aur_check-v2.sh exists
+# Check archcanary.sh exists
 # ---------------------------------------------------------------------------
-[[ -x "$AUR_CHECK" ]] || error "aur_check-v2.sh not found or not executable at: $AUR_CHECK"
+[[ -x "$ARCHCANARY" ]] || error "archcanary.sh not found or not executable at: $ARCHCANARY"
 
 # ---------------------------------------------------------------------------
 # Source helpers (reuse load_list logic)
@@ -237,13 +237,13 @@ if [[ ${#LISTS[@]} -gt 0 || ${#NPM_LISTS[@]} -gt 0 ]]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Run aur_check-v2.sh
+# Run archcanary.sh
 # Temp files remain in /tmp — v2 reads them via --package-list= and
 # --malicious-npm-list=.  The cleanup trap above handles early exits;
 # after exec the trap is irrelevant (process image replaced).
 # ---------------------------------------------------------------------------
-info "running: aur_check-v2.sh --package-list=$AUR_TEMP ${AUR_ARGS[*]}"
-exec "$AUR_CHECK" \
+info "running: archcanary.sh --package-list=$AUR_TEMP ${AUR_ARGS[*]}"
+exec "$ARCHCANARY" \
     --package-list="$AUR_TEMP" \
     --malicious-npm-list="$NPM_TEMP" \
     "${AUR_ARGS[@]}"

--- a/archcanary.desktop
+++ b/archcanary.desktop
@@ -1,8 +1,8 @@
 [Desktop Entry]
 Type=Application
-Name=AUR Malware Check
+Name=Archcanary
 Comment=Scan for compromised AUR packages
-Exec=aur_malware_gui.sh
+Exec=archcanary-gui.sh
 Icon=security-high
 Categories=System;Security;
 Terminal=false

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# aur_check.sh - Consolidated AUR Malware Check Script
+# archcanary.sh - Consolidated Archcanary Script
 # Campaign: June 2026 - atomic-lockfile infostealer + eBPF rootkit
 #
 # Combines best features from all community forks:
@@ -16,15 +16,15 @@
 #   - atomic-lockfile npm cache presence
 #
 # Usage:
-#   ./aur_check.sh                    # normal check
-#   ./aur_check.sh --check-systemd    # also scan systemd for unknown services
-#   ./aur_check.sh --check-ebpf       # also check for eBPF rootkit traces
-#   ./aur_check.sh --check-npm-cache  # also check npm cache for atomic-lockfile
-#   ./aur_check.sh --full             # enable all checks
+#   ./archcanary.sh                    # normal check
+#   ./archcanary.sh --check-systemd    # also scan systemd for unknown services
+#   ./archcanary.sh --check-ebpf       # also check for eBPF rootkit traces
+#   ./archcanary.sh --check-npm-cache  # also check npm cache for atomic-lockfile
+#   ./archcanary.sh --full             # enable all checks
 #
 # Environment:
-#   START_DATE=2026-06-09  END_DATE=2026-06-12  ./aur_check.sh
-#   PACMAN_LOG_GLOB="/var/log/pacman.log*"       ./aur_check.sh
+#   START_DATE=2026-06-09  END_DATE=2026-06-12  ./archcanary.sh
+#   PACMAN_LOG_GLOB="/var/log/pacman.log*"       ./archcanary.sh
 #
 # Exit codes:
 #   0 = clean
@@ -126,7 +126,7 @@ for arg in "$@"; do
             echo "  --full             Enable all checks"
             echo "  --refresh          Download the latest package list before scanning"
             echo "  --verbose, -v, --debug    Verbose output (--debug also enables set -x)"
-            echo "  --log-file=PATH           Write full detail log to PATH (auto: ~/.cache/aur-malware-check/aur-check-<date>.log)"
+            echo "  --log-file=PATH           Write full detail log to PATH (auto: ~/.cache/archcanary/aur-check-<date>.log)"
             echo "  --package-list=PATH       Custom infected AUR package list (default: ./package_list.txt)"
             echo "  --malicious-npm-list=PATH Custom malicious npm package name list (default: ./malicious_npm_packages.txt)"
             echo "  --chaos-rat-list=PATH     Custom CHAOS RAT (2025) package list (default: ./chaos_rat_packages.txt)"
@@ -170,15 +170,15 @@ done
 run_doctor() {
     local repo_dir cfg_dir user_bin user_sd
     repo_dir="$(dirname "$(realpath "$0")")"
-    cfg_dir="${XDG_CONFIG_HOME:-$HOME/.config}/aur-malware-check"
+    cfg_dir="${XDG_CONFIG_HOME:-$HOME/.config}/archcanary"
     user_bin="$HOME/.local/bin"
     user_sd="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
 
     # The repo-relative fix sources only exist when run from a clone; degrade
     # gracefully to a hint when run from an installed copy.
     local installer="$repo_dir/install.sh" luasrc="$repo_dir/configs/yay-init.lua"
-    [[ -f $installer ]] || installer="install.sh   # (run from the aur-malware-check repo)"
-    [[ -f $luasrc    ]] || luasrc="configs/yay-init.lua   # (from the aur-malware-check repo)"
+    [[ -f $installer ]] || installer="install.sh   # (run from the archcanary repo)"
+    [[ -f $luasrc    ]] || luasrc="configs/yay-init.lua   # (from the archcanary repo)"
 
     # --- Section selection -------------------------------------------------
     # Sections are listed in install order (prerequisite chain) so a full run
@@ -306,7 +306,7 @@ run_doctor() {
     }
 
     printf '%s============================================================%s\n' "$B" "$N"
-    printf '%s AUR Malware Check — setup doctor%s\n' "$B" "$N"
+    printf '%s Archcanary — setup doctor%s\n' "$B" "$N"
     if [[ -n $DOCTOR_SECTIONS ]]; then
         # Show the resolved sections (in order), not the raw input — keeps the
         # header clean when tool-name aliases or stray spaces were used.
@@ -350,19 +350,19 @@ run_doctor() {
     # --- User install ------------------------------------------------------
     if [[ -n ${want[user]:-} ]]; then
         printf '%sUser install%s\n' "$B" "$N"
-        _item "main scanner (~/.local/bin)" "$(_file "$user_bin/aur-malware-check.sh")" "bash $installer"           "path: $user_bin/aur-malware-check.sh"
-        _item "GUI (~/.local/bin)"          "$(_file "$user_bin/aur_malware_gui.sh")"   "bash $installer"           "path: $user_bin/aur_malware_gui.sh"
-        _item "package list (config dir)"   "$(_file "$cfg_dir/package_list.txt")"      "aur-malware-check.sh --refresh" "path: $cfg_dir/package_list.txt"
+        _item "main scanner (~/.local/bin)" "$(_file "$user_bin/archcanary.sh")" "bash $installer"           "path: $user_bin/archcanary.sh"
+        _item "GUI (~/.local/bin)"          "$(_file "$user_bin/archcanary-gui.sh")"   "bash $installer"           "path: $user_bin/archcanary-gui.sh"
+        _item "package list (config dir)"   "$(_file "$cfg_dir/package_list.txt")"      "archcanary.sh --refresh" "path: $cfg_dir/package_list.txt"
         printf '\n'
     fi
 
     # --- System install (root) --------------------------------------------
     if [[ -n ${want[system]:-} ]]; then
         printf '%sSystem install (root)%s\n' "$B" "$N"
-        _item "system scanner copy" "$(_file /usr/lib/aur-malware-check/aur-malware-check.sh)"          "sudo bash $installer --system" "path: /usr/lib/aur-malware-check/aur-malware-check.sh"
-        _item "root-helper (pkexec)" "$(_file /usr/lib/aur-malware-check/root-helper)"                  "sudo bash $installer --system" "path: /usr/lib/aur-malware-check/root-helper"
-        _item "polkit policy"        "$(_file /usr/share/polkit-1/actions/org.aur-malware-check.policy)" "sudo bash $installer --system" "path: /usr/share/polkit-1/actions/org.aur-malware-check.policy"
-        _item "DKMS allowlist"       "$(_file /etc/aur-malware-check/dkms_allowlist.conf)"              "sudo bash $installer --system" "path: /etc/aur-malware-check/dkms_allowlist.conf"
+        _item "system scanner copy" "$(_file /usr/lib/archcanary/archcanary.sh)"          "sudo bash $installer --system" "path: /usr/lib/archcanary/archcanary.sh"
+        _item "root-helper (pkexec)" "$(_file /usr/lib/archcanary/root-helper)"                  "sudo bash $installer --system" "path: /usr/lib/archcanary/root-helper"
+        _item "polkit policy"        "$(_file /usr/share/polkit-1/actions/org.archcanary.policy)" "sudo bash $installer --system" "path: /usr/share/polkit-1/actions/org.archcanary.policy"
+        _item "DKMS allowlist"       "$(_file /etc/archcanary/dkms_allowlist.conf)"              "sudo bash $installer --system" "path: /etc/archcanary/dkms_allowlist.conf"
         printf '\n'
     fi
 
@@ -371,10 +371,10 @@ run_doctor() {
         printf '%sAutomation (systemd)%s\n' "$B" "$N"
         # Checks enabled state (not just file presence) for the four units the
         # installer enables: two system, two user.
-        _unit system "aur-malware-check.timer"        "system scan timer (weekly + boot)"
-        _unit system "aur-malware-check.path"         "pacman-tx trigger (scan after each install)"
-        _unit user   "aur-malware-check-user.timer"   "user scan timer (cache/autostart checks)"
-        _unit user   "aur-malware-check-notify.path"  "desktop notifier (watches last-scan.log)"
+        _unit system "archcanary.timer"        "system scan timer (weekly + boot)"
+        _unit system "archcanary.path"         "pacman-tx trigger (scan after each install)"
+        _unit user   "archcanary-user.timer"   "user scan timer (cache/autostart checks)"
+        _unit user   "archcanary-notify.path"  "desktop notifier (watches last-scan.log)"
         printf '\n'
     fi
 
@@ -471,9 +471,9 @@ fi
 
 # ---------------------------------------------------------------------------
 # Log file: always write full detail, auto-named unless --log-file=PATH
-# Default location: XDG_CACHE_HOME/aur-malware-check/ (~/.cache/aur-malware-check/)
+# Default location: XDG_CACHE_HOME/archcanary/ (~/.cache/archcanary/)
 # ---------------------------------------------------------------------------
-_AUR_CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/aur-malware-check"
+_AUR_CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/archcanary"
 mkdir -p "$_AUR_CACHE_DIR"
 : "${LOG_FILE:=$_AUR_CACHE_DIR/aur-check-$(date +%Y%m%d-%H%M%S).log}"
 unset _AUR_CACHE_DIR
@@ -483,10 +483,10 @@ unset _AUR_CACHE_DIR
 exec > >(tee "$LOG_FILE") 2>&1
 
 # ---------------------------------------------------------------------------
-# Config dir: XDG_CONFIG_HOME/aur-malware-check (default ~/.config/aur-malware-check)
+# Config dir: XDG_CONFIG_HOME/archcanary (default ~/.config/archcanary)
 # Can be overridden via PACKAGE_LIST_FILE / MALICIOUS_NPM_LIST env vars
 # ---------------------------------------------------------------------------
-AUR_CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/aur-malware-check"
+AUR_CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/archcanary"
 mkdir -p "$AUR_CONFIG_DIR"
 
 PACKAGE_LIST_FILE="${PACKAGE_LIST_FILE:-$AUR_CONFIG_DIR/package_list.txt}"
@@ -502,7 +502,7 @@ MALICIOUS_NPM_LIST="${MALICIOUS_NPM_LIST:-$AUR_CONFIG_DIR/malicious_npm_packages
 # file — DKMS modules are machine-level and the kmod audit only runs as root.
 # Override the path with DKMS_ALLOWLIST_FILE (used by the tests).
 DKMS_ALLOWLIST="${DKMS_ALLOWLIST:-}"
-_dkms_cfg="${DKMS_ALLOWLIST_FILE:-/etc/aur-malware-check/dkms_allowlist.conf}"
+_dkms_cfg="${DKMS_ALLOWLIST_FILE:-/etc/archcanary/dkms_allowlist.conf}"
 if [[ -r "$_dkms_cfg" ]]; then    # skip if missing/unreadable (don't abort under set -e)
     while IFS= read -r _dl || [[ -n "$_dl" ]]; do
         _dl="${_dl%%#*}"       # strip inline comments
@@ -836,7 +836,7 @@ check_ebpf() {
     if [[ ! -d /sys/fs/bpf ]]; then
         echo "  /sys/fs/bpf not accessible — BPF filesystem not mounted or insufficient privileges."
         echo "  → Requires root to scan for hidden BPF maps (e.g. hidden_pids, hidden_names)."
-        echo "  → Try: sudo ./aur_check.sh --check-ebpf"
+        echo "  → Try: sudo ./archcanary.sh --check-ebpf"
         echo "  → Skip this check if eBPF rootkit detection is not needed for your threat model."
         return 77
     fi
@@ -1501,7 +1501,7 @@ for p in "${INFECTED_PKGS[@]}"; do
 done
 
 echo "============================================================"
-echo " AUR Malware Check v${SCRIPT_VERSION}"
+echo " Archcanary v${SCRIPT_VERSION}"
 echo " Campaign: malicious npm packages (malicious_npm_packages.txt) infostealer + eBPF rootkit"
 if $ALL_TIME; then
     echo " Date window: all-time (no recency filter)"
@@ -1647,7 +1647,7 @@ if [[ $EXIT_CODE -eq 2 ]] && ! $NO_NOTIFY; then
     if command -v notify-send &>/dev/null; then
         notify-send -u critical -i dialog-warning \
             "AUR: malicious package detected" \
-            "Indicators found. Open AUR Malware Check to review."
+            "Indicators found. Open Archcanary to review."
     fi
 fi
 

--- a/archcanary_py/README.md
+++ b/archcanary_py/README.md
@@ -1,26 +1,26 @@
-# aur_check_py — Python 3.14+ AUR Malware Checker
+# archcanary_py — Python 3.14+ Archcanaryer
 
-Python-Äquivalent zu `aur_check-v2.sh` + `custom_list_merge_aur_scan.sh`.
+Python-Äquivalent zu `archcanary.sh` + `custom_list_merge_aur_scan.sh`.
 
 ## Quick Start (Äquivalente)
 
 | Bash | Python |
 |---|---|
-| `./aur_check-v2.sh` | `python -m aur_check_py` |
-| `./aur_check-v2.sh --full` | `python -m aur_check_py --full` |
-| `./aur_check-v2.sh --all-time` | `python -m aur_check_py --all-time` |
-| `./aur_check-v2.sh --check-bun-cache` | `python -m aur_check_py --check-bun-cache` |
-| `./aur_check-v2.sh --refresh --full` | `python -m aur_check_py --refresh --full` |
-| `./aur_check-v2.sh --package-list=FILE --malicious-npm-list=FILE` | `python -m aur_check_py --package-list=FILE --malicious-npm-list=FILE` |
-| `./custom_list_merge_aur_scan.sh -l FILE` | `python -m aur_check_py --merge -l FILE` |
-| `./custom_list_merge_aur_scan.sh -l URL1 -l FILE2 --skip-hedgedoc` | `python -m aur_check_py --merge -l URL1 -l FILE2 --skip-hedgedoc` |
-| `./custom_list_merge_aur_scan.sh -l FILE -- --all-time` | `python -m aur_check_py --merge -l FILE --all-time` |
+| `./archcanary.sh` | `python -m archcanary_py` |
+| `./archcanary.sh --full` | `python -m archcanary_py --full` |
+| `./archcanary.sh --all-time` | `python -m archcanary_py --all-time` |
+| `./archcanary.sh --check-bun-cache` | `python -m archcanary_py --check-bun-cache` |
+| `./archcanary.sh --refresh --full` | `python -m archcanary_py --refresh --full` |
+| `./archcanary.sh --package-list=FILE --malicious-npm-list=FILE` | `python -m archcanary_py --package-list=FILE --malicious-npm-list=FILE` |
+| `./custom_list_merge_aur_scan.sh -l FILE` | `python -m archcanary_py --merge -l FILE` |
+| `./custom_list_merge_aur_scan.sh -l URL1 -l FILE2 --skip-hedgedoc` | `python -m archcanary_py --merge -l URL1 -l FILE2 --skip-hedgedoc` |
+| `./custom_list_merge_aur_scan.sh -l FILE -- --all-time` | `python -m archcanary_py --merge -l FILE --all-time` |
 | `--verbose` / `--debug` | identisch |
 | `--help` / `-h` | identisch |
 | `--log-file=PATH` | identisch |
-| `./aur_check-v2.sh --check-systemd` | `python -m aur_check_py --check-systemd` |
-| `./aur_check-v2.sh --check-ebpf` | `python -m aur_check_py --check-ebpf` |
-| `./aur_check-v2.sh --check-npm-cache` | `python -m aur_check_py --check-npm-cache` |
+| `./archcanary.sh --check-systemd` | `python -m archcanary_py --check-systemd` |
+| `./archcanary.sh --check-ebpf` | `python -m archcanary_py --check-ebpf` |
+| `./archcanary.sh --check-npm-cache` | `python -m archcanary_py --check-npm-cache` |
 
 ## Exit Codes (identisch)
 - 0 = clean
@@ -29,7 +29,7 @@ Python-Äquivalent zu `aur_check-v2.sh` + `custom_list_merge_aur_scan.sh`.
 
 ## Tests
 ```bash
-python -m unittest discover -s aur_check_py/tests/ -v
+python -m unittest discover -s archcanary_py/tests/ -v
 ```
 75 Tests, laufen ohne Arch-System/pacman/npm/bun.
 

--- a/archcanary_py/__main__.py
+++ b/archcanary_py/__main__.py
@@ -9,14 +9,14 @@ import sys
 from datetime import date
 from pathlib import Path
 
-from aur_check_py.merger import (
+from archcanary_py.merger import (
     HEDGEDOC_URL,
     extract_package_names,
     fetch_url,
     merge_lists,
     read_file,
 )
-from aur_check_py.scanner import (
+from archcanary_py.scanner import (
     AurScanner,
     BunMatch,
     LogHit,
@@ -26,7 +26,7 @@ from aur_check_py.scanner import (
 
 SCRIPT_VERSION = '3.0'
 
-logger = logging.getLogger('aur_check')
+logger = logging.getLogger('archcanary')
 
 
 def setup_logging(log_file: str, debug: bool = False) -> None:
@@ -48,7 +48,7 @@ def setup_logging(log_file: str, debug: bool = False) -> None:
 
 def create_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description='AUR Malware Check - scans for indicators of compromise',
+        description='Archcanary - scans for indicators of compromise',
     )
     parser.add_argument('--check-systemd', action='store_true',
         help='Scan for unknown systemd services (Restart=always)')
@@ -89,7 +89,7 @@ def create_parser() -> argparse.ArgumentParser:
 
 def print_banner(infected_count: int, start_date: str, end_date: str, all_time: bool) -> None:
     print('============================================================')
-    print(f' AUR Malware Check v{SCRIPT_VERSION}')
+    print(f' Archcanary v{SCRIPT_VERSION}')
     print(' Campaign: malicious npm packages (malicious_npm_packages.txt) infostealer + eBPF rootkit')
     if all_time:
         print(' Date window: all-time (no recency filter)')
@@ -148,7 +148,7 @@ def print_ebpf_hits(hits: list[Path], bpf_accessible: bool) -> None:
     if not bpf_accessible:
         print('  /sys/fs/bpf not accessible \u2014 BPF filesystem not mounted or insufficient privileges.')
         print('  \u2192 Requires root to scan for hidden BPF maps (e.g. hidden_pids, hidden_names).')
-        print('  \u2192 Try: sudo ./aur_check.sh --check-ebpf')
+        print('  \u2192 Try: sudo ./archcanary.sh --check-ebpf')
         print('  \u2192 Skip this check if eBPF rootkit detection is not needed for your threat model.')
         return
     if not hits:

--- a/archcanary_py/demo.sh
+++ b/archcanary_py/demo.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# Demo: alle aur_check_py CLI-Fälle aus dem README
+# Demo: alle archcanary_py CLI-Fälle aus dem README
 set -euo pipefail
 cd "$(dirname "$0")"/..
 
-P="python -m aur_check_py"
+P="python -m archcanary_py"
 SEP="========================================"
 
 echo "$SEP"
@@ -14,7 +14,7 @@ echo
 
 echo "$SEP"
 echo " 2) Standard-Scan (v2-Äquivalent)"
-echo "    python -m aur_check_py"
+echo "    python -m archcanary_py"
 echo "$SEP"
 $P || true
 echo
@@ -45,7 +45,7 @@ echo
 
 echo "$SEP"
 echo " 6) Merge-Mode: HedgeDoc + lokale package_list.txt"
-echo "    python -m aur_check_py --merge -l ../package_list.txt"
+echo "    python -m archcanary_py --merge -l ../package_list.txt"
 echo "$SEP"
 $P --merge -l ../package_list.txt || true
 echo

--- a/archcanary_py/developing.md
+++ b/archcanary_py/developing.md
@@ -1,4 +1,4 @@
-# Developing — aur_check_py
+# Developing — archcanary_py
 
 ## Tech Stack
 - Python ≥3.14, stdlib only
@@ -25,7 +25,7 @@
 
 ## Tests (Red/Green/Refactor)
 - `tests/test_<module>.py`, `from unittest import TestCase`
-- Jede Check-Funktion isoliert mocken: `@patch('aur_check_py.scanner.subprocess.run')`
+- Jede Check-Funktion isoliert mocken: `@patch('archcanary_py.scanner.subprocess.run')`
 - Assert Exit-Codes, Output-Strings, Date-Window-Edge-Cases
 - Laufen ohne Arch-System, `pacman`, `npm`, `bun`
 

--- a/archcanary_py/tests/test_main.py
+++ b/archcanary_py/tests/test_main.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
-from aur_check_py.__main__ import create_parser, main
+from archcanary_py.__main__ import create_parser, main
 
 
 class TestMainCreateParser(unittest.TestCase):
@@ -71,9 +71,9 @@ class TestMainCreateParser(unittest.TestCase):
 
 
 class TestMainExitCodes(unittest.TestCase):
-    @patch('aur_check_py.__main__.setup_logging')
-    @patch('aur_check_py.__main__.read_file')
-    @patch('aur_check_py.__main__.AurScanner')
+    @patch('archcanary_py.__main__.setup_logging')
+    @patch('archcanary_py.__main__.read_file')
+    @patch('archcanary_py.__main__.AurScanner')
     def test_clean_exit(self, mock_scanner_cls, mock_read_file, mock_log):
         mock_read_file.side_effect = [
             ['package-a'],
@@ -96,9 +96,9 @@ class TestMainExitCodes(unittest.TestCase):
         ec = main([])
         self.assertEqual(ec, 0)
 
-    @patch('aur_check_py.__main__.setup_logging')
-    @patch('aur_check_py.__main__.read_file')
-    @patch('aur_check_py.__main__.AurScanner')
+    @patch('archcanary_py.__main__.setup_logging')
+    @patch('archcanary_py.__main__.read_file')
+    @patch('archcanary_py.__main__.AurScanner')
     def test_infected_exit(self, mock_scanner_cls, mock_read_file, mock_log):
         mock_read_file.side_effect = [
             ['package-a'],
@@ -121,9 +121,9 @@ class TestMainExitCodes(unittest.TestCase):
         ec = main([])
         self.assertEqual(ec, 2)
 
-    @patch('aur_check_py.__main__.setup_logging')
-    @patch('aur_check_py.__main__.read_file')
-    @patch('aur_check_py.__main__.AurScanner')
+    @patch('archcanary_py.__main__.setup_logging')
+    @patch('archcanary_py.__main__.read_file')
+    @patch('archcanary_py.__main__.AurScanner')
     def test_all_time_flag_passed(self, mock_scanner_cls, mock_read_file, mock_log):
         mock_read_file.side_effect = [
             ['package-a'],
@@ -147,9 +147,9 @@ class TestMainExitCodes(unittest.TestCase):
         self.assertEqual(ec, 0)
         self.assertEqual(mock_scanner_cls.call_args[1]['all_time'], True)
 
-    @patch('aur_check_py.__main__.setup_logging')
-    @patch('aur_check_py.__main__.merge_lists')
-    @patch('aur_check_py.__main__.AurScanner')
+    @patch('archcanary_py.__main__.setup_logging')
+    @patch('archcanary_py.__main__.merge_lists')
+    @patch('archcanary_py.__main__.AurScanner')
     def test_merge_mode(self, mock_scanner_cls, mock_merge, mock_log):
         mock_merge.return_value = ({'merged-pkg'}, {'merged-npm'})
         mock_scanner = MagicMock()

--- a/archcanary_py/tests/test_merger.py
+++ b/archcanary_py/tests/test_merger.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
-from aur_check_py.merger import (
+from archcanary_py.merger import (
     extract_package_names,
     fetch_url,
     merge_lists,
@@ -91,7 +91,7 @@ class TestReadFile(unittest.TestCase):
 
 
 class TestReadListSource(unittest.TestCase):
-    @patch('aur_check_py.merger.fetch_url')
+    @patch('archcanary_py.merger.fetch_url')
     def test_url(self, mock_fetch):
         mock_fetch.return_value = 'pkg-a\npkg-b\n'
         result = read_list_source('http://example.com/list')
@@ -112,7 +112,7 @@ class TestReadListSource(unittest.TestCase):
 
 
 class TestMergeLists(unittest.TestCase):
-    @patch('aur_check_py.merger.fetch_url')
+    @patch('archcanary_py.merger.fetch_url')
     @patch.object(Path, 'is_file', return_value=False)
     def test_hedgedoc_only(self, mock_is_file, mock_fetch):
         mock_fetch.return_value = 'pkg-a\npkg-b\n'
@@ -120,13 +120,13 @@ class TestMergeLists(unittest.TestCase):
         self.assertEqual(aur_set, {'pkg-a', 'pkg-b'})
         self.assertEqual(npm_set, set())
 
-    @patch('aur_check_py.merger.fetch_url')
+    @patch('archcanary_py.merger.fetch_url')
     @patch.object(Path, 'is_file', return_value=False)
     def test_skip_hedgedoc(self, mock_is_file, mock_fetch):
         aur_set, npm_set = merge_lists(skip_hedgedoc=True)
         self.assertEqual(aur_set, set())
 
-    @patch('aur_check_py.merger.fetch_url')
+    @patch('archcanary_py.merger.fetch_url')
     @patch.object(Path, 'is_file', return_value=False)
     def test_extra_aur_lists(self, mock_is_file, mock_fetch):
         def fake_fetch(url, timeout=15):
@@ -140,14 +140,14 @@ class TestMergeLists(unittest.TestCase):
         )
         self.assertEqual(aur_set, {'pkg-a', 'pkg-b'})
 
-    @patch('aur_check_py.merger.fetch_url')
+    @patch('archcanary_py.merger.fetch_url')
     @patch.object(Path, 'is_file', return_value=False)
     def test_dedup(self, mock_is_file, mock_fetch):
         mock_fetch.return_value = 'pkg-a\npkg-a\npkg-b\n'
         aur_set, npm_set = merge_lists(skip_hedgedoc=False)
         self.assertEqual(aur_set, {'pkg-a', 'pkg-b'})
 
-    @patch('aur_check_py.merger.fetch_url')
+    @patch('archcanary_py.merger.fetch_url')
     def test_extra_npm_and_aur(self, mock_fetch):
         mock_fetch.return_value = 'pkg-a\n'
         mock_fetch.side_effect = None

--- a/archcanary_py/tests/test_scanner.py
+++ b/archcanary_py/tests/test_scanner.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
-from aur_check_py.scanner import (
+from archcanary_py.scanner import (
     AurScanner,
     BunMatch,
     LogHit,

--- a/docs/my-setup.md
+++ b/docs/my-setup.md
@@ -9,12 +9,12 @@ Full overview of how this fork is deployed and how the pieces connect.
 
 | Component | Package / Source | Purpose |
 |-----------|-----------------|---------|
-| `aur_check-v2.sh` | [musqz/aur-malware-check](https://github.com/musqz/aur-malware-check) (fork of [lenucksi/aur-malware-check](https://github.com/lenucksi/aur-malware-check)) | Main scanner — known-bad packages, pacman logs, systemd persistence (incl. drop-ins + timers), eBPF rootkit, npm/bun/yarn/pnpm cache, PKGBUILD obfuscation (incl. base64/eval/printf/varsplit), loaded-eBPF enumeration (`bpftool`), `ld.so.preload` injection, XDG autostart + shell RC persistence, kernel module / DKMS audit |
-| `aur_malware_gui.sh` | [musqz/aur-malware-check](https://github.com/musqz/aur-malware-check) | yad GUI — grouped menu with per-session status column (✅/⚠/❌/?), polkit auth for root checks, streaming output window |
+| `archcanary.sh` | [musqz/archcanary](https://github.com/musqz/archcanary) (fork of [lenucksi/archcanary](https://github.com/lenucksi/archcanary)) | Main scanner — known-bad packages, pacman logs, systemd persistence (incl. drop-ins + timers), eBPF rootkit, npm/bun/yarn/pnpm cache, PKGBUILD obfuscation (incl. base64/eval/printf/varsplit), loaded-eBPF enumeration (`bpftool`), `ld.so.preload` injection, XDG autostart + shell RC persistence, kernel module / DKMS audit |
+| `archcanary-gui.sh` | [musqz/archcanary](https://github.com/musqz/archcanary) | yad GUI — grouped menu with per-session status column (✅/⚠/❌/?), polkit auth for root checks, streaming output window |
 | `traur` | [AUR: traur](https://aur.archlinux.org/packages/traur) | Pre-install trust scanner — 279 signals across PKGBUILD static analysis (reverse shells, download-and-execute, obfuscation, exfiltration), maintainer behaviour (new account, orphan takeover, typosquatting), AUR metadata (votes, popularity, orphaned), and git history (major rewrites, checksum removal, source domain changes) |
 | `aurscan` (`syay`) | [musqz/aurscan](https://github.com/musqz/aurscan) (fork of [manticore-projects/aurscan](https://github.com/manticore-projects/aurscan)) | LLM-based PKGBUILD scanner using Claude. Installed as `syay` and bound with `alias yay=syay` in `.bashrc`, so it runs **automatically** on every AUR install/upgrade — it reads the PKGBUILD with Claude (plus offline static rules) and only hands off to the real `/usr/bin/yay` on a CLEAN verdict |
 | `yay` 13.0 `init.lua` | `~/.config/yay/init.lua` | yay 13.0 Lua hooks — runs on every install/upgrade *after* aurscan clears it: upgrade-age warning (`UpgradeSelect`), offline malicious-pattern block (`AURPreInstall`), and AUR install logging (`PostInstall`) |
-| `yad` | official repos | GTK dialog toolkit used by `aur_malware_gui.sh` |
+| `yad` | official repos | GTK dialog toolkit used by `archcanary-gui.sh` |
 | `polkit` / `pkexec` | official repos | Graphical privilege escalation for root-requiring checks (eBPF, kmod) in the GUI |
 | `libnotify` | official repos | Provides `notify-send` — the desktop notification on exit code 2 |
 | `bpftool` | `bpf` — official repos | Enumerates loaded eBPF programs for `--check-bpftool` |
@@ -23,7 +23,7 @@ Full overview of how this fork is deployed and how the pieces connect.
 
 ```
 systemd SYSTEM timer (weekly + on boot, runs as root)
-    └── aur-malware-check.sh --refresh --full --all-time --no-notify
+    └── archcanary.sh --refresh --full --all-time --no-notify
             ├── [1]  currently installed foreign packages
             ├── [2]  historical pacman logs
             ├── [3]  systemd persistence (services, drop-ins, timers)
@@ -38,13 +38,13 @@ systemd SYSTEM timer (weekly + on boot, runs as root)
             ├── [10] XDG autostart + shell RC persistence
             └── [11] kernel module / DKMS audit          (root → actually runs)
                     │
-                    └── writes /var/lib/aur-malware-check/last-scan.log
+                    └── writes /var/lib/archcanary/last-scan.log
                             │
    systemd USER path unit watches that file
             └── on "RESULT: INFECTED" → notify-send (libnotify) → critical desktop alert
-                    └── open AUR Malware Check from the app launcher to review
+                    └── open Archcanary from the app launcher to review
 
-aur_malware_gui.sh (on-demand — desktop shortcut or app launcher)
+archcanary-gui.sh (on-demand — desktop shortcut or app launcher)
     └── yad list menu with per-session status column
             ├── standard checks run as user
             └── root checks (eBPF, bpftool, kmod) → pkexec → polkit auth → root-helper
@@ -53,7 +53,7 @@ aur_malware_gui.sh (on-demand — desktop shortcut or app launcher)
 traur — two use cases:
     ├── GUI "Trust scan (traur)"  → traur scan  (no args)
     │       └── bulk audit of ALL installed AUR packages
-    │               └── useful as a periodic sweep alongside aur_check-v2.sh
+    │               └── useful as a periodic sweep alongside archcanary.sh
     │
     └── terminal: traur scan <pkg>  (before installing a specific package)
             └── 279 signals, 5 weighted categories
@@ -91,11 +91,11 @@ For the lifecycle map and the what-runs-when table, see
 [overview.md](overview.md). All layers are complementary — none replaces the
 others.
 
-### The yad GUI (`aur_malware_gui.sh`)
+### The yad GUI (`archcanary-gui.sh`)
 
 Run from a desktop shortcut or app launcher — grouped menu with a per-session status column, polkit auth for root-requiring checks, and a live streaming output window:
 
-![aur_malware_gui.sh yad GUI — status column and grouped checks](../images/gui.png)
+![archcanary-gui.sh yad GUI — status column and grouped checks](../images/gui.png)
 
 ### Headless / SSH
 
@@ -106,29 +106,29 @@ Run the scanner directly:
 # bpftool) need root; without it they are skipped and the run is reported as
 # INCOMPLETE (exit 1, WARNINGS) rather than CLEAN, so a partial scan is never
 # mistaken for an all-clear.
-sudo ~/.local/bin/aur-malware-check.sh --full --all-time
+sudo ~/.local/bin/archcanary.sh --full --all-time
 
 # User-level checks run fine without root:
-aur-malware-check.sh --check-systemd
-aur-malware-check.sh --check-pkgbuild
+archcanary.sh --check-systemd
+archcanary.sh --check-pkgbuild
 
 # A single root-requiring check:
-sudo ~/.local/bin/aur-malware-check.sh --check-kmod
+sudo ~/.local/bin/archcanary.sh --check-kmod
 
 # Setup health check — is every element installed and configured? (no root,
 # no scan; auto-detects distro/AUR helpers and prints a fix command per gap).
 # When something is missing it points to the next step to run.
-aur-malware-check.sh --doctor
+archcanary.sh --doctor
 
 # Check one section (with extra detail), or several — runs in install order:
 # platform, deps, user, system, systemd, external
-aur-malware-check.sh --doctor=deps
-aur-malware-check.sh --doctor=user,system
+archcanary.sh --doctor=deps
+archcanary.sh --doctor=user,system
 ```
 
 > Root checks use the **full path** under `sudo`. `sudo` resets `$PATH` to its
 > `secure_path` (set in `/etc/sudoers`), which does not include `~/.local/bin`, so a
-> bare `sudo aur-malware-check.sh` fails with *command not found*. The script then
+> bare `sudo archcanary.sh` fails with *command not found*. The script then
 > resolves your config from `$SUDO_USER`, so the lists are still found.
 
 The GUI is for interactive desktop use; the CLI covers everything else (SSH, cron, systemd, scripting).
@@ -141,10 +141,10 @@ triggers (timer + `.path` units) are in [systemd.md](systemd.md).
 ## Install locations
 
 ```
-~/.local/bin/aur-malware-check.sh     # main script
-~/.local/bin/aur_malware_gui.sh       # yad GUI script
+~/.local/bin/archcanary.sh     # main script
+~/.local/bin/archcanary-gui.sh       # yad GUI script
 
-~/.config/aur-malware-check/
+~/.config/archcanary/
     ├── package_list.txt              # refreshed weekly via --refresh
     └── malicious_npm_packages.txt    # static list, auto-seeded on first run
 
@@ -155,30 +155,30 @@ triggers (timer + `.path` units) are in [systemd.md](systemd.md).
 /usr/local/bin/aurscan                # = syay; alias yay=syay in ~/.bashrc
 
 ~/.config/systemd/user/                   # installed by ./install.sh --system
-    ├── aur-malware-check-user.service    # user-level scan (npm/bun/pkgbuild caches, autostart)
-    ├── aur-malware-check-user.timer      # weekly + on boot
-    ├── aur-malware-check-notify.path     # watches the root scan's result file
-    └── aur-malware-check-notify.service  # greps INFECTED → notify-send
+    ├── archcanary-user.service    # user-level scan (npm/bun/pkgbuild caches, autostart)
+    ├── archcanary-user.timer      # weekly + on boot
+    ├── archcanary-notify.path     # watches the root scan's result file
+    └── archcanary-notify.service  # greps INFECTED → notify-send
 
 # system components — installed by ./install.sh --system (requires sudo)
-/usr/lib/aur-malware-check/
-    ├── aur-malware-check.sh          # root-accessible copy of the main script
+/usr/lib/archcanary/
+    ├── archcanary.sh          # root-accessible copy of the main script
     ├── package_list.txt              # bundled lists, seeded so the root scan finds them
     ├── malicious_npm_packages.txt
     ├── chaos_rat_packages.txt
     └── root-helper                   # pkexec target (validates flags, restores XDG env)
-/etc/aur-malware-check/
+/etc/archcanary/
     └── dkms_allowlist.conf           # the single DKMS allowlist (edit via GUI/sudoedit)
 /usr/share/polkit-1/actions/
-    └── org.aur-malware-check.policy  # polkit policy allowing GUI to call root-helper
+    └── org.archcanary.policy  # polkit policy allowing GUI to call root-helper
 
 # automated scan — units installed by ./install.sh --system
 /etc/systemd/system/
-    ├── aur-malware-check.service     # system-level scan as root, writes last-scan.log
-    ├── aur-malware-check.timer       # weekly + on boot
-    ├── aur-malware-check-onchange.service
-    └── aur-malware-check.path        # triggers after each pacman transaction
-/var/lib/aur-malware-check/
+    ├── archcanary.service     # system-level scan as root, writes last-scan.log
+    ├── archcanary.timer       # weekly + on boot
+    ├── archcanary-onchange.service
+    └── archcanary.path        # triggers after each pacman transaction
+/var/lib/archcanary/
     └── last-scan.log                 # shared result the user notifier watches
 ```
 
@@ -226,7 +226,7 @@ See [systemd.md](systemd.md) for the full service and timer contents.
 
 ```bash
 # 1. Clone the fork
-git clone https://github.com/musqz/aur-malware-check.git ~/Github/aur-malware-check
+git clone https://github.com/musqz/archcanary.git ~/Github/archcanary
 
 # 2. Install dependencies (bpf provides bpftool for --check-bpftool; yad for GUI)
 sudo pacman -S libnotify bpf yad polkit
@@ -238,15 +238,15 @@ cd ~/Github/aurscan && ./install.sh
 echo 'alias yay=syay' >> ~/.bashrc
 
 # 3. Run install script (installs to ~/.local/bin by default)
-bash ~/Github/aur-malware-check/install.sh
+bash ~/Github/archcanary/install.sh
 
 # Also install root helper + polkit policy (enables eBPF/kmod checks in the GUI)
-bash ~/Github/aur-malware-check/install.sh --system
+bash ~/Github/archcanary/install.sh --system
 
 # 4. yay 13.0 Lua hooks (age warning, pattern block, install log)
 mkdir -p ~/.config/yay
-cp ~/Github/aur-malware-check/configs/yay-init.lua ~/.config/yay/init.lua
+cp ~/Github/archcanary/configs/yay-init.lua ~/.config/yay/init.lua
 
 # 5. Run a first scan with package list refresh
-aur-malware-check.sh --refresh --full --all-time
+archcanary.sh --refresh --full --all-time
 ```

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -22,14 +22,14 @@ flowchart TD
     end
 
     subgraph AFTER["3 · AFTER install / always — automatic, root"]
-        TIM["systemd timer<br/>weekly + on boot"] --> SCAN["aur_check-v2.sh<br/>--full --all-time"]
+        TIM["systemd timer<br/>weekly + on boot"] --> SCAN["archcanary.sh<br/>--full --all-time"]
         PTH[".path unit<br/>after each pacman tx"] --> SCAN
         SCAN --> LOG["last-scan.log"]
     end
 
     subgraph ALERT["4 · ON detection / review"]
         LOG -->|INFECTED| NOT["user .path → notify-send<br/>critical desktop alert"]
-        NOT --> GUI["aur_malware_gui.sh<br/>review + root checks"]
+        NOT --> GUI["archcanary-gui.sh<br/>review + root checks"]
     end
 
     T -.->|install if trusted| U
@@ -43,7 +43,7 @@ flowchart TD
 | 1 · Before | `traur scan <pkg>` | You run it before installing | ✗ manual | Maintainer reputation, PKGBUILD heuristics (279 signals) |
 | 2 · At install | `syay` / `aurscan` | Every `yay` call (`alias yay=syay`) | ✓ | Novel / obfuscated payloads — Claude reads the PKGBUILD |
 | 2 · At install | yay `init.lua` hooks | After aurscan clears the build | ✓ | Known campaign signatures, stale-rewrite upgrades (offline) |
-| 3 · After / always | `aur_check-v2.sh` | systemd timer (weekly + boot) + `.path` (after each pacman tx) | ✓ root | Known-bad packages, systemd/eBPF/npm persistence, rootkit traces |
+| 3 · After / always | `archcanary.sh` | systemd timer (weekly + boot) + `.path` (after each pacman tx) | ✓ root | Known-bad packages, systemd/eBPF/npm persistence, rootkit traces |
 | 4 · On detection | notifier → GUI | `last-scan.log` flips to INFECTED | ✓ | Surfaces a result; review is manual |
 
 ## Read this first

--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -1,4 +1,4 @@
-# Running aur-malware-check via systemd
+# Running archcanary via systemd
 
 Run the scanner automatically with full coverage and a desktop notification if anything is found.
 
@@ -12,28 +12,28 @@ user-level checks — wrong home, false positives. So the two are split:
 
 ```
 system (root) — system-level checks:
-  aur-malware-check.service  --check-systemd --check-ebpf --check-bpftool
+  archcanary.service  --check-systemd --check-ebpf --check-bpftool
                              --check-ldso --check-kmod  (+ package/log checks)
-     └─ writes /var/lib/aur-malware-check/last-scan.log   (--no-notify)
-  aur-malware-check.timer    weekly + on boot
-  aur-malware-check.path     + -onchange.service  (after each pacman transaction)
+     └─ writes /var/lib/archcanary/last-scan.log   (--no-notify)
+  archcanary.timer    weekly + on boot
+  archcanary.path     + -onchange.service  (after each pacman transaction)
 
-  aur-malware-check-notify.path (user) watches last-scan.log
+  archcanary-notify.path (user) watches last-scan.log
      └─ notify.service: grep INFECTED → notify-send
 
 user (you) — user-level checks:
-  aur-malware-check-user.service  --check-npm-cache --check-bun-cache
+  archcanary-user.service  --check-npm-cache --check-bun-cache
                                   --check-{yarn,pnpm}-cache --check-pkgbuild
                                   --check-autostart   (scans your real ~)
      └─ notifies itself on a detection (runs in your session)
-  aur-malware-check-user.timer    weekly + on boot
+  archcanary-user.timer    weekly + on boot
 ```
 
 The root scan can't notify (no desktop session), so a user `.path` unit watches its result file and raises the alert. The user scan runs in your session, so it just calls `notify-send` itself.
 
 ## Quick setup (recommended)
 
-`./install.sh --system` does all of this for you — it installs the system scan units, the user-level scan, and the notifier; creates `/var/lib/aur-malware-check/`; seeds the package lists and the system-wide DKMS allowlist; enables the system timer + pacman-trigger, the user timer, and the notifier; and migrates away any old user-scope scan units:
+`./install.sh --system` does all of this for you — it installs the system scan units, the user-level scan, and the notifier; creates `/var/lib/archcanary/`; seeds the package lists and the system-wide DKMS allowlist; enables the system timer + pacman-trigger, the user timer, and the notifier; and migrates away any old user-scope scan units:
 
 ```bash
 ./install.sh --system
@@ -41,11 +41,11 @@ The root scan can't notify (no desktop session), so a user `.path` unit watches 
 
 The rest of this document describes the units it installs, for reference or manual setup.
 
-> The system components are required — `install.sh --system` installs the root-accessible script, the root helper, the polkit policy, **and** the bundled package lists under `/usr/lib/aur-malware-check/` so the root scan can find them (root's `$HOME` is `/root`, which is not seeded).
+> The system components are required — `install.sh --system` installs the root-accessible script, the root helper, the polkit policy, **and** the bundled package lists under `/usr/lib/archcanary/` so the root scan can find them (root's `$HOME` is `/root`, which is not seeded).
 
 ## 1. System scan (root)
 
-**`/etc/systemd/system/aur-malware-check.service`**
+**`/etc/systemd/system/archcanary.service`**
 ```ini
 [Unit]
 Description=AUR malware check (system-level scan, root)
@@ -54,13 +54,13 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-StateDirectory=aur-malware-check
-ExecStart=/usr/lib/aur-malware-check/aur-malware-check.sh --refresh --all-time --check-systemd --check-ebpf --check-bpftool --check-ldso --check-kmod --no-notify --log-file=/var/lib/aur-malware-check/last-scan.log
+StateDirectory=archcanary
+ExecStart=/usr/lib/archcanary/archcanary.sh --refresh --all-time --check-systemd --check-ebpf --check-bpftool --check-ldso --check-kmod --no-notify --log-file=/var/lib/archcanary/last-scan.log
 ```
 
-> `StateDirectory=aur-malware-check` makes systemd create `/var/lib/aur-malware-check` (mode 0755, root) automatically. This runs only the **system-level** checks (plus the always-on package/log checks) — the ones that need root and are machine-wide. The user-level checks run in section 3 as your user. `--no-notify` because root has no desktop session — section 2 handles alerts.
+> `StateDirectory=archcanary` makes systemd create `/var/lib/archcanary` (mode 0755, root) automatically. This runs only the **system-level** checks (plus the always-on package/log checks) — the ones that need root and are machine-wide. The user-level checks run in section 3 as your user. `--no-notify` because root has no desktop session — section 2 handles alerts.
 
-**`/etc/systemd/system/aur-malware-check.timer`**
+**`/etc/systemd/system/archcanary.timer`**
 ```ini
 [Unit]
 Description=Run AUR malware check weekly and on boot
@@ -77,57 +77,57 @@ WantedBy=timers.target
 Enable and start:
 ```bash
 sudo systemctl daemon-reload
-sudo systemctl enable --now aur-malware-check.timer
+sudo systemctl enable --now archcanary.timer
 ```
 
 ## 2. Desktop notification (user)
 
-**`~/.config/systemd/user/aur-malware-check-notify.path`**
+**`~/.config/systemd/user/archcanary-notify.path`**
 ```ini
 [Unit]
 Description=Watch for AUR malware scan results
 
 [Path]
-PathModified=/var/lib/aur-malware-check/last-scan.log
-Unit=aur-malware-check-notify.service
+PathModified=/var/lib/archcanary/last-scan.log
+Unit=archcanary-notify.service
 
 [Install]
 WantedBy=default.target
 ```
 
-**`~/.config/systemd/user/aur-malware-check-notify.service`**
+**`~/.config/systemd/user/archcanary-notify.service`**
 ```ini
 [Unit]
 Description=Notify on AUR malware detection
 
 [Service]
 Type=oneshot
-ExecStart=/bin/sh -c 'grep -q "RESULT: INFECTED" /var/lib/aur-malware-check/last-scan.log && notify-send -u critical -i dialog-warning "AUR: malicious package detected" "Open AUR Malware Check to review." || true'
+ExecStart=/bin/sh -c 'grep -q "RESULT: INFECTED" /var/lib/archcanary/last-scan.log && notify-send -u critical -i dialog-warning "AUR: malicious package detected" "Open Archcanary to review." || true'
 ```
 
 Enable and start:
 ```bash
 systemctl --user daemon-reload
-systemctl --user enable --now aur-malware-check-notify.path
+systemctl --user enable --now archcanary-notify.path
 ```
 
-> The path unit fires whenever the root scan rewrites the result file; the service notifies only when a detection is present. Needs a notification daemon (`dunst`, `mako`, GNOME, KDE) and `libnotify`. To review/remediate, open **AUR Malware Check** from your app launcher.
+> The path unit fires whenever the root scan rewrites the result file; the service notifies only when a detection is present. Needs a notification daemon (`dunst`, `mako`, GNOME, KDE) and `libnotify`. To review/remediate, open **Archcanary** from your app launcher.
 
 ## 3. User-level scan (your session)
 
 Runs the user-level checks **as you**, so they scan your real `~/.cache` and `~/.config` (not root's) and resolve autostart `Exec=` names against your PATH. Running in your session, it raises its own notification on a detection — no `--no-notify`, no separate notifier needed.
 
-**`~/.config/systemd/user/aur-malware-check-user.service`**
+**`~/.config/systemd/user/archcanary-user.service`**
 ```ini
 [Unit]
 Description=AUR malware check (user-level scan)
 
 [Service]
 Type=oneshot
-ExecStart=%h/.local/bin/aur-malware-check.sh --all-time --check-npm-cache --check-bun-cache --check-yarn-cache --check-pnpm-cache --check-pkgbuild --check-autostart --log-file=%h/.cache/aur-malware-check/last-user-scan.log
+ExecStart=%h/.local/bin/archcanary.sh --all-time --check-npm-cache --check-bun-cache --check-yarn-cache --check-pnpm-cache --check-pkgbuild --check-autostart --log-file=%h/.cache/archcanary/last-user-scan.log
 ```
 
-**`~/.config/systemd/user/aur-malware-check-user.timer`**
+**`~/.config/systemd/user/archcanary-user.timer`**
 ```ini
 [Unit]
 Description=Run AUR malware user-level check weekly and on boot
@@ -144,32 +144,32 @@ WantedBy=timers.target
 Enable and start:
 ```bash
 systemctl --user daemon-reload
-systemctl --user enable --now aur-malware-check-user.timer
+systemctl --user enable --now archcanary-user.timer
 ```
 
 ## 4. Scan after every pacman transaction (optional)
 
 A **system** path unit watches `/var/log/pacman.log` and runs an offline (no `--refresh`) system-level scan right after any install/upgrade/removal, so a freshly installed compromised package is caught immediately. The section-2 user notifier covers these runs too (same result file).
 
-**`/etc/systemd/system/aur-malware-check-onchange.service`**
+**`/etc/systemd/system/archcanary-onchange.service`**
 ```ini
 [Unit]
 Description=AUR malware check (system-level scan, after pacman transaction)
 
 [Service]
 Type=oneshot
-StateDirectory=aur-malware-check
-ExecStart=/usr/lib/aur-malware-check/aur-malware-check.sh --all-time --check-systemd --check-ebpf --check-bpftool --check-ldso --check-kmod --no-notify --log-file=/var/lib/aur-malware-check/last-scan.log
+StateDirectory=archcanary
+ExecStart=/usr/lib/archcanary/archcanary.sh --all-time --check-systemd --check-ebpf --check-bpftool --check-ldso --check-kmod --no-notify --log-file=/var/lib/archcanary/last-scan.log
 ```
 
-**`/etc/systemd/system/aur-malware-check.path`**
+**`/etc/systemd/system/archcanary.path`**
 ```ini
 [Unit]
 Description=Trigger AUR malware check after pacman transactions
 
 [Path]
 PathChanged=/var/log/pacman.log
-Unit=aur-malware-check-onchange.service
+Unit=archcanary-onchange.service
 
 [Install]
 WantedBy=multi-user.target
@@ -178,7 +178,7 @@ WantedBy=multi-user.target
 Enable and start:
 ```bash
 sudo systemctl daemon-reload
-sudo systemctl enable --now aur-malware-check.path
+sudo systemctl enable --now archcanary.path
 ```
 
 > The path unit only triggers when `/var/log/pacman.log` changes; systemd coalesces rapid writes (e.g. a big `-Syu`) so the scan runs once after the transaction settles. Runs offline against the cached list; freshness comes from the weekly timer's `--refresh`.
@@ -187,27 +187,27 @@ sudo systemctl enable --now aur-malware-check.path
 
 ```bash
 # Last system-scan output (root-owned)
-sudo cat /var/lib/aur-malware-check/last-scan.log
+sudo cat /var/lib/archcanary/last-scan.log
 # Last user-scan output
-cat ~/.cache/aur-malware-check/last-user-scan.log
+cat ~/.cache/archcanary/last-user-scan.log
 
 # Or via the journal
-journalctl -u aur-malware-check            # system scan
-journalctl --user -u aur-malware-check-user   # user scan
+journalctl -u archcanary            # system scan
+journalctl --user -u archcanary-user   # user scan
 
 # Timer / unit status
-systemctl status aur-malware-check.timer
-systemctl --user status aur-malware-check-user.timer aur-malware-check-notify.path
+systemctl status archcanary.timer
+systemctl --user status archcanary-user.timer archcanary-notify.path
 ```
 
 ## Migrating from the old user service
 
-Earlier versions ran the scan as a **user** service (`~/.config/systemd/user/aur-malware-check.{service,timer}`). Because that runs without root, the kmod/eBPF/bpftool checks are skipped and the scan now reports `INCOMPLETE` (exit 1). Disable the old user units and use the system scan above instead:
+Earlier versions ran the scan as a **user** service (`~/.config/systemd/user/archcanary.{service,timer}`). Because that runs without root, the kmod/eBPF/bpftool checks are skipped and the scan now reports `INCOMPLETE` (exit 1). Disable the old user units and use the system scan above instead:
 
 ```bash
-systemctl --user disable --now aur-malware-check.timer
-rm -f ~/.config/systemd/user/aur-malware-check.service \
-      ~/.config/systemd/user/aur-malware-check.timer
+systemctl --user disable --now archcanary.timer
+rm -f ~/.config/systemd/user/archcanary.service \
+      ~/.config/systemd/user/archcanary.timer
 ```
 
 ## Why the split?

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # ---------------------------------------------------------------------------
-# install.sh — install or uninstall aur-malware-check
+# install.sh — install or uninstall archcanary
 #   Usage: ./install.sh [--system] [bin-dir]
 #          ./install.sh uninstall [--system]
 #
@@ -45,7 +45,7 @@ for arg in "$@"; do
         *) BIN_DIR="$arg" ;;
     esac
 done
-CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/aur-malware-check"
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/archcanary"
 
 if $UNINSTALL; then
     echo "Uninstalling from: $BIN_DIR"
@@ -53,7 +53,7 @@ if $UNINSTALL; then
     echo
 
     removed=0
-    for f in aur-malware-check.sh aur_malware_gui.sh; do
+    for f in archcanary.sh archcanary-gui.sh; do
         if [[ -f "$BIN_DIR/$f" ]]; then
             rm "$BIN_DIR/$f"
             echo "  removed: $BIN_DIR/$f"
@@ -63,7 +63,7 @@ if $UNINSTALL; then
         fi
     done
 
-    desktop_dst="${XDG_DATA_HOME:-$HOME/.local/share}/applications/aur-malware-check.desktop"
+    desktop_dst="${XDG_DATA_HOME:-$HOME/.local/share}/applications/archcanary.desktop"
     if [[ -f "$desktop_dst" ]]; then
         rm "$desktop_dst"
         echo "  removed: $desktop_dst"
@@ -81,33 +81,33 @@ if $UNINSTALL; then
         echo "Removing system components (requires root)..."
 
         # User-scope units (user scan + notifier)
-        systemctl --user disable --now aur-malware-check-notify.path 2>/dev/null || true
-        systemctl --user disable --now aur-malware-check-user.timer 2>/dev/null || true
-        rm -f "$HOME/.config/systemd/user/aur-malware-check-notify.path" \
-              "$HOME/.config/systemd/user/aur-malware-check-notify.service" \
-              "$HOME/.config/systemd/user/aur-malware-check-user.service" \
-              "$HOME/.config/systemd/user/aur-malware-check-user.timer"
+        systemctl --user disable --now archcanary-notify.path 2>/dev/null || true
+        systemctl --user disable --now archcanary-user.timer 2>/dev/null || true
+        rm -f "$HOME/.config/systemd/user/archcanary-notify.path" \
+              "$HOME/.config/systemd/user/archcanary-notify.service" \
+              "$HOME/.config/systemd/user/archcanary-user.service" \
+              "$HOME/.config/systemd/user/archcanary-user.timer"
         systemctl --user daemon-reload 2>/dev/null || true
 
         # System scan units
-        sudo systemctl disable --now aur-malware-check.timer aur-malware-check.path 2>/dev/null || true
-        sudo rm -f /etc/systemd/system/aur-malware-check.service \
-                   /etc/systemd/system/aur-malware-check.timer \
-                   /etc/systemd/system/aur-malware-check-onchange.service \
-                   /etc/systemd/system/aur-malware-check.path
+        sudo systemctl disable --now archcanary.timer archcanary.path 2>/dev/null || true
+        sudo rm -f /etc/systemd/system/archcanary.service \
+                   /etc/systemd/system/archcanary.timer \
+                   /etc/systemd/system/archcanary-onchange.service \
+                   /etc/systemd/system/archcanary.path
         sudo systemctl daemon-reload
-        sudo rm -rf /var/lib/aur-malware-check
-        echo "  removed: systemd units (system scan + user notifier) and /var/lib/aur-malware-check"
+        sudo rm -rf /var/lib/archcanary
+        echo "  removed: systemd units (system scan + user notifier) and /var/lib/archcanary"
 
-        sudo rm -rf /usr/lib/aur-malware-check /etc/aur-malware-check
-        echo "  removed: /usr/lib/aur-malware-check, /etc/aur-malware-check"
-        sudo rm -f /usr/share/polkit-1/actions/org.aur-malware-check.policy
-        echo "  removed: /usr/share/polkit-1/actions/org.aur-malware-check.policy"
+        sudo rm -rf /usr/lib/archcanary /etc/archcanary
+        echo "  removed: /usr/lib/archcanary, /etc/archcanary"
+        sudo rm -f /usr/share/polkit-1/actions/org.archcanary.policy
+        echo "  removed: /usr/share/polkit-1/actions/org.archcanary.policy"
     fi
 
     echo
     if [[ $removed -gt 0 ]]; then
-        echo "Done. aur-malware-check uninstalled."
+        echo "Done. archcanary uninstalled."
     else
         echo "Nothing was removed (files not found at $BIN_DIR)."
     fi
@@ -122,20 +122,20 @@ echo
 mkdir -p "$BIN_DIR" "$CONFIG_DIR"
 
 # Install main script
-cp "$REPO_DIR/aur_check-v2.sh" "$BIN_DIR/aur-malware-check.sh"
-chmod +x "$BIN_DIR/aur-malware-check.sh"
-echo "  installed: $BIN_DIR/aur-malware-check.sh"
+cp "$REPO_DIR/archcanary.sh" "$BIN_DIR/archcanary.sh"
+chmod +x "$BIN_DIR/archcanary.sh"
+echo "  installed: $BIN_DIR/archcanary.sh"
 
 # Install GUI script
-cp "$REPO_DIR/aur_malware_gui.sh" "$BIN_DIR/aur_malware_gui.sh"
-chmod +x "$BIN_DIR/aur_malware_gui.sh"
-echo "  installed: $BIN_DIR/aur_malware_gui.sh"
+cp "$REPO_DIR/archcanary-gui.sh" "$BIN_DIR/archcanary-gui.sh"
+chmod +x "$BIN_DIR/archcanary-gui.sh"
+echo "  installed: $BIN_DIR/archcanary-gui.sh"
 
 # Install desktop entry
 DESKTOP_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/applications"
 mkdir -p "$DESKTOP_DIR"
-cp "$REPO_DIR/aur-malware-check.desktop" "$DESKTOP_DIR/aur-malware-check.desktop"
-echo "  installed: $DESKTOP_DIR/aur-malware-check.desktop"
+cp "$REPO_DIR/archcanary.desktop" "$DESKTOP_DIR/archcanary.desktop"
+echo "  installed: $DESKTOP_DIR/archcanary.desktop"
 
 # Seed config dir (only if files don't already exist)
 for f in package_list.txt malicious_npm_packages.txt; do
@@ -147,20 +147,20 @@ for f in package_list.txt malicious_npm_packages.txt; do
     fi
 done
 
-# The DKMS allowlist is a single system-wide file at /etc/aur-malware-check/
+# The DKMS allowlist is a single system-wide file at /etc/archcanary/
 # (the kmod audit only runs as root). It is seeded by --system below, not here.
 
 if $SYSTEM; then
     echo
     echo "Installing system components (requires root)..."
-    SYSTEM_LIB="/usr/lib/aur-malware-check"
+    SYSTEM_LIB="/usr/lib/archcanary"
     sudo mkdir -p "$SYSTEM_LIB"
-    sudo cp "$REPO_DIR/aur_check-v2.sh" "$SYSTEM_LIB/aur-malware-check.sh"
-    sudo chmod 755 "$SYSTEM_LIB/aur-malware-check.sh"
-    sudo cp "$REPO_DIR/aur-malware-root-helper" "$SYSTEM_LIB/root-helper"
+    sudo cp "$REPO_DIR/archcanary.sh" "$SYSTEM_LIB/archcanary.sh"
+    sudo chmod 755 "$SYSTEM_LIB/archcanary.sh"
+    sudo cp "$REPO_DIR/archcanary-root-helper" "$SYSTEM_LIB/root-helper"
     sudo chown root:root "$SYSTEM_LIB/root-helper"
     sudo chmod 755 "$SYSTEM_LIB/root-helper"
-    sudo cp "$REPO_DIR/org.aur-malware-check.policy" /usr/share/polkit-1/actions/
+    sudo cp "$REPO_DIR/org.archcanary.policy" /usr/share/polkit-1/actions/
     # Seed the bundled package lists next to the system script so a root scan
     # (system service) finds them — root's $HOME is /root, which is not seeded.
     for _list in package_list.txt malicious_npm_packages.txt chaos_rat_packages.txt; do
@@ -170,12 +170,12 @@ if $SYSTEM; then
     # Seed it once (mode 644 so non-root runs can read it), preferring an existing
     # legacy ~/.config copy so prior entries are preserved on upgrade; otherwise a
     # commented template. Never clobber an existing /etc copy.
-    sudo install -d -m 755 /etc/aur-malware-check
-    if [[ ! -f /etc/aur-malware-check/dkms_allowlist.conf ]]; then
+    sudo install -d -m 755 /etc/archcanary
+    if [[ ! -f /etc/archcanary/dkms_allowlist.conf ]]; then
         if [[ -f "$CONFIG_DIR/dkms_allowlist.conf" ]]; then
-            sudo install -m 644 "$CONFIG_DIR/dkms_allowlist.conf" /etc/aur-malware-check/dkms_allowlist.conf
+            sudo install -m 644 "$CONFIG_DIR/dkms_allowlist.conf" /etc/archcanary/dkms_allowlist.conf
         else
-            sudo tee /etc/aur-malware-check/dkms_allowlist.conf >/dev/null << 'EOF'
+            sudo tee /etc/archcanary/dkms_allowlist.conf >/dev/null << 'EOF'
 # DKMS modules to skip during --check-kmod (system-wide allowlist).
 # One module name per line. Everything after # is a comment.
 # Add modules that are known-good but not tracked by pacman.
@@ -186,7 +186,7 @@ if $SYSTEM; then
 # vboxdrv         # VirtualBox host kernel module
 # vmmon           # VMware Workstation
 EOF
-            sudo chmod 644 /etc/aur-malware-check/dkms_allowlist.conf
+            sudo chmod 644 /etc/archcanary/dkms_allowlist.conf
         fi
     fi
     # The per-user allowlist is no longer read — remove the legacy copy to avoid
@@ -195,17 +195,17 @@ EOF
         rm -f "$CONFIG_DIR/dkms_allowlist.conf"
         echo "  migrated:  ~/.config dkms_allowlist.conf → /etc (per-user copy removed)"
     fi
-    echo "  installed: $SYSTEM_LIB/aur-malware-check.sh"
+    echo "  installed: $SYSTEM_LIB/archcanary.sh"
     echo "  installed: $SYSTEM_LIB/root-helper"
     echo "  installed: $SYSTEM_LIB/{package_list,malicious_npm_packages,chaos_rat_packages}.txt"
-    echo "  installed: /etc/aur-malware-check/dkms_allowlist.conf (system-wide DKMS allowlist for the root scan)"
-    echo "  installed: /usr/share/polkit-1/actions/org.aur-malware-check.policy"
+    echo "  installed: /etc/archcanary/dkms_allowlist.conf (system-wide DKMS allowlist for the root scan)"
+    echo "  installed: /usr/share/polkit-1/actions/org.archcanary.policy"
 
     # --- Automated scan: root system units + user-session notifier ---------
     # Migrate away from the old user-scope scan units (superseded by the root
     # system scan; running --full as the user skips the root checks).
-    for _u in aur-malware-check.service aur-malware-check.timer \
-              aur-malware-check.path aur-malware-check-onchange.service; do
+    for _u in archcanary.service archcanary.timer \
+              archcanary.path archcanary-onchange.service; do
         if [[ -f "$HOME/.config/systemd/user/$_u" ]]; then
             systemctl --user disable --now "$_u" 2>/dev/null || true
             rm -f "$HOME/.config/systemd/user/$_u"
@@ -215,36 +215,36 @@ EOF
 
     # Pre-create the result dir so the user notifier can watch it right away
     # (the scan's StateDirectory= also creates it, but the .path needs it now).
-    sudo install -d -m 755 /var/lib/aur-malware-check
+    sudo install -d -m 755 /var/lib/archcanary
 
     # System scan units (run as root → complete scan)
-    sudo cp "$REPO_DIR"/systemd/system/aur-malware-check.service \
-            "$REPO_DIR"/systemd/system/aur-malware-check.timer \
-            "$REPO_DIR"/systemd/system/aur-malware-check-onchange.service \
-            "$REPO_DIR"/systemd/system/aur-malware-check.path \
+    sudo cp "$REPO_DIR"/systemd/system/archcanary.service \
+            "$REPO_DIR"/systemd/system/archcanary.timer \
+            "$REPO_DIR"/systemd/system/archcanary-onchange.service \
+            "$REPO_DIR"/systemd/system/archcanary.path \
             /etc/systemd/system/
     sudo systemctl daemon-reload
-    sudo systemctl enable --now aur-malware-check.timer aur-malware-check.path
-    echo "  installed: /etc/systemd/system/aur-malware-check.{service,timer,path} + -onchange.service (enabled)"
+    sudo systemctl enable --now archcanary.timer archcanary.path
+    echo "  installed: /etc/systemd/system/archcanary.{service,timer,path} + -onchange.service (enabled)"
 
     # User-scope units: the user-level scan (npm/bun/pkgbuild caches, autostart —
     # run as you so they see your real home) + the notifier that watches the root
     # scan's result. The user scan notifies itself (runs in your session).
     USER_UNITS="$HOME/.config/systemd/user"
     mkdir -p "$USER_UNITS"
-    cp "$REPO_DIR"/systemd/user/aur-malware-check-notify.path \
-       "$REPO_DIR"/systemd/user/aur-malware-check-notify.service \
-       "$REPO_DIR"/systemd/user/aur-malware-check-user.service \
-       "$REPO_DIR"/systemd/user/aur-malware-check-user.timer \
+    cp "$REPO_DIR"/systemd/user/archcanary-notify.path \
+       "$REPO_DIR"/systemd/user/archcanary-notify.service \
+       "$REPO_DIR"/systemd/user/archcanary-user.service \
+       "$REPO_DIR"/systemd/user/archcanary-user.timer \
        "$USER_UNITS/"
     if systemctl --user daemon-reload 2>/dev/null; then
-        systemctl --user enable --now aur-malware-check-notify.path 2>/dev/null || true
-        systemctl --user enable --now aur-malware-check-user.timer 2>/dev/null || true
-        echo "  installed: $USER_UNITS/aur-malware-check-user.{service,timer} + notify.{path,service} (enabled)"
+        systemctl --user enable --now archcanary-notify.path 2>/dev/null || true
+        systemctl --user enable --now archcanary-user.timer 2>/dev/null || true
+        echo "  installed: $USER_UNITS/archcanary-user.{service,timer} + notify.{path,service} (enabled)"
     else
-        echo "  installed: $USER_UNITS/aur-malware-check-user.{service,timer} + notify.{path,service}"
+        echo "  installed: $USER_UNITS/archcanary-user.{service,timer} + notify.{path,service}"
         echo "             (no user systemd session detected — enable later with:"
-        echo "              systemctl --user enable --now aur-malware-check-user.timer aur-malware-check-notify.path)"
+        echo "              systemctl --user enable --now archcanary-user.timer archcanary-notify.path)"
     fi
 
     echo
@@ -253,7 +253,7 @@ EOF
 fi
 
 echo
-echo "Done. Run: aur-malware-check.sh --refresh --full --all-time"
+echo "Done. Run: archcanary.sh --refresh --full --all-time"
 
 # Warn if BIN_DIR is not in PATH
 if [[ ":$PATH:" != *":$BIN_DIR:"* ]]; then

--- a/iocs.txt
+++ b/iocs.txt
@@ -1,5 +1,5 @@
 # Indicators of Compromise (IOCs) - AUR Malware Campaign June 2026
-# Sources: https://ioctl.fail/preliminary-analysis-of-aur-malware/
+# Sources: https://ioctl.fail/preliminary-analysis-of-archcanary/
 #          https://gist.github.com/Kidev/59bf9f5fb53ab5eee99f19a6a2fc3992
 
 ## File Hashes

--- a/org.archcanary.policy
+++ b/org.archcanary.policy
@@ -4,10 +4,10 @@
     "https://specifications.freedesktop.org/PolicyKit/1.0/policyconfig.dtd">
 <policyconfig>
 
-    <vendor>aur-malware-check</vendor>
-    <vendor_url>https://github.com/musqz/aur-malware-check</vendor_url>
+    <vendor>archcanary</vendor>
+    <vendor_url>https://github.com/musqz/archcanary</vendor_url>
 
-    <action id="org.aur-malware-check.root-check">
+    <action id="org.archcanary.root-check">
         <description>Run a privileged AUR malware check</description>
         <message>Authentication is required to run a privileged AUR malware check (kernel modules, eBPF programs).</message>
         <icon_name>security-high</icon_name>
@@ -16,7 +16,7 @@
             <allow_inactive>auth_admin</allow_inactive>
             <allow_active>auth_admin</allow_active>
         </defaults>
-        <annotate key="org.freedesktop.policykit.exec.path">/usr/lib/aur-malware-check/root-helper</annotate>
+        <annotate key="org.freedesktop.policykit.exec.path">/usr/lib/archcanary/root-helper</annotate>
         <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
     </action>
 

--- a/systemd/system/archcanary-onchange.service
+++ b/systemd/system/archcanary-onchange.service
@@ -3,5 +3,5 @@ Description=AUR malware check (system-level scan, after pacman transaction)
 
 [Service]
 Type=oneshot
-StateDirectory=aur-malware-check
-ExecStart=/usr/lib/aur-malware-check/aur-malware-check.sh --all-time --check-systemd --check-ebpf --check-bpftool --check-ldso --check-kmod --no-notify --log-file=/var/lib/aur-malware-check/last-scan.log
+StateDirectory=archcanary
+ExecStart=/usr/lib/archcanary/archcanary.sh --all-time --check-systemd --check-ebpf --check-bpftool --check-ldso --check-kmod --no-notify --log-file=/var/lib/archcanary/last-scan.log

--- a/systemd/system/archcanary.path
+++ b/systemd/system/archcanary.path
@@ -3,7 +3,7 @@ Description=Trigger AUR malware check after pacman transactions
 
 [Path]
 PathChanged=/var/log/pacman.log
-Unit=aur-malware-check-onchange.service
+Unit=archcanary-onchange.service
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/system/archcanary.service
+++ b/systemd/system/archcanary.service
@@ -5,5 +5,5 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-StateDirectory=aur-malware-check
-ExecStart=/usr/lib/aur-malware-check/aur-malware-check.sh --refresh --all-time --check-systemd --check-ebpf --check-bpftool --check-ldso --check-kmod --no-notify --log-file=/var/lib/aur-malware-check/last-scan.log
+StateDirectory=archcanary
+ExecStart=/usr/lib/archcanary/archcanary.sh --refresh --all-time --check-systemd --check-ebpf --check-bpftool --check-ldso --check-kmod --no-notify --log-file=/var/lib/archcanary/last-scan.log

--- a/systemd/user/archcanary-notify.path
+++ b/systemd/user/archcanary-notify.path
@@ -8,8 +8,8 @@ StartLimitIntervalSec=0
 # PathChanged (IN_CLOSE_WRITE) fires once when the writer closes the file, not
 # on every write. The scan streams last-scan.log line-by-line via tee, so
 # PathModified would fire dozens of times per scan and trip the start limit.
-PathChanged=/var/lib/aur-malware-check/last-scan.log
-Unit=aur-malware-check-notify.service
+PathChanged=/var/lib/archcanary/last-scan.log
+Unit=archcanary-notify.service
 
 [Install]
 WantedBy=default.target

--- a/systemd/user/archcanary-notify.service
+++ b/systemd/user/archcanary-notify.service
@@ -6,4 +6,4 @@ StartLimitIntervalSec=0
 
 [Service]
 Type=oneshot
-ExecStart=/bin/sh -c 'grep -q "RESULT: INFECTED" /var/lib/aur-malware-check/last-scan.log && notify-send -u critical -i dialog-warning "AUR: malicious package detected" "Open AUR Malware Check to review." || true'
+ExecStart=/bin/sh -c 'grep -q "RESULT: INFECTED" /var/lib/archcanary/last-scan.log && notify-send -u critical -i dialog-warning "AUR: malicious package detected" "Open Archcanary to review." || true'

--- a/systemd/user/archcanary-user.service
+++ b/systemd/user/archcanary-user.service
@@ -6,4 +6,4 @@ Type=oneshot
 # Runs as your user, so it scans your real ~/.cache and ~/.config and resolves
 # autostart Exec= names against your PATH. No --no-notify: in the user session
 # it can raise the desktop alert itself on a detection.
-ExecStart=%h/.local/bin/aur-malware-check.sh --all-time --check-npm-cache --check-bun-cache --check-yarn-cache --check-pnpm-cache --check-pkgbuild --check-autostart --log-file=%h/.cache/aur-malware-check/last-user-scan.log
+ExecStart=%h/.local/bin/archcanary.sh --all-time --check-npm-cache --check-bun-cache --check-yarn-cache --check-pnpm-cache --check-pkgbuild --check-autostart --log-file=%h/.cache/archcanary/last-user-scan.log

--- a/tests/run_matching_tests.sh
+++ b/tests/run_matching_tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Matching test runner for aur_malware_check
+# Matching test runner for archcanary
 # Tests that package matching is exact (no prefix/suffix false positives)
 # and that list parsing handles edge cases correctly.
 #
@@ -24,7 +24,7 @@ pass()  { echo >&2 "  PASS: $1"; PASS_COUNT=$((PASS_COUNT + 1)); }
 fail()  { echo >&2 "  FAIL: $1"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
 
 # ---------------------------------------------------------------------------
-# Helper: load a package list file the same way aur_check-v2.sh does
+# Helper: load a package list file the same way archcanary.sh does
 # Returns array via nameref
 # ---------------------------------------------------------------------------
 load_list() {
@@ -197,7 +197,7 @@ test_cli_flag() {
     # Run via env var (existing path)
     local result=0
     PACKAGE_LIST_FILE="$SCRIPT_DIR/fake_package_lists/simple.txt" \
-    "$REPO_DIR/aur_check-v2.sh" --log-file="$log_file" >/dev/null 2>&1 || true
+    "$REPO_DIR/archcanary.sh" --log-file="$log_file" >/dev/null 2>&1 || true
     grep -q "Packages checked: 10" "$log_file" || result=$?
 
     if [[ $result -eq 0 ]]; then
@@ -205,7 +205,7 @@ test_cli_flag() {
     else
         # Try with direct --package-list flag
         result=0
-        "$REPO_DIR/aur_check-v2.sh" \
+        "$REPO_DIR/archcanary.sh" \
             --package-list="$SCRIPT_DIR/fake_package_lists/simple.txt" \
             --log-file="$log_file" >/dev/null 2>&1 || true
         grep -q "Packages checked: 10" "$log_file" || result=$?
@@ -226,7 +226,7 @@ test_npm_cli_flag() {
     local log_file
     log_file=$(mktemp)
 
-    "$REPO_DIR/aur_check-v2.sh" \
+    "$REPO_DIR/archcanary.sh" \
         --package-list="$SCRIPT_DIR/fake_package_lists/simple.txt" \
         --malicious-npm-list="$SCRIPT_DIR/fake_npm_lists/malicious_npm.txt" \
         --log-file="$log_file" >/dev/null 2>&1 || true
@@ -271,7 +271,7 @@ test_check_ldso() {
     # Sub-test A: absent/empty preload, empty conf.d → clean
     rc=0
     out=$(LDSO_PRELOAD_FILE="$preload_file" LDSO_CONF_DIR="$conf_dir" \
-        "$REPO_DIR/aur_check-v2.sh" \
+        "$REPO_DIR/archcanary.sh" \
         --package-list="$SCRIPT_DIR/fake_package_lists/simple.txt" \
         --malicious-npm-list="$SCRIPT_DIR/fake_npm_lists/malicious_npm.txt" \
         --check-ldso --no-notify 2>&1) || rc=$?
@@ -285,7 +285,7 @@ test_check_ldso() {
     echo "/tmp/evil.so" > "$preload_file"
     rc=0
     out=$(LDSO_PRELOAD_FILE="$preload_file" LDSO_CONF_DIR="$conf_dir" \
-        "$REPO_DIR/aur_check-v2.sh" \
+        "$REPO_DIR/archcanary.sh" \
         --package-list="$SCRIPT_DIR/fake_package_lists/simple.txt" \
         --malicious-npm-list="$SCRIPT_DIR/fake_npm_lists/malicious_npm.txt" \
         --check-ldso --no-notify 2>&1) || rc=$?
@@ -313,7 +313,7 @@ test_check_systemd_hardened() {
 
     # Sub-test A: drop-in override with Restart=on-failure → WARNING
     out=$(SYSTEMD_SCAN_DIRS="$fixture_dir" \
-        "$REPO_DIR/aur_check-v2.sh" "${base_args[@]}" 2>&1) || rc=$?
+        "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
     if [[ $rc -eq 2 && "$out" == *"WARNING"* && "$out" == *"on-failure"* ]]; then
         pass "check_systemd: drop-in Restart=on-failure → WARNING (exit 2)"
     else
@@ -332,7 +332,7 @@ test_check_systemd_hardened() {
     tmpdir=$(mktemp -d)
     rc=0
     out=$(SYSTEMD_SCAN_DIRS="$tmpdir" \
-        "$REPO_DIR/aur_check-v2.sh" "${base_args[@]}" 2>&1) || rc=$?
+        "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
     if [[ "$out" == *"Clean"* && "$out" != *"WARNING"* ]]; then
         pass "check_systemd: empty scan dir → clean"
     else
@@ -356,7 +356,7 @@ test_check_autostart() {
     # Sub-test A: fixture home with evil.desktop + malicious .bashrc → WARNING
     rc=0
     out=$(AUTOSTART_HOME="$fake_home" \
-        "$REPO_DIR/aur_check-v2.sh" "${base_args[@]}" 2>&1) || rc=$?
+        "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
     if [[ $rc -eq 2 && "$out" == *"WARNING"* ]]; then
         pass "check_autostart: evil.desktop + malicious .bashrc → WARNING (exit 2)"
     else
@@ -383,7 +383,7 @@ test_check_autostart() {
     mkdir -p "$tmpdir/.config/autostart"
     rc=0
     out=$(AUTOSTART_HOME="$tmpdir" \
-        "$REPO_DIR/aur_check-v2.sh" "${base_args[@]}" 2>&1) || rc=$?
+        "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
     if [[ "$out" == *"Clean"* && "$out" != *"WARNING"* ]]; then
         pass "check_autostart: empty home → clean"
     else
@@ -407,7 +407,7 @@ test_pkgbuild_obfuscation() {
     # Sub-test A: base64 -d | bash → WARNING
     rc=0
     out=$(PKGBUILD_CACHE_DIRS="$fixtures/pkg-base64" \
-        "$REPO_DIR/aur_check-v2.sh" "${base_args[@]}" 2>&1) || rc=$?
+        "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
     if [[ $rc -eq 2 && "$out" == *"base64"* ]]; then
         pass "pkgbuild_obfuscation: base64-decode-to-shell detected"
     else
@@ -417,7 +417,7 @@ test_pkgbuild_obfuscation() {
     # Sub-test B: eval $(...) → WARNING
     rc=0
     out=$(PKGBUILD_CACHE_DIRS="$fixtures/pkg-eval" \
-        "$REPO_DIR/aur_check-v2.sh" "${base_args[@]}" 2>&1) || rc=$?
+        "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
     if [[ $rc -eq 2 && "$out" == *"eval"* ]]; then
         pass "pkgbuild_obfuscation: eval+subshell detected"
     else
@@ -427,7 +427,7 @@ test_pkgbuild_obfuscation() {
     # Sub-test C: printf hex → WARNING
     rc=0
     out=$(PKGBUILD_CACHE_DIRS="$fixtures/pkg-printf" \
-        "$REPO_DIR/aur_check-v2.sh" "${base_args[@]}" 2>&1) || rc=$?
+        "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
     if [[ $rc -eq 2 && "$out" == *"printf"* ]]; then
         pass "pkgbuild_obfuscation: printf hex/octal detected"
     else
@@ -437,7 +437,7 @@ test_pkgbuild_obfuscation() {
     # Sub-test D: variable-split reassembly → WARNING
     rc=0
     out=$(PKGBUILD_CACHE_DIRS="$fixtures/pkg-varsplit" \
-        "$REPO_DIR/aur_check-v2.sh" "${base_args[@]}" 2>&1) || rc=$?
+        "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
     if [[ $rc -eq 2 && "$out" == *"variable-split"* ]]; then
         pass "pkgbuild_obfuscation: variable-split reassembly detected"
     else
@@ -447,7 +447,7 @@ test_pkgbuild_obfuscation() {
     # Sub-test E: clean PKGBUILD → no WARNING
     rc=0
     out=$(PKGBUILD_CACHE_DIRS="$fixtures/pkg-clean" \
-        "$REPO_DIR/aur_check-v2.sh" "${base_args[@]}" 2>&1) || rc=$?
+        "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
     if [[ "$out" == *"Clean"* && "$out" != *"WARNING"* ]]; then
         pass "pkgbuild_obfuscation: clean PKGBUILD → no false positive"
     else
@@ -483,7 +483,7 @@ test_check_kmod() {
 
     rc=0
     out=$(LSMOD_CMD="$lsmod_evil" DKMS_CMD="$null_dkms" \
-        "$REPO_DIR/aur_check-v2.sh" "${base_args[@]}" 2>&1) || rc=$?
+        "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
     if [[ $rc -eq 2 && "$out" == *"WARNING"* && "$out" == *"evil_rootkit_kmod"* ]]; then
         pass "check_kmod: unknown module → WARNING (exit 2) with name listed"
     else
@@ -496,7 +496,7 @@ test_check_kmod() {
 
     rc=0
     out=$(LSMOD_CMD="$lsmod_empty" DKMS_CMD="$null_dkms" \
-        "$REPO_DIR/aur_check-v2.sh" "${base_args[@]}" 2>&1) || rc=$?
+        "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
     if [[ "$out" == *"Clean"* && "$out" != *"WARNING"* ]]; then
         pass "check_kmod: empty lsmod/dkms → clean"
     else


### PR DESCRIPTION
## Summary
- Replace all `aur-malware-check`, `aur_malware`, `aur_check` strings with `archcanary` across 27 files
- Paths: `/etc/archcanary`, `/usr/lib/archcanary`, `/var/lib/archcanary`
- Systemd unit references, polkit action ID (`org.archcanary`)
- Script cross-references, Python module name (`archcanary_py`), bash variable (`ARCHCANARY`)
- Display names, docs, CHANGELOG

File renames were done in PR #1; this PR is content-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)