### PR TITLE
fix: suppress init.lua loaded log from yay -Qua output

### DIFF
--- a/configs/yay-init.lua
+++ b/configs/yay-init.lua
@@ -13,8 +13,6 @@ yay.opt.clean_after = false
 yay.opt.sort_by     = "votes"
 yay.opt.bottom_up   = false
 
-yay.log.info("yay init.lua loaded")
-
 -- Warn about AUR packages with PKGBUILD modified < 3 days ago
 yay.create_autocmd("UpgradeSelect", {
   desc = "flag recently modified AUR upgrades",


### PR DESCRIPTION
The info log fired on every yay invocation including read-only ones like yay -Qua, polluting Mabox update indicator output with a spurious line.