### PR TITLE
docs: document aurscan editor-gate and traur pacman hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ archcanary integrates with and builds on the following:
 | [lenucksi/aur-malware-check](https://github.com/lenucksi/aur-malware-check) | Origin — the aur-malware-check script archcanary started from |
 | [musqz/aurscan](https://github.com/musqz/aurscan) | LLM PKGBUILD scanner — Claude reads each PKGBUILD before `yay` builds; fork of [manticore-projects/aurscan](https://github.com/manticore-projects/aurscan), adapted to read `~/.config/aurscan/env` for archcanary GUI integration |
 | [claude-code](https://code.claude.com/docs/en/setup) | `claude` CLI — LLM backend used by aurscan to analyse PKGBUILDs |
-| [traur](https://aur.archlinux.org/packages/traur) | Pre-install heuristic scanner — 279 signals across 5 weighted categories |
+| [traur](https://aur.archlinux.org/packages/traur) | Heuristic trust scanner — 279 signals across 5 weighted categories; runs automatically as a pacman PreTransaction hook (aborts the install on fail) and on demand (`traur scan <pkg>`) |
 | [yay](https://github.com/Jguer/yay) 13.0 | AUR helper with Lua hook support (`~/.config/yay/init.lua`) — upgrade age warnings, offline pattern check, install log |
 | [yad](https://github.com/v1cont/yad) | GTK dialog toolkit used by `archcanary-gui` |
 | [bpftool](https://github.com/libbpf/bpftool) (pkg: `bpf`) | Enumerates all loaded eBPF programs for rootkit detection |

--- a/README.md
+++ b/README.md
@@ -60,18 +60,19 @@ archcanary integrates with and builds on the following:
 ### Detection Layers
 
 ```
-User runs `aurscan <pkg>` before installing
-    ├── static rules (offline) — known campaign signatures
-    ├── Claude LLM reads PKGBUILD — novel/obfuscated patterns
-    └── on CLEAN → user runs `yay -S pkg` / `yay -Syu`
-            └── yay init.lua hooks
-                            ├── UpgradeSelect  — warn if PKGBUILD modified < 3 days ago
-                            ├── AURPreInstall  — offline pattern check
-                            └── PostInstall    — logs AUR installs
+yay -S pkg / yay -Syu / yay <term>   (transparent — aurscan is wired in as yay's editor-gate)
+    ├── aurscan-gate runs on each AUR PKGBUILD before build
+    │       ├── static rules (offline) — known campaign signatures
+    │       ├── Claude LLM reads PKGBUILD — novel/obfuscated patterns
+    │       └── non-CLEAN → build aborted;  CLEAN → build proceeds
+    └── yay init.lua hooks (independent offline layer)
+            ├── UpgradeSelect  — warn if PKGBUILD modified < 3 days ago
+            ├── AURPreInstall  — offline pattern check
+            └── PostInstall    — logs AUR installs
 
 systemd system timer (weekly + on boot + after each pacman transaction)
     └── archcanary --full --all-time
-            ├── known-bad package list (1900+ JS campaign + 83 Russian spam)
+            ├── known-bad package list (1900+ JS campaign + 73 Russian spam)
             ├── pacman.log history (compressed log support)
             ├── systemd persistence (services, drop-ins, timers)
             ├── eBPF rootkit traces + bpftool program enumeration
@@ -196,7 +197,7 @@ See [docs/systemd.md](docs/systemd.md) for unit file details and [docs/my-setup.
 
 [aurscan](https://github.com/musqz/aurscan) scans PKGBUILDs with an LLM before `yay` builds them. The GUI exposes its backend configuration under **Utilities → LLM settings**.
 
-> **AUR helper compatibility:** aurscan's automatic pre-install scanning only works with **yay** — it relies on yay 13.0's `init.lua` hook system, which fires before each build. Other helpers (paru, pikaur, aurutils) have no equivalent hook, so PKGBUILD scanning won't trigger automatically with them. archcanary's post-install detection (all other checks) works with any AUR helper.
+> **AUR helper compatibility:** aurscan's automatic scanning is wired into **yay** as its **editor-gate** — yay's `config.json` sets `editor=aurscan-gate` with `editmenu=true`, so yay invokes aurscan on each PKGBUILD before building (no `alias yay=syay` needed). Other helpers (paru, pikaur, aurutils) need their own equivalent, so PKGBUILD scanning won't trigger automatically with them out of the box. archcanary's post-install detection (all other checks) works with any AUR helper.
 
 <img src="images/llm.png" alt="LLM Settings dialog" width="400"/>
 
@@ -230,7 +231,7 @@ Two waves:
 
 ### Russian Spam Campaign (June 14, 2026)
 
-A separate campaign ([reported by Sid Karunaratne](https://lists.archlinux.org/archives/list/aur-general@lists.archlinux.org/message/2YQSHTC27MOKDDKHZTH2BJGTEN2CYC7W/)) in which 83 AUR package PKGBUILDs were modified to inject Russian-language spam `echo` statements into `~/.bashrc`, `~/.zshrc`, and other shell configs at install time. No credential theft or persistence — nuisance/propaganda payload. Reported to Arch DevOps; cleanup was in progress as of 2026-06-14.
+A separate campaign ([reported by Sid Karunaratne](https://lists.archlinux.org/archives/list/aur-general@lists.archlinux.org/message/2YQSHTC27MOKDDKHZTH2BJGTEN2CYC7W/)) in which 73 AUR package PKGBUILDs were modified to inject Russian-language spam `echo` statements into `~/.bashrc`, `~/.zshrc`, and other shell configs at install time. No credential theft or persistence — nuisance/propaganda payload. Reported to Arch DevOps; cleanup was in progress as of 2026-06-14.
 
 archcanary detects these via `malicious_russian_spam_packages.txt` (shown in the scan header alongside the JS campaign count).
 

--- a/archcanary-merge-lists.sh
+++ b/archcanary-merge-lists.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# custom_list_merge_aur_scan.sh — Fetch, merge, dedup, and scan
+# archcanary-merge-lists.sh — Fetch, merge, dedup, and scan
 #
 # Fetches the official HedgeDoc list (optional), merges with custom package
 # lists from URLs or files, deduplicates, and runs archcanary.sh.
@@ -8,10 +8,10 @@
 # the options separator to scan regardless of install date.
 #
 # Usage:
-#   ./custom_list_merge_aur_scan.sh -l ./historical_packages.txt
-#   ./custom_list_merge_aur_scan.sh -l https://paste.example.org/list.txt -l ./more.txt
-#   ./custom_list_merge_aur_scan.sh --skip-hedgedoc -l legacy.txt -- --all-time
-#   ./custom_list_merge_aur_scan.sh --skip-hedgedoc -l legacy.txt -- --all-time --verbose
+#   ./archcanary-merge-lists.sh -l ./historical_packages.txt
+#   ./archcanary-merge-lists.sh -l https://paste.example.org/list.txt -l ./more.txt
+#   ./archcanary-merge-lists.sh --skip-hedgedoc -l legacy.txt -- --all-time
+#   ./archcanary-merge-lists.sh --skip-hedgedoc -l legacy.txt -- --all-time --verbose
 #
 # Options:
 #   -l, --list=URL|FILE          Additional AUR package list (repeatable)

--- a/archcanary_py/README.md
+++ b/archcanary_py/README.md
@@ -1,6 +1,6 @@
 # archcanary_py — Python 3.14+ Archcanaryer
 
-Python-Äquivalent zu `archcanary.sh` + `custom_list_merge_aur_scan.sh`.
+Python-Äquivalent zu `archcanary.sh` + `archcanary-merge-lists.sh`.
 
 ## Quick Start (Äquivalente)
 
@@ -12,9 +12,9 @@ Python-Äquivalent zu `archcanary.sh` + `custom_list_merge_aur_scan.sh`.
 | `./archcanary.sh --check-bun-cache` | `python -m archcanary_py --check-bun-cache` |
 | `./archcanary.sh --refresh --full` | `python -m archcanary_py --refresh --full` |
 | `./archcanary.sh --package-list=FILE --malicious-npm-list=FILE` | `python -m archcanary_py --package-list=FILE --malicious-npm-list=FILE` |
-| `./custom_list_merge_aur_scan.sh -l FILE` | `python -m archcanary_py --merge -l FILE` |
-| `./custom_list_merge_aur_scan.sh -l URL1 -l FILE2 --skip-hedgedoc` | `python -m archcanary_py --merge -l URL1 -l FILE2 --skip-hedgedoc` |
-| `./custom_list_merge_aur_scan.sh -l FILE -- --all-time` | `python -m archcanary_py --merge -l FILE --all-time` |
+| `./archcanary-merge-lists.sh -l FILE` | `python -m archcanary_py --merge -l FILE` |
+| `./archcanary-merge-lists.sh -l URL1 -l FILE2 --skip-hedgedoc` | `python -m archcanary_py --merge -l URL1 -l FILE2 --skip-hedgedoc` |
+| `./archcanary-merge-lists.sh -l FILE -- --all-time` | `python -m archcanary_py --merge -l FILE --all-time` |
 | `--verbose` / `--debug` | identisch |
 | `--help` / `-h` | identisch |
 | `--log-file=PATH` | identisch |

--- a/configs/yay-init.lua
+++ b/configs/yay-init.lua
@@ -2,12 +2,14 @@
 --
 -- yay 13.0 Lua hooks for the AUR security stack.
 -- Seeded to ~/.config/yay/init.lua by install.sh if not already present.
--- These hooks run on every AUR install/upgrade alongside aurscan pre-checks.
+-- An offline backstop that runs on every AUR install/upgrade alongside the
+-- aurscan editor-gate (config.json editor=aurscan-gate + editmenu=true), which
+-- runs the Claude PKGBUILD scan transparently — no `alias yay=syay` needed.
 -- See docs/my-setup.md, "yay 13.0 integration".
 
 -- Options
 yay.opt.diff_menu   = true
-yay.opt.edit_menu   = true    -- prompt to review PKGBUILD before build
+yay.opt.edit_menu   = true    -- REQUIRED: makes yay invoke the editor-gate (aurscan-gate) per PKGBUILD
 yay.opt.clean_menu  = true
 yay.opt.clean_after = false
 yay.opt.sort_by     = "votes"

--- a/docs/my-setup.md
+++ b/docs/my-setup.md
@@ -12,8 +12,8 @@ Full overview of how this fork is deployed and how the pieces connect.
 | `archcanary` | [musqz/archcanary](https://github.com/musqz/archcanary) (started from [lenucksi/aur-malware-check](https://github.com/lenucksi/aur-malware-check)) | Main scanner — known-bad packages, pacman logs, systemd persistence (incl. drop-ins + timers), eBPF rootkit, npm/bun/yarn/pnpm cache, PKGBUILD obfuscation (incl. base64/eval/printf/varsplit), loaded-eBPF enumeration (`bpftool`), `ld.so.preload` injection, XDG autostart + shell RC persistence, kernel module / DKMS audit. Prints a per-check summary table at the end of every scan. |
 | `archcanary-gui` | [musqz/archcanary](https://github.com/musqz/archcanary) | yad GUI — grouped menu with per-session status column (✅/⚠/❌/?), polkit auth for root checks, streaming output window. `--no-gui` bypasses yad and runs a full scan in the terminal with the structured summary. |
 | `traur` | [AUR: traur](https://aur.archlinux.org/packages/traur) | Pre-install trust scanner — 279 signals across PKGBUILD static analysis (reverse shells, download-and-execute, obfuscation, exfiltration), maintainer behaviour (new account, orphan takeover, typosquatting), AUR metadata (votes, popularity, orphaned), and git history (major rewrites, checksum removal, source domain changes) |
-| `aurscan` | [musqz/aurscan](https://github.com/musqz/aurscan) (fork of [manticore-projects/aurscan](https://github.com/manticore-projects/aurscan)) | LLM-based PKGBUILD scanner using Claude. Run manually before installing (`aurscan <pkg>`) — reads the PKGBUILD with Claude (plus offline static rules) and only proceed to install on a CLEAN verdict. Requires the `claude` CLI (`@anthropic-ai/claude-code`) as its LLM backend |
-| `yay` 13.0 `init.lua` | `~/.config/yay/init.lua` | yay 13.0 Lua hooks — runs on every install/upgrade *after* aurscan clears it: upgrade-age warning (`UpgradeSelect`), offline malicious-pattern block (`AURPreInstall`), and AUR install logging (`PostInstall`) |
+| `aurscan` | [musqz/aurscan](https://github.com/musqz/aurscan) (fork of [manticore-projects/aurscan](https://github.com/manticore-projects/aurscan)) | LLM-based PKGBUILD scanner using Claude. Wired into yay as its **editor-gate** (`config.json` `editor=aurscan-gate` + `editmenu=true`): yay invokes it on each AUR PKGBUILD before building, so every `yay` build (and AUR dependency) is scanned transparently — a non-CLEAN verdict exits non-zero and aborts the build. Still runnable standalone (`aurscan <pkg>`). Requires the `claude` CLI (`@anthropic-ai/claude-code`) as its LLM backend |
+| `yay` 13.0 `init.lua` | `~/.config/yay/init.lua` | yay 13.0 Lua hooks — an independent offline layer that also runs on every build: upgrade-age warning (`UpgradeSelect`), malicious-pattern block (`AURPreInstall`), and AUR install logging (`PostInstall`) |
 | `yad` | official repos | GTK dialog toolkit used by `archcanary-gui` |
 | `polkit` / `pkexec` | official repos | Graphical privilege escalation for root-requiring checks (eBPF, kmod) in the GUI |
 | `libnotify` | official repos | Provides `notify-send` — the desktop notification on exit code 2 |
@@ -66,17 +66,20 @@ traur — two use cases:
     note: pre-install scan of a specific package requires the terminal —
           the GUI has no package name input
 
-pre-install (manual — run before each yay install/upgrade)
-    └── aurscan <pkg>  (or aurscan --update-check for pending upgrades)
-            ├── offline static rules  — known campaign signatures
-            ├── Claude LLM reads the PKGBUILD — novel / obfuscated patterns
-            └── on suspicious → blocks; on CLEAN → run yay normally
-                    └── yay 13.0 init.lua hooks (~/.config/yay/init.lua)
-                            ├── UpgradeSelect  — warn if PKGBUILD modified < 3 days ago
-                            ├── AURPreInstall  — abort on malicious patterns
-                            │                    (npm atomic-lockfile, bun js-digest,
-                            │                     curl|bash / wget|sh download-exec)
-                            └── PostInstall    — log AUR installs (name + version)
+yay install/upgrade  (yay -S <pkg>, yay -Syu, bare yay <term>)  — transparent, no alias
+    └── yay invokes its editor on each AUR PKGBUILD before building
+            ├── editor = aurscan-gate   (config.json editor= + editmenu=true)
+            │       └── aurscan-gate → aurscan-edit  (EDITOR/VISUAL cleared, gate-only)
+            │               ├── offline static rules — known campaign signatures
+            │               ├── Claude LLM reads the PKGBUILD — novel / obfuscated patterns
+            │               └── non-CLEAN → exit non-zero → yay aborts the build
+            │                              CLEAN → build proceeds (no manual editor opens)
+            └── yay 13.0 init.lua hooks (~/.config/yay/init.lua) — independent offline layer
+                    ├── UpgradeSelect  — warn if PKGBUILD modified < 3 days ago
+                    ├── AURPreInstall  — abort on malicious patterns
+                    │                    (npm atomic-lockfile, bun js-digest,
+                    │                     curl|bash / wget|sh download-exec)
+                    └── PostInstall    — log AUR installs (name + version)
 
 standalone aurscan (manual — audit without installing)
     ├── aurscan <pkg>            — scan a single package
@@ -149,14 +152,19 @@ triggers (timer + `.path` units) are in [systemd.md](systemd.md).
 ~/.local/bin/archcanary-gui          # yad GUI script
 
 ~/.config/archcanary/
-    ├── package_list.txt              # refreshed weekly via --refresh
-    └── malicious_npm_packages.txt    # static list, auto-seeded on first run
+    ├── package_list.txt                   # refreshed weekly via --refresh
+    ├── malicious_npm_packages.txt         # static lists, auto-seeded on first run
+    ├── chaos_rat_packages.txt
+    ├── malicious_russian_spam_packages.txt
+    └── extra_lists.conf                   # optional extra list subscriptions (paths/URLs)
 
 ~/.config/yay/
     ├── init.lua                      # Lua hooks (age warning, pattern block, install log) — new in yay 13.0
-    └── config.json                   # standard yay config — edit_menu on (aurscan is manual, not intercepting)
+    └── config.json                   # editor=~/.local/bin/aurscan-gate + editmenu=true (the editor-gate)
 
-/usr/local/bin/aurscan                # manual pre-install scanner
+~/.local/bin/aurscan-gate             # editor-gate wrapper: exec env -u EDITOR -u VISUAL aurscan-edit "$@"
+/usr/local/bin/aurscan                # aurscan binary (standalone scans + the gate backend)
+/usr/local/bin/aurscan-edit           # edit-hook entrypoint yay invokes per PKGBUILD
 ~/.local/bin/claude                   # LLM backend (curl -fsSL https://claude.ai/install.sh | bash)
 
 ~/.config/systemd/user/                   # installed by ./install.sh --system
@@ -171,6 +179,7 @@ triggers (timer + `.path` units) are in [systemd.md](systemd.md).
     ├── package_list.txt              # bundled lists, seeded so the root scan finds them
     ├── malicious_npm_packages.txt
     ├── chaos_rat_packages.txt
+    ├── malicious_russian_spam_packages.txt
     └── root-helper                   # pkexec target (validates flags, restores XDG env)
 /etc/archcanary/
     └── dkms_allowlist.conf           # the single DKMS allowlist (edit via GUI/sudoedit)
@@ -208,7 +217,17 @@ curl -fsSL https://claude.ai/install.sh | bash
 
 ## yay 13.0 integration
 
-yay 13.0 added a Lua config (`~/.config/yay/init.lua`) — seeded automatically to `~/.config/yay/init.lua` by `install.sh` if not already present (source: [`configs/yay-init.lua`](../configs/yay-init.lua)). Run `aurscan <pkg>` before installing — it reads the PKGBUILD with Claude and applies offline static rules, aborting on a suspicious verdict. Once cleared, `yay` runs normally and these hooks fire:
+aurscan is wired into yay transparently as yay's **editor-gate** — no `alias yay=syay`, `yay` runs normally. Two independent layers fire on every AUR build:
+
+**1. The editor-gate (aurscan / Claude).** `~/.config/yay/config.json` sets `editor` to `~/.local/bin/aurscan-gate` and `editmenu = true`. yay invokes its editor on each AUR PKGBUILD it is about to build (including AUR dependencies); `aurscan-gate` is a one-line wrapper —
+
+```bash
+exec env -u EDITOR -u VISUAL aurscan-edit "$@"
+```
+
+— that runs aurscan's edit-hook (`aurscan-edit`) with `EDITOR`/`VISUAL` cleared, so a CLEAN scan proceeds without dropping you into a manual editor and a non-CLEAN verdict exits non-zero, aborting the build. Because yay only invokes the editor for actual builds, non-build operations (`yay -Syu` with nothing to build, `-Ss`, `-Q`, `--version`) are untouched — this is why the old `syay` wrapper alias was dropped.
+
+**2. The yay 13.0 Lua hooks** (`~/.config/yay/init.lua`) — seeded by `install.sh` if not already present (source: [`configs/yay-init.lua`](../configs/yay-init.lua)). An offline backstop that runs alongside the editor-gate:
 
 | Hook | Event | What it does |
 |------|-------|--------------|
@@ -216,9 +235,9 @@ yay 13.0 added a Lua config (`~/.config/yay/init.lua`) — seeded automatically 
 | Pattern block | `AURPreInstall` | Aborts the build if the PKGBUILD matches a known-malicious pattern: `npm install atomic-lockfile` (Atomic Arch wave 1), `bun install js-digest` (wave 2), or `curl`/`wget` piped to `bash`/`sh` |
 | Install log | `PostInstall` | Logs every installed AUR package (name + version) via `yay.log.info` |
 
-Options set in `init.lua`: `diff_menu = true`, `clean_menu = true`, `sort_by = "votes"`, and **`edit_menu = true`** — keeping yay's edit prompt active since aurscan is now a manual pre-install step rather than an intercepting wrapper. `config.json` mirrors the rest of the options.
+Options set in `init.lua`: `diff_menu = true`, `clean_menu = true`, `sort_by = "votes"`, and **`edit_menu = true`** — `editmenu`/`edit_menu` being on is **required** for the editor-gate: it forces yay to invoke its editor (`aurscan-gate`) on each PKGBUILD, which is the interception point for the scan. `config.json` mirrors the rest of the options and sets `editor=aurscan-gate`.
 
-> The two layers are complementary: aurscan/Claude catches novel or obfuscated payloads; the Lua hooks are a fast offline backstop for known campaign signatures and stale-rewrite upgrades, and run even if the LLM call is unavailable.
+> The two layers are complementary: the editor-gate (aurscan/Claude) catches novel or obfuscated payloads; the Lua hooks are a fast offline backstop for known campaign signatures and stale-rewrite upgrades, and run even if the LLM call is unavailable.
 
 ## Known false positives
 
@@ -238,12 +257,25 @@ git clone https://github.com/musqz/archcanary.git ~/Github/archcanary
 sudo pacman -S libnotify bpf yad polkit
 yay -S traur
 
-# aurscan — GitHub only, no AUR package
+# aurscan — GitHub only, no AUR package (installs aurscan, aurscan-edit, syay)
 git clone https://github.com/musqz/aurscan.git ~/Github/aurscan
 cd ~/Github/aurscan && ./install.sh
 
 # claude CLI — LLM backend for aurscan
 curl -fsSL https://claude.ai/install.sh | bash
+
+# Wire aurscan into yay as the editor-gate (transparent auto-scan on every build).
+# The gate wrapper and config.json editor are NOT set by either installer — do it once:
+cat > ~/.local/bin/aurscan-gate <<'EOF'
+#!/usr/bin/env bash
+# yay editor-gate for aurscan (gate-only): a CLEAN scan does not open a manual
+# editor; a non-OK scan exits non-zero and yay aborts the build.
+exec env -u EDITOR -u VISUAL aurscan-edit "$@"
+EOF
+chmod +x ~/.local/bin/aurscan-gate
+# Then in ~/.config/yay/config.json set:
+#   "editor": "/home/<you>/.local/bin/aurscan-gate"
+#   "editmenu": true
 
 # 3. Run install script (installs to ~/.local/bin by default)
 #    Also seeds ~/.config/yay/init.lua if not already present

--- a/docs/my-setup.md
+++ b/docs/my-setup.md
@@ -11,7 +11,7 @@ Full overview of how this fork is deployed and how the pieces connect.
 |-----------|-----------------|---------|
 | `archcanary` | [musqz/archcanary](https://github.com/musqz/archcanary) (started from [lenucksi/aur-malware-check](https://github.com/lenucksi/aur-malware-check)) | Main scanner — known-bad packages, pacman logs, systemd persistence (incl. drop-ins + timers), eBPF rootkit, npm/bun/yarn/pnpm cache, PKGBUILD obfuscation (incl. base64/eval/printf/varsplit), loaded-eBPF enumeration (`bpftool`), `ld.so.preload` injection, XDG autostart + shell RC persistence, kernel module / DKMS audit. Prints a per-check summary table at the end of every scan. |
 | `archcanary-gui` | [musqz/archcanary](https://github.com/musqz/archcanary) | yad GUI — grouped menu with per-session status column (✅/⚠/❌/?), polkit auth for root checks, streaming output window. `--no-gui` bypasses yad and runs a full scan in the terminal with the structured summary. |
-| `traur` | [AUR: traur](https://aur.archlinux.org/packages/traur) | Pre-install trust scanner — 279 signals across PKGBUILD static analysis (reverse shells, download-and-execute, obfuscation, exfiltration), maintainer behaviour (new account, orphan takeover, typosquatting), AUR metadata (votes, popularity, orphaned), and git history (major rewrites, checksum removal, source domain changes) |
+| `traur` | [AUR: traur](https://aur.archlinux.org/packages/traur) | Trust scanner — 279 signals across PKGBUILD static analysis (reverse shells, download-and-execute, obfuscation, exfiltration), maintainer behaviour (new account, orphan takeover, typosquatting), AUR metadata (votes, popularity, orphaned), and git history (major rewrites, checksum removal, source domain changes). Runs **automatically as a pacman PreTransaction hook** (`/usr/share/libalpm/hooks/traur.hook` → `traur-hook`, `AbortOnFail`) on every install/upgrade — including repo packages — and is also runnable by hand (`traur scan <pkg>`) |
 | `aurscan` | [musqz/aurscan](https://github.com/musqz/aurscan) (fork of [manticore-projects/aurscan](https://github.com/manticore-projects/aurscan)) | LLM-based PKGBUILD scanner using Claude. Wired into yay as its **editor-gate** (`config.json` `editor=aurscan-gate` + `editmenu=true`): yay invokes it on each AUR PKGBUILD before building, so every `yay` build (and AUR dependency) is scanned transparently — a non-CLEAN verdict exits non-zero and aborts the build. Still runnable standalone (`aurscan <pkg>`). Requires the `claude` CLI (`@anthropic-ai/claude-code`) as its LLM backend |
 | `yay` 13.0 `init.lua` | `~/.config/yay/init.lua` | yay 13.0 Lua hooks — an independent offline layer that also runs on every build: upgrade-age warning (`UpgradeSelect`), malicious-pattern block (`AURPreInstall`), and AUR install logging (`PostInstall`) |
 | `yad` | official repos | GTK dialog toolkit used by `archcanary-gui` |
@@ -50,12 +50,17 @@ archcanary-gui (on-demand — desktop shortcut or app launcher)
             └── root checks (eBPF, bpftool, kmod) → pkexec → polkit auth → root-helper
                     └── streams output live, updates status on close
 
-traur — two use cases:
+traur — runs three ways:
+    ├── pacman PreTransaction hook (automatic — installed by the traur package)
+    │       └── /usr/share/libalpm/hooks/traur.hook → traur-hook   (AbortOnFail)
+    │               └── trust-scores every pacman install/upgrade (incl. repo pkgs);
+    │                   a failing score aborts the transaction before install
+    │
     ├── GUI "Trust scan (traur)"  → traur scan  (no args)
     │       └── bulk audit of ALL installed AUR packages
     │               └── useful as a periodic sweep alongside archcanary
     │
-    └── terminal: traur scan <pkg>  (before installing a specific package)
+    └── terminal: traur scan <pkg>  (manually vet a package before installing)
             └── 279 signals, 5 weighted categories
                     ├── Pkgbuild (0.45)   — static analysis: shells, download-exec, obfuscation, exfil, miners
                     ├── Behavioral (0.25) — maintainer: new account, batch creation, orphan takeover, typosquat

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -9,15 +9,17 @@ detection*.
 
 ```mermaid
 flowchart TD
-    subgraph PRE["1 · BEFORE install — manual"]
+    subgraph PRE["1 · BEFORE install — manual (optional)"]
         T["traur scan &lt;pkg&gt;<br/>279 heuristic signals"]
     end
 
-    subgraph AT["2 · AT install — automatic on every yay build"]
+    subgraph AT["2 · AT install — automatic"]
         U["yay -S pkg / yay -Syu / yay &lt;term&gt;"] --> GATE["aurscan editor-gate<br/>static rules + Claude LLM"]
-        GATE -->|non-CLEAN| AB["build aborted"]
+        GATE -->|non-CLEAN| AB["build / install aborted"]
         GATE -->|CLEAN| LUA["yay init.lua hooks<br/>age warn · pattern block · log"]
-        LUA --> OK["package installed"]
+        LUA --> TH["traur pacman hook<br/>trust score · AbortOnFail"]
+        TH -->|low trust| AB
+        TH -->|OK| OK["package installed"]
     end
 
     subgraph AFTER["3 · AFTER install / always — automatic, root"]
@@ -39,9 +41,10 @@ flowchart TD
 
 | Phase | Tool | Trigger | Automatic? | Catches |
 |-------|------|---------|:---------:|---------|
-| 1 · Before | `traur scan <pkg>` | You run it before installing | ✗ manual | Maintainer reputation, PKGBUILD heuristics (279 signals) |
+| 1 · Before (optional) | `traur scan <pkg>` | You run it before installing | ✗ manual | Maintainer reputation, PKGBUILD heuristics (279 signals) |
 | 2 · At install | `aurscan` editor-gate | Every `yay` build (transparent) | ✓ auto | Novel / obfuscated payloads — Claude reads each PKGBUILD before build |
 | 2 · At install | yay `init.lua` hooks | Every `yay` install/upgrade | ✓ | Known campaign signatures, stale-rewrite upgrades (offline) |
+| 2 · At install | `traur` pacman hook | Every pacman install/upgrade (incl. repo pkgs) | ✓ auto | Maintainer/metadata trust score; aborts the transaction on fail |
 | 3 · After / always | `archcanary` | systemd timer (weekly + boot) + `.path` (after each pacman tx) | ✓ root | Known-bad packages, systemd/eBPF/npm persistence, rootkit traces |
 | 4 · On detection | notifier → GUI | `last-scan.log` flips to INFECTED | ✓ | Surfaces a result; review is manual |
 
@@ -49,7 +52,7 @@ flowchart TD
 
 - **Nothing here removes malware.** Every layer *detects and reports* — remediation is left to you. See [Read-only by design](../README.md).
 - **Pre-install vs post-install.** Phases 1–2 try to stop a bad package before it lands; phase 3 catches anything already installed (or installed before the stack existed).
-- **Defence in depth.** `aurscan` (with Claude) catches novel/obfuscated payloads; the offline Lua hooks catch known campaign signatures and run even with no network; `traur` adds maintainer/metadata signals no static scan sees. None replaces the others.
+- **Defence in depth.** `aurscan` (with Claude) catches novel/obfuscated payloads; the offline Lua hooks catch known campaign signatures and run even with no network; `traur` (a pacman PreTransaction hook, also runnable by hand) adds maintainer/metadata trust signals no static scan sees and can abort the install. None replaces the others.
 
 ## Go deeper
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -13,10 +13,10 @@ flowchart TD
         T["traur scan &lt;pkg&gt;<br/>279 heuristic signals"]
     end
 
-    subgraph AT["2 · AT install — manual pre-check + automatic hooks"]
-        AS["aurscan &lt;pkg&gt;<br/>static rules + Claude LLM"] -->|suspicious| AB["build aborted"]
-        AS -->|CLEAN| U["yay -S pkg / yay -Syu"]
-        U --> LUA["yay init.lua hooks<br/>age warn · pattern block · log"]
+    subgraph AT["2 · AT install — automatic on every yay build"]
+        U["yay -S pkg / yay -Syu / yay &lt;term&gt;"] --> GATE["aurscan editor-gate<br/>static rules + Claude LLM"]
+        GATE -->|non-CLEAN| AB["build aborted"]
+        GATE -->|CLEAN| LUA["yay init.lua hooks<br/>age warn · pattern block · log"]
         LUA --> OK["package installed"]
     end
 
@@ -40,7 +40,7 @@ flowchart TD
 | Phase | Tool | Trigger | Automatic? | Catches |
 |-------|------|---------|:---------:|---------|
 | 1 · Before | `traur scan <pkg>` | You run it before installing | ✗ manual | Maintainer reputation, PKGBUILD heuristics (279 signals) |
-| 2 · Before build | `aurscan <pkg>` | You run it before installing | ✗ manual | Novel / obfuscated payloads — Claude reads the PKGBUILD |
+| 2 · At install | `aurscan` editor-gate | Every `yay` build (transparent) | ✓ auto | Novel / obfuscated payloads — Claude reads each PKGBUILD before build |
 | 2 · At install | yay `init.lua` hooks | Every `yay` install/upgrade | ✓ | Known campaign signatures, stale-rewrite upgrades (offline) |
 | 3 · After / always | `archcanary` | systemd timer (weekly + boot) + `.path` (after each pacman tx) | ✓ root | Known-bad packages, systemd/eBPF/npm persistence, rootkit traces |
 | 4 · On detection | notifier → GUI | `last-scan.log` flips to INFECTED | ✓ | Surfaces a result; review is manual |

--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -86,9 +86,15 @@ sudo systemctl enable --now archcanary.timer
 ```ini
 [Unit]
 Description=Watch for archcanary scan results
+# A transient trigger burst must never wedge the watcher into a permanent
+# 'failed' (start-limit-hit) state and silence detections.
+StartLimitIntervalSec=0
 
 [Path]
-PathModified=/var/lib/archcanary/last-scan.log
+# PathChanged (IN_CLOSE_WRITE) fires once when the writer closes the file, not
+# on every write. The scan streams last-scan.log line-by-line via tee, so
+# PathModified would fire dozens of times per scan and trip the start limit.
+PathChanged=/var/lib/archcanary/last-scan.log
 Unit=archcanary-notify.service
 
 [Install]
@@ -99,6 +105,9 @@ WantedBy=default.target
 ```ini
 [Unit]
 Description=Notify on archcanary malware detection
+# Don't rate-limit: the path unit may trigger this oneshot a few times around a
+# scan; a burst must not leave it stuck 'failed' (start-limit-hit).
+StartLimitIntervalSec=0
 
 [Service]
 Type=oneshot
@@ -111,7 +120,7 @@ systemctl --user daemon-reload
 systemctl --user enable --now archcanary-notify.path
 ```
 
-> The path unit fires whenever the root scan rewrites the result file; the service notifies only when a detection is present. Needs a notification daemon (`dunst`, `mako`, GNOME, KDE) and `libnotify`. To review/remediate, open **Archcanary** from your app launcher.
+> The path unit fires once when the root scan finishes writing the result file (it watches for file close, not every write); the service notifies only when a detection is present. Needs a notification daemon (`dunst`, `mako`, GNOME, KDE) and `libnotify`. To review/remediate, open **Archcanary** from your app launcher.
 
 ## 3. User-level scan (your session)
 


### PR DESCRIPTION
## What

Brings the docs in line with how the stack actually runs, and fixes stale references found along the way.

- **aurscan editor-gate** — documents the real integration (`config.json editor=aurscan-gate` + `editmenu=true`), which auto-scans every yay build transparently and replaced the dropped `alias yay=syay`. Updated README detection-layers diagram, overview mermaid + table, my-setup yay-integration section, and the `configs/yay-init.lua` comments.
- **traur pacman hook** — adds traur's ALPM PreTransaction hook (`traur.hook → traur-hook`, `AbortOnFail`, `Target=*`) as a fourth automatic layer; it trust-scores every install/upgrade (incl. repo pkgs) and can abort the transaction. Corrects the prior "manual-only" framing.
- **Stale-reference cleanup** — Russian-spam count 83→73, systemd notifier unit `PathModified`→`PathChanged` + `StartLimitIntervalSec` (matches the shipped unit), my-setup install-location lists, and merge-script name → `archcanary-merge-lists.sh`.

Docs-only (plus the yay-init.lua/merge-script comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)