### PR TITLE
fix: correct user service ExecStart path for --system install and skip /usr/local/bin in autostart check

### DIFF
--- a/archcanary.sh
+++ b/archcanary.sh
@@ -1567,6 +1567,10 @@ check_autostart() {
             exec_bin="${exec_bin//%h/$home_dir}"
             [[ "$exec_bin" == "$home_dir/.local/bin/"* ]] && continue
             [[ "$exec_bin" == "$home_dir/bin/"* ]] && continue
+            # /usr/local/ is the FHS-conventional prefix for manually-installed
+            # software; Arch's pacman never writes there, so unowned binaries in
+            # /usr/local/bin/ are expected and not a persistence signal.
+            [[ "$exec_bin" == "/usr/local/bin/"* ]] && continue
             if ! pacman -Qo "$exec_bin" &>/dev/null 2>&1; then
                 echo "  WARNING: user service with unowned ExecStart binary: $svc"
                 echo "    ExecStart=$exec_bin (not tracked by pacman)"

--- a/install.sh
+++ b/install.sh
@@ -281,6 +281,12 @@ EOF
        "$REPO_DIR"/systemd/user/archcanary-user.service \
        "$REPO_DIR"/systemd/user/archcanary-user.timer \
        "$USER_UNITS/"
+    # The source unit uses %h/.local/bin (user install default). For a system
+    # install the binary lands in $SYSTEM_BIN, so patch the installed copy.
+    if $SYSTEM; then
+        sed -i "s|%h/.local/bin/archcanary|$SYSTEM_BIN/archcanary|g" \
+            "$USER_UNITS/archcanary-user.service"
+    fi
     if systemctl --user daemon-reload 2>/dev/null; then
         systemctl --user enable --now archcanary-notify.path 2>/dev/null || true
         systemctl --user enable --now archcanary-user.timer 2>/dev/null || true


### PR DESCRIPTION
## Summary
- `install.sh`: `--system` install now patches the copied user service unit to use `/usr/local/bin/archcanary` instead of the hardcoded `%h/.local/bin/archcanary` — without this the user timer fires and immediately fails with `EXEC 203`
- `archcanary.sh`: `/usr/local/bin/` added to the autostart check skip list alongside `~/.local/bin/` and `~/bin/`; Arch's pacman never writes to `/usr/local/`, so unowned binaries there are expected locally-installed software, not a persistence signal

## Test plan
- [ ] Run `./install.sh --system`; confirm `~/.config/systemd/user/archcanary-user.service` contains `/usr/local/bin/archcanary` in ExecStart
- [ ] `systemctl --user start archcanary-user.service` succeeds (exit 0 / CLEAN)
- [ ] `archcanary-user.service` no longer flags itself as INFECTED

🤖 Generated with [Claude Code](https://claude.com/claude-code)