### PR TITLE
feat: Lynis security auditing integration

### DIFF
--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -89,6 +89,7 @@ LABELS=(
     "LLM settings (aurscan)"   # 14
     "Extra lists"               # 15
     "Lynis hardening report"   # 16
+    "Run Lynis audit"          # 17  root
 )
 
 FLAGS=(
@@ -109,6 +110,7 @@ FLAGS=(
     "__aurscan_settings__"
     "__extra_lists__"
     "--check-lynis --no-notify --no-summary"
+    "--run-lynis"
 )
 
 NEEDS_ROOT=(
@@ -116,6 +118,7 @@ NEEDS_ROOT=(
     true true true
     false false false false
     false
+    true
 )
 
 # Per-session status for each check index.
@@ -419,6 +422,16 @@ run_action() {
     local flags="${FLAGS[$idx]}"
     local needs_root="${NEEDS_ROOT[$idx]}"
 
+    if [[ "$idx" -eq 16 || "$idx" -eq 17 ]] && ! $HAS_LYNIS; then
+        yad --info \
+            --title="Lynis — Archcanary" \
+            --window-icon=security-high \
+            --text="<b>Lynis</b> is not installed.\n\nInstall from official repos:\n  <tt>sudo pacman -S lynis</tt>" \
+            --width=420 \
+            --button="OK:0" 2>/dev/null || true
+        return
+    fi
+
     if [[ "$flags" == "__dkms_edit__" ]]; then
         edit_allowlist
         return
@@ -586,12 +599,13 @@ build_list_args() {
 
     _sep "Root checks"
     for i in 9 10 11; do _row "$i" "🔐  ${LABELS[$i]}"; done
+    _row 17 "🔐  ${LABELS[17]}"
 
     _sep "Utilities"
     _row 12
     $HAS_TRAUR && _row 13
     $HAS_AURSCAN && _row 14
-    $HAS_LYNIS && _row 16
+    _row 16
     _row 15
 }
 

--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -62,6 +62,10 @@ AURSCAN="$(command -v aurscan 2>/dev/null || true)"
 HAS_AURSCAN=false
 [[ -n "$AURSCAN" ]] && HAS_AURSCAN=true
 
+LYNIS="$(command -v lynis 2>/dev/null || true)"
+HAS_LYNIS=false
+[[ -n "$LYNIS" ]] && HAS_LYNIS=true
+
 # True once the package list has been refreshed this session.
 # The first run of the full scan (idx 0) auto-adds --refresh and sets this.
 REFRESHED=false
@@ -84,6 +88,7 @@ LABELS=(
     "Trust scan (traur)"        # 13
     "LLM settings (aurscan)"   # 14
     "Extra lists"               # 15
+    "Lynis hardening report"   # 16
 )
 
 FLAGS=(
@@ -103,12 +108,14 @@ FLAGS=(
     "__traur__"
     "__aurscan_settings__"
     "__extra_lists__"
+    "--check-lynis --no-notify --no-summary"
 )
 
 NEEDS_ROOT=(
     true false false false false false false false false
     true true true
     false false false false
+    false
 )
 
 # Per-session status for each check index.
@@ -134,6 +141,7 @@ _update_status() {
 declare -A _SCAN_TAG=(
     [1]='3'  [2]='5'  [3]='6'  [4]='6b' [5]='6c'
     [6]='7'  [7]='9'  [8]='10' [9]='4'  [10]='8' [11]='11'
+    [16]='12'
 )
 
 # After a full scan (idx 0), set each check row from ITS OWN section in the
@@ -141,7 +149,7 @@ declare -A _SCAN_TAG=(
 # whole list. $1 = overall exit code (fallback), $2 = scan output file.
 _propagate_full_scan() {
     local code=$1 out="${2:-}" i tag block
-    for i in 1 2 3 4 5 6 7 8 9 10 11; do
+    for i in 1 2 3 4 5 6 7 8 9 10 11 16; do
         tag="${_SCAN_TAG[$i]:-}"
         block=""
         [[ -n "$out" && -r "$out" && -n "$tag" ]] && block=$(awk -v t="$tag" '
@@ -584,6 +592,7 @@ build_list_args() {
     $HAS_TRAUR && _row 13
     $HAS_AURSCAN && _row 14
     _row 15
+    $HAS_LYNIS && _row 16
 }
 
 # Main loop

--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -499,7 +499,11 @@ run_action() {
         exec 8>"$fifo"
         rm -f "$fifo"
 
-        printf 'Authenticate in the polkit dialog to continue...\n  After authenticating, please wait — the first scan fetches package lists from the network.\n\n' >&8 || true
+        if [[ "$idx" -eq 0 ]]; then
+            printf 'Authenticate in the polkit dialog to continue...\n  After authenticating, please wait — the first scan fetches package lists from the network.\n\n' >&8 || true
+        else
+            printf 'Authenticate in the polkit dialog to continue...\n\n' >&8 || true
+        fi
 
         # Let yad render and settle so the polkit dialog opens as the newest
         # (and thus focused) window — without this delay, yad may steal focus
@@ -526,6 +530,9 @@ run_action() {
         done
 
         printf '\n============================================================\n\n' >&8 2>/dev/null || true
+        if [[ "$idx" -eq 17 ]]; then
+            printf 'Running lynis audit system, please wait (1-2 minutes)...\n\n' >&8 || true
+        fi
 
         if [[ -n "$_xdotool_pid" ]]; then
             kill "$_xdotool_pid" 2>/dev/null || true

--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -591,8 +591,8 @@ build_list_args() {
     _row 12
     $HAS_TRAUR && _row 13
     $HAS_AURSCAN && _row 14
-    _row 15
     $HAS_LYNIS && _row 16
+    _row 15
 }
 
 # Main loop

--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -117,7 +117,7 @@ NEEDS_ROOT=(
     true false false false false false false false false
     true true true
     false false false false
-    false
+    true
     true
 )
 
@@ -612,7 +612,7 @@ build_list_args() {
     _row 12
     $HAS_TRAUR && _row 13
     $HAS_AURSCAN && _row 14
-    _row 16
+    _row 16 "🔐  ${LABELS[16]}"
     _row 15
 }
 

--- a/archcanary-root-helper
+++ b/archcanary-root-helper
@@ -22,7 +22,7 @@ if [[ -n "${PKEXEC_UID:-}" ]]; then
     fi
 fi
 
-ALLOWED_FLAGS=(--full --refresh --check-kmod --check-bpftool --check-ebpf --run-lynis --no-notify --no-summary)
+ALLOWED_FLAGS=(--full --refresh --check-kmod --check-bpftool --check-ebpf --check-lynis --run-lynis --no-notify --no-summary)
 
 for _arg in "$@"; do
     _ok=false

--- a/archcanary-root-helper
+++ b/archcanary-root-helper
@@ -22,7 +22,7 @@ if [[ -n "${PKEXEC_UID:-}" ]]; then
     fi
 fi
 
-ALLOWED_FLAGS=(--full --refresh --check-kmod --check-bpftool --check-ebpf --no-notify --no-summary)
+ALLOWED_FLAGS=(--full --refresh --check-kmod --check-bpftool --check-ebpf --run-lynis --no-notify --no-summary)
 
 for _arg in "$@"; do
     _ok=false

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -80,6 +80,7 @@ NO_NOTIFY=false
 NO_SUMMARY=false
 DOCTOR=false
 DOCTOR_SECTIONS=""
+RUN_LYNIS=false
 
 # CLI arg overrides for env-var-backed settings
 PACKAGE_LIST_FILE_OPT=""
@@ -122,6 +123,7 @@ for arg in "$@"; do
         --no-summary)            NO_SUMMARY=true ;;
         --doctor)                DOCTOR=true ;;
         --doctor=*)              DOCTOR=true; DOCTOR_SECTIONS="${arg#*=}" ;;
+        --run-lynis)             RUN_LYNIS=true ;;
         --help|-h)
             echo "Usage: $0 [OPTIONS]"
             echo "Options:"
@@ -479,6 +481,14 @@ run_doctor() {
 if $DOCTOR; then
     _doctor_rc=0; run_doctor || _doctor_rc=$?
     exit $_doctor_rc
+fi
+
+if $RUN_LYNIS; then
+    if ! command -v lynis &>/dev/null; then
+        echo "Error: lynis not installed (pacman -S lynis)" >&2
+        exit 1
+    fi
+    exec lynis audit system
 fi
 
 # ---------------------------------------------------------------------------

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -502,7 +502,7 @@ if $RUN_LYNIS; then
     # that yad text-info renders as [?] boxes. pipefail off so set -e doesn't
     # fire on lynis's own exit code before we can capture it.
     set +o pipefail
-    lynis audit system --no-colors 2>&1 | sed 's/[^\x09\x0A\x0D\x20-\x7E]//g'
+    lynis audit system --no-colors 2>&1 | sed 's/\x1b\[[0-9;]*[a-zA-Z]//g; s/[^\x09\x0A\x0D\x20-\x7E]//g'
     exit "${PIPESTATUS[0]}"
 fi
 

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -71,6 +71,7 @@ CHECK_BPFTOOL=false
 CHECK_LDSO=false
 CHECK_AUTOSTART=false
 CHECK_KMOD=false
+CHECK_LYNIS=false
 CHECK_FULL=false
 REFRESH_PACKAGE_LIST=false
 VERBOSE=false
@@ -105,7 +106,8 @@ for arg in "$@"; do
         --check-ldso)       CHECK_LDSO=true ;;
         --check-autostart)  CHECK_AUTOSTART=true ;;
         --check-kmod)       CHECK_KMOD=true ;;
-        --full)          CHECK_SYSTEMD=true; CHECK_EBPF=true; CHECK_NPM_CACHE=true; CHECK_BUN_CACHE=true; CHECK_YARN_CACHE=true; CHECK_PNPM_CACHE=true; CHECK_PKGBUILD=true; CHECK_BPFTOOL=true; CHECK_LDSO=true; CHECK_AUTOSTART=true; CHECK_KMOD=true; CHECK_FULL=true ;;
+        --check-lynis)      CHECK_LYNIS=true ;;
+        --full)          CHECK_SYSTEMD=true; CHECK_EBPF=true; CHECK_NPM_CACHE=true; CHECK_BUN_CACHE=true; CHECK_YARN_CACHE=true; CHECK_PNPM_CACHE=true; CHECK_PKGBUILD=true; CHECK_BPFTOOL=true; CHECK_LDSO=true; CHECK_AUTOSTART=true; CHECK_KMOD=true; CHECK_LYNIS=true; CHECK_FULL=true ;;
         --refresh)               REFRESH_PACKAGE_LIST=true ;;
         --verbose|-v)            VERBOSE=true ;;
         --debug)                 VERBOSE=true; set -x ;;
@@ -134,6 +136,7 @@ for arg in "$@"; do
             echo "  --check-ldso       Check /etc/ld.so.preload for shared library injection"
             echo "  --check-autostart  Scan XDG autostart entries and shell RCs for low-privilege persistence"
             echo "  --check-kmod       Audit loaded kernel modules against pacman-tracked files (needs root)"
+            echo "  --check-lynis      Parse Lynis hardening report (/var/log/lynis-report.dat)"
             echo "  --full             Enable all checks"
             echo "  --refresh          Download the latest package list before scanning"
             echo "  --verbose, -v, --debug    Verbose output (--debug also enables set -x)"
@@ -175,7 +178,7 @@ done
 FOCUSED_MODE=false
 if ! $CHECK_FULL && { $CHECK_SYSTEMD || $CHECK_EBPF || $CHECK_NPM_CACHE || \
     $CHECK_BUN_CACHE || $CHECK_YARN_CACHE || $CHECK_PNPM_CACHE || $CHECK_PKGBUILD || \
-    $CHECK_BPFTOOL || $CHECK_LDSO || $CHECK_AUTOSTART || $CHECK_KMOD; }; then
+    $CHECK_BPFTOOL || $CHECK_LDSO || $CHECK_AUTOSTART || $CHECK_KMOD || $CHECK_LYNIS; }; then
     FOCUSED_MODE=true
 fi
 
@@ -448,6 +451,7 @@ run_doctor() {
                 "$(command -v claude 2>/dev/null || echo 'not found — curl -fsSL https://claude.ai/install.sh | bash')"
         fi
         _opt_dep "traur (pre-install behavioral scanner)" traur traur "279-signal pre-install scanner"
+        _opt_dep "lynis (system hardening auditor)" lynis lynis "post-install hardening audit"
         _opt_item "yay hooks (auto-scan on yay install)" "$(_file "$HOME/.config/yay/init.lua")" "" "path: $HOME/.config/yay/init.lua"
         printf '\n'
     fi
@@ -1709,6 +1713,73 @@ check_kmod() {
 }
 
 # ---------------------------------------------------------------------------
+# Check 12: Lynis hardening report
+# Parses /var/log/lynis-report.dat (written by: sudo lynis audit system).
+# Reports the hardening index and warnings from the last Lynis run.
+# The report file is root-owned (600) — returns 77 if unreadable without root.
+# Override the report path with LYNIS_REPORT_FILE for testing.
+# ---------------------------------------------------------------------------
+check_lynis() {
+    local report_file="${LYNIS_REPORT_FILE:-/var/log/lynis-report.dat}"
+
+    if ! command -v lynis &>/dev/null; then
+        echo "  Skipped: lynis not installed (pacman -S lynis)."
+        return 0
+    fi
+
+    if [[ ! -f "$report_file" ]]; then
+        echo "  No Lynis report found at $report_file."
+        echo "  Generate one with: sudo lynis audit system"
+        return 1
+    fi
+
+    if [[ ! -r "$report_file" ]]; then
+        echo "  Cannot read $report_file — needs root."
+        echo "  → Try: sudo archcanary --check-lynis"
+        return 77
+    fi
+
+    local hardening_index scan_date
+    hardening_index=$(grep '^hardening_index=' "$report_file" | cut -d= -f2 | tr -d '[:space:]' || true)
+    scan_date=$(grep '^report_datetime_start=' "$report_file" | cut -d= -f2 | head -1 | cut -c1-10 || true)
+
+    local stale_warning=""
+    if [[ -n "$scan_date" ]]; then
+        local scan_epoch today_epoch days_ago
+        scan_epoch=$(date -d "$scan_date" +%s 2>/dev/null || true)
+        today_epoch=$(date +%s)
+        if [[ -n "$scan_epoch" && "$scan_epoch" -gt 0 ]]; then
+            days_ago=$(( (today_epoch - scan_epoch) / 86400 ))
+            if [[ $days_ago -gt 30 ]]; then
+                stale_warning=" (${days_ago} days old — consider re-running: sudo lynis audit system)"
+            fi
+        fi
+    fi
+
+    echo "  Last scan: ${scan_date:-unknown}${stale_warning}"
+    [[ -n "$hardening_index" ]] && echo "  Hardening index: $hardening_index / 100"
+
+    local warnings=()
+    while IFS= read -r line; do
+        local id desc
+        id=$(cut -d'|' -f1 <<< "$line")
+        desc=$(cut -d'|' -f2 <<< "$line")
+        warnings+=("$id  $desc")
+    done < <(grep '^warning\[\]=' "$report_file" | sed 's/^warning\[\]=//' || true)
+
+    if [[ ${#warnings[@]} -gt 0 ]]; then
+        echo "  Warnings (${#warnings[@]}):"
+        for w in "${warnings[@]}"; do
+            echo "    • $w"
+        done
+        return 1
+    fi
+
+    echo "  No warnings in last Lynis report."
+    return 0
+}
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 EXIT_CODE=0
@@ -1928,6 +1999,14 @@ if $CHECK_KMOD; then
     check_kmod && ret=$? || ret=$?
     _apply_ret "$ret" kmod
     _rec "Kernel modules (DKMS)" "$ret"
+    echo
+fi
+
+if $CHECK_LYNIS; then
+    echo "--- [12] Lynis hardening report ---"
+    check_lynis && ret=$? || ret=$?
+    _apply_ret "$ret" lynis
+    _rec "Lynis hardening" "$ret"
     echo
 fi
 

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -498,7 +498,12 @@ if $RUN_LYNIS; then
         echo
     fi
     unset _plugin_src _plugin_dst
-    exec lynis audit system --no-colors
+    # Can't use exec: pipe through sed to strip non-ASCII block chars (▆ etc.)
+    # that yad text-info renders as [?] boxes. pipefail off so set -e doesn't
+    # fire on lynis's own exit code before we can capture it.
+    set +o pipefail
+    lynis audit system --no-colors 2>&1 | sed 's/[^\x09\x0A\x0D\x20-\x7E]//g'
+    exit "${PIPESTATUS[0]}"
 fi
 
 # ---------------------------------------------------------------------------

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -488,7 +488,17 @@ if $RUN_LYNIS; then
         echo "Error: lynis not installed (pacman -S lynis)" >&2
         exit 1
     fi
-    exec lynis audit system
+    # Auto-install the archcanary Lynis plugin on first run (already root via pkexec).
+    # Ships as /usr/lib/archcanary/lynis-plugin-archcanary.sh; Lynis loads it on next audit.
+    _plugin_src="/usr/lib/archcanary/lynis-plugin-archcanary.sh"
+    _plugin_dst="/etc/lynis/plugins/plugin_archcanary_phase1.sh"
+    if [[ -f "$_plugin_src" && -d /etc/lynis/plugins && ! -f "$_plugin_dst" ]]; then
+        install -m 644 "$_plugin_src" "$_plugin_dst"
+        echo "Installed Lynis plugin: $_plugin_dst"
+        echo
+    fi
+    unset _plugin_src _plugin_dst
+    exec lynis audit system --no-colors
 fi
 
 # ---------------------------------------------------------------------------
@@ -1780,7 +1790,7 @@ check_lynis() {
     if [[ ${#warnings[@]} -gt 0 ]]; then
         echo "  Warnings (${#warnings[@]}):"
         for w in "${warnings[@]}"; do
-            echo "    • $w"
+            echo "    * $w"
         done
         return 1
     fi

--- a/configs/lynis-plugin-archcanary.sh
+++ b/configs/lynis-plugin-archcanary.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+#################################################################################
+#
+#   Lynis plugin — archcanary
+#   Registers archcanary as an AUR supply chain malware scanner.
+#
+#   Auto-installed by: archcanary --run-lynis (runs as root via pkexec)
+#   Source:            /usr/lib/archcanary/lynis-plugin-archcanary.sh
+#
+#################################################################################
+
+PLUGIN_AUTHOR="musqz"
+PLUGIN_CATEGORY="malware"
+PLUGIN_DATE="2026-06-22"
+PLUGIN_DESC="Detects archcanary AUR supply chain malware scanner"
+PLUGIN_NAME="archcanary"
+PLUGIN_REQUIRED_PROFILE="generic"
+PLUGIN_MINIMUM_VERSION="3.0.0"
+PLUGIN_VERSION="1.0"
+
+InsertSection "Archcanary (AUR supply chain scanner)"
+
+Register --test-no ARCH-0001 --weight L --network NO --category security \
+    --description "Check for archcanary AUR malware scanner"
+
+if command -v archcanary > /dev/null 2>&1; then
+    LogText "Result: archcanary found at $(command -v archcanary)"
+    Display --indent 2 --text "- Archcanary AUR scanner" --result FOUND --color GREEN
+    AddHP 3 3
+else
+    LogText "Result: archcanary not found"
+    Display --indent 2 --text "- Archcanary AUR scanner" --result "NOT FOUND" --color YELLOW
+    ReportSuggestion "ARCH-0001" "Install archcanary to detect compromised AUR packages" \
+        "https://github.com/musqz/archcanary" "-"
+    AddHP 0 3
+fi

--- a/install.sh
+++ b/install.sh
@@ -204,6 +204,8 @@ if $SYSTEM; then
     sudo cp "$REPO_DIR/archcanary-root-helper" "$SYSTEM_LIB/root-helper"
     sudo chown root:root "$SYSTEM_LIB/root-helper"
     sudo chmod 755 "$SYSTEM_LIB/root-helper"
+    sudo install -m 644 "$REPO_DIR/configs/lynis-plugin-archcanary.sh" \
+        "$SYSTEM_LIB/lynis-plugin-archcanary.sh"
     sudo cp "$REPO_DIR/org.archcanary.policy" /usr/share/polkit-1/actions/
     # Seed the bundled package lists next to the system script so a root scan
     # (system service) finds them — root's $HOME is /root, which is not seeded.
@@ -241,6 +243,7 @@ EOF
     fi
     echo "  installed: $SYSTEM_LIB/archcanary.sh"
     echo "  installed: $SYSTEM_LIB/root-helper"
+    echo "  installed: $SYSTEM_LIB/lynis-plugin-archcanary.sh (auto-installed to /etc/lynis/plugins on first Lynis run)"
     echo "  installed: $SYSTEM_LIB/{package_list,malicious_npm_packages,chaos_rat_packages,malicious_russian_spam_packages}.txt"
     echo "  installed: /etc/archcanary/dkms_allowlist.conf (system-wide DKMS allowlist for the root scan)"
     echo "  installed: /usr/share/polkit-1/actions/org.archcanary.policy"


### PR DESCRIPTION
## Summary

- Adds two GUI rows for Lynis: **Lynis hardening report** (row 16, reads `/var/log/lynis-report.dat`) and **Run Lynis audit** (row 17, executes `lynis audit system` via pkexec)
- Both rows always visible; clicking either prompts install if Lynis is missing
- Lynis plugin (`configs/lynis-plugin-archcanary.sh`) auto-installs to `/etc/lynis/plugins/` on first audit run — registers archcanary as a malware scanner, fixing the `HRDN-7230 [X]` finding without requiring user action
- `install.sh --system` ships the plugin to `/usr/lib/archcanary/` so it is available even before Lynis is installed

## Changes

- `archcanary.sh` — `check_lynis()` (section 12), `--check-lynis` and `--run-lynis` flags, plugin auto-install, ANSI/Unicode output filtering
- `archcanary-gui.sh` — rows 16/17, NEEDS_ROOT corrections, polkit message scoped per action, busy indicator for long audit run
- `archcanary-root-helper` — `--check-lynis` and `--run-lynis` added to allowlist
- `install.sh` — plugin file deployed to `/usr/lib/archcanary/`
- `configs/lynis-plugin-archcanary.sh` — new Lynis plugin (test ARCH-0001, +3 hardening points)

## Test plan

- [ ] GUI shows Lynis rows without Lynis installed → install prompt appears
- [ ] GUI shows Lynis rows with Lynis installed → both actions work via pkexec
- [ ] "Lynis hardening report" reads `/var/log/lynis-report.dat` and displays hardening index + warnings
- [ ] "Run Lynis audit" streams full audit output, no `[2C` ANSI noise or Unicode boxes
- [ ] On first "Run Lynis audit", plugin appears in `/etc/lynis/plugins/`; subsequent runs show `Plugins enabled: 1` and archcanary as `FOUND` under malware scanner
- [ ] `archcanary --full` as non-root marks lynis check as skipped (not WARNINGS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)