### PR TITLE
feat: auditd rules editor

### DIFF
--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -66,6 +66,9 @@ LYNIS="$(command -v lynis 2>/dev/null || true)"
 HAS_LYNIS=false
 [[ -n "$LYNIS" ]] && HAS_LYNIS=true
 
+HAS_AUDITD=false
+command -v auditctl &>/dev/null && HAS_AUDITD=true
+
 # True once the package list has been refreshed this session.
 # The first run of the full scan (idx 0) auto-adds --refresh and sets this.
 REFRESHED=false
@@ -90,6 +93,7 @@ LABELS=(
     "Extra lists"               # 15
     "Lynis hardening report"   # 16
     "Run Lynis audit"          # 17  root
+    "Edit audit rules"         # 18
 )
 
 FLAGS=(
@@ -111,6 +115,7 @@ FLAGS=(
     "__extra_lists__"
     "--check-lynis --no-notify --no-summary"
     "--run-lynis"
+    "__audit_rules_edit__"
 )
 
 NEEDS_ROOT=(
@@ -119,6 +124,7 @@ NEEDS_ROOT=(
     false false false false
     true
     true
+    false
 )
 
 # Per-session status for each check index.
@@ -129,6 +135,7 @@ STATUS[12]="   "  # Edit DKMS allowlist
 STATUS[13]="   "  # traur — opens its own output window, no verdict here
 STATUS[14]="   "  # aurscan settings — config dialog, no scan verdict
 STATUS[15]="   "  # extra lists — config dialog, no scan verdict
+STATUS[18]="   "  # Edit audit rules — config dialog, no scan verdict
 unset _i
 
 _update_status() {
@@ -209,6 +216,39 @@ edit_allowlist() {
         > "$tmpout" 2>/dev/null; then
         # Write back to /etc as root — pkexec prompts via the polkit agent.
         if [[ -z "$PKEXEC" ]] || ! "$PKEXEC" tee "$cfg" < "$tmpout" >/dev/null 2>&1; then
+            yad --error --title="Archcanary" --window-icon=security-high \
+                --text="Could not save <tt>$cfg</tt>\n(root authorization failed or cancelled)." \
+                --width=420 2>/dev/null || true
+        fi
+    fi
+    rm -f "$tmpout"
+}
+
+edit_audit_rules() {
+    local cfg="/etc/audit/rules.d/30-archcanary.conf"
+    if [[ ! -f "$cfg" ]]; then
+        yad --warning \
+            --title="Audit Rules — Archcanary" \
+            --window-icon=security-high \
+            --text="<b>$cfg</b> does not exist.\n\nRun <tt>./install.sh --system</tt> to create it." \
+            --width=440 2>/dev/null || true
+        return
+    fi
+    local tmpout
+    tmpout="$(mktemp /tmp/archcanary-XXXXXX.conf)"
+    if yad --text-info \
+        --title="Audit Rules — Archcanary" \
+        --window-icon=security-high \
+        --filename="$cfg" \
+        --width=700 --height=520 \
+        --fontname="Monospace 10" \
+        --editable \
+        --button="Save + restart auditd:0" \
+        --button="Cancel:1" \
+        > "$tmpout" 2>/dev/null; then
+        if [[ -n "$PKEXEC" ]] && "$PKEXEC" tee "$cfg" < "$tmpout" >/dev/null 2>&1; then
+            "$PKEXEC" systemctl restart auditd 2>/dev/null || true
+        else
             yad --error --title="Archcanary" --window-icon=security-high \
                 --text="Could not save <tt>$cfg</tt>\n(root authorization failed or cancelled)." \
                 --width=420 2>/dev/null || true
@@ -437,6 +477,11 @@ run_action() {
         return
     fi
 
+    if [[ "$flags" == "__audit_rules_edit__" ]]; then
+        edit_audit_rules
+        return
+    fi
+
     if [[ "$flags" == "__aurscan_settings__" ]]; then
         aurscan_settings
         return
@@ -613,6 +658,7 @@ build_list_args() {
     $HAS_TRAUR && _row 13
     $HAS_AURSCAN && _row 14
     _row 16 "🔐  ${LABELS[16]}"
+    $HAS_AUDITD && _row 18
     _row 15
 }
 

--- a/configs/audit-rules.conf
+++ b/configs/audit-rules.conf
@@ -1,0 +1,88 @@
+# Auditd rules — archcanary
+# Installed to /etc/audit/rules.d/30-archcanary.conf by ./install.sh --system
+# Edit via the archcanary GUI (Utilities → Edit audit rules) or directly as root.
+# Apply changes: sudo systemctl restart auditd
+#
+# Rule format:
+#   -w /path -p [r][w][x][a] -k keyname   (watch file/directory)
+#   -a always,exit -F arch=b64 -S syscall -k keyname   (syscall audit)
+# Search logs: sudo ausearch -k keyname | aureport -i
+
+# ---------------------------------------------------------------------------
+# Startup: delete prior rules and set buffer size
+# ---------------------------------------------------------------------------
+-D
+-b 8192
+-f 1
+
+# ---------------------------------------------------------------------------
+# Authentication and privilege escalation
+# ---------------------------------------------------------------------------
+
+# Privileged commands
+-a always,exit -F path=/usr/bin/sudo   -F perm=x -F auid>=1000 -F auid!=-1 -k priv_cmd
+-a always,exit -F path=/usr/bin/su     -F perm=x -F auid>=1000 -F auid!=-1 -k priv_cmd
+-a always,exit -F path=/usr/bin/pkexec -F perm=x -F auid>=1000 -F auid!=-1 -k priv_cmd
+-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=-1 -k priv_cmd
+
+# Login records
+-w /var/log/faillog  -p wa -k logins
+-w /var/log/lastlog  -p wa -k logins
+
+# Identity files
+-w /etc/passwd   -p wa -k identity
+-w /etc/shadow   -p wa -k identity
+-w /etc/group    -p wa -k identity
+-w /etc/gshadow  -p wa -k identity
+
+# Sudo configuration
+-w /etc/sudoers    -p wa -k sudoers
+-w /etc/sudoers.d/ -p wa -k sudoers
+
+# ---------------------------------------------------------------------------
+# Package management — Arch / AUR
+# ---------------------------------------------------------------------------
+
+# Pacman database writes (package install / remove / upgrade)
+-w /var/lib/pacman/local -p wa -k pacman
+
+# makepkg executions (AUR builds)
+-a always,exit -F arch=b64 -S execve -F path=/usr/bin/makepkg -k aur_build
+-a always,exit -F arch=b32 -S execve -F path=/usr/bin/makepkg -k aur_build
+
+# ---------------------------------------------------------------------------
+# Kernel modules
+# ---------------------------------------------------------------------------
+
+-w /usr/bin/kmod    -p x -k module_load
+-w /usr/sbin/insmod -p x -k module_load
+-w /usr/sbin/rmmod  -p x -k module_load
+-a always,exit -F arch=b64 -S init_module,finit_module,delete_module -k module_load
+
+# ---------------------------------------------------------------------------
+# System configuration changes
+# ---------------------------------------------------------------------------
+
+-w /etc/hosts      -p wa -k system_config
+-w /etc/hostname   -p wa -k system_config
+-w /etc/fstab      -p wa -k system_config
+-w /etc/os-release -p wa -k system_config
+
+# Cron (scheduled task tampering)
+-w /etc/crontab      -p wa -k cron
+-w /etc/cron.d/      -p wa -k cron
+-w /etc/cron.daily/  -p wa -k cron
+-w /etc/cron.weekly/ -p wa -k cron
+
+# Systemd units (watch for new/modified services)
+-w /etc/systemd/system/ -p wa -k systemd_units
+
+# SSH config (monitor even if sshd is disabled — detects re-enablement)
+-w /etc/ssh/sshd_config    -p wa -k sshd_config
+-w /etc/ssh/sshd_config.d/ -p wa -k sshd_config
+
+# ---------------------------------------------------------------------------
+# Optional: lock rules after loading (requires reboot to modify)
+# Uncomment only when rules are finalized.
+# ---------------------------------------------------------------------------
+# -e 2

--- a/install.sh
+++ b/install.sh
@@ -248,6 +248,19 @@ EOF
     echo "  installed: /etc/archcanary/dkms_allowlist.conf (system-wide DKMS allowlist for the root scan)"
     echo "  installed: /usr/share/polkit-1/actions/org.archcanary.policy"
 
+    # Seed auditd rules (only if auditd is installed and file not yet present)
+    if command -v auditctl &>/dev/null; then
+        sudo install -d -m 755 /etc/audit/rules.d
+        if [[ ! -f /etc/audit/rules.d/30-archcanary.conf ]]; then
+            sudo install -m 640 "$REPO_DIR/configs/audit-rules.conf" \
+                /etc/audit/rules.d/30-archcanary.conf
+            sudo systemctl restart auditd 2>/dev/null || true
+            echo "  installed: /etc/audit/rules.d/30-archcanary.conf (auditd rules — edit via GUI)"
+        else
+            echo "  kept:      /etc/audit/rules.d/30-archcanary.conf (already exists)"
+        fi
+    fi
+
     # --- Automated scan: root system units + user-session notifier ---------
     # Migrate away from the old user-scope scan units (superseded by the root
     # system scan; running --full as the user skips the root checks).


### PR DESCRIPTION
## Summary

- Adds an **Edit audit rules** row to the GUI Utilities section, visible only when `auditd` is installed
- Ships `configs/audit-rules.conf` — a default ruleset for Arch/AUR-focused monitoring (privilege escalation, pacman/makepkg, kernel modules, systemd units, cron, SSH config)
- `install.sh --system` seeds `/etc/audit/rules.d/30-archcanary.conf` on first install (never overwrites an existing file), then restarts auditd to apply
- GUI editor (`edit_audit_rules`) follows the same pattern as the DKMS allowlist editor: yad text-info with editable mode, saves via `pkexec tee`, restarts auditd after save

## Test plan

- [ ] Row absent when auditd not installed
- [ ] Row present after `pacman -S audit`
- [ ] `./install.sh --system` seeds `/etc/audit/rules.d/30-archcanary.conf` and restarts auditd
- [ ] Re-running install does not clobber an edited rules file
- [ ] GUI editor opens the file, edits save correctly and auditd restarts
- [ ] `sudo ausearch -k pacman` shows entries after a `pacman -Q` or install

🤖 Generated with [Claude Code](https://claude.com/claude-code)