### PR TITLE
fix: DBUS false-positive doctor warn + v0.1.7 docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.1.7 (2026-06-22)
+
+- New: **Lynis integration** — two GUI rows: *Lynis hardening report* reads the last `/var/log/lynis-report.dat` (hardening index, warnings, scan date); *Run Lynis audit* executes `lynis audit system` via pkexec and streams output.
+- New: **Lynis plugin** (`configs/lynis-plugin-archcanary.sh`) — registers archcanary as a malware scanner (test `ARCH-0001`, +3 hardening points). Auto-installed to `/etc/lynis/plugins/` on first audit run; shipped to `/usr/lib/archcanary/` by `install.sh --system`.
+- New: **auditd rules editor** — GUI row (Utilities → Edit audit rules) visible when auditd is installed. Ships a default ruleset covering privilege escalation, pacman/AUR builds, kernel modules, systemd units, cron, and SSH config. Editable in-GUI; saves via pkexec and restarts auditd.
+- New: `install.sh --system` seeds `/etc/audit/rules.d/30-archcanary.conf` from the bundled template when auditd is installed and the file has no rules.
+- Fix: Lynis output ANSI cursor-movement codes (`ESC[2C`, `ESC[30C`) stripped before display in yad — `--no-colors` suppresses color SGR sequences but not cursor movement.
+- Fix: non-ASCII Unicode block characters (`▆` etc.) stripped from Lynis output for yad text-info compatibility.
+- Fix: `NEEDS_ROOT[16]` corrected to `true` — `/var/log/lynis-report.dat` is always mode 600; the non-root designation caused spurious WARNINGS in every full scan.
+- Fix: `--check-lynis` added to root-helper allowlist.
+- Fix: polkit wait message scoped to idx 0 only — other root checks no longer show the network-fetch warning.
+- Fix: busy indicator added to Run Lynis audit output window.
+- Fix: `*` bullet used in `check_lynis` warnings list (replaces `•` for monospace font compatibility).
+
 ## v0.1.6 (2026-06-21)
 
 - Fix: the GUI root-scan (pkexec) output window now opens immediately when you

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ archcanary integrates with and builds on the following:
 | [bpftool](https://github.com/libbpf/bpftool) (pkg: `bpf`) | Enumerates all loaded eBPF programs for rootkit detection |
 | [libnotify](https://gitlab.gnome.org/GNOME/libnotify) | `notify-send` — desktop critical alert on infected scan result |
 | [polkit](https://gitlab.freedesktop.org/polkit/polkit) / pkexec | GUI privilege escalation for root-requiring checks |
+| [lynis](https://cisofy.com/lynis/) | Optional — system hardening auditor; archcanary reads the last report and can trigger a new audit from the GUI; a plugin registers archcanary as a malware scanner in Lynis |
+| [audit](https://people.redhat.com/sgrubb/audit/) / auditd | Optional — kernel audit daemon; archcanary ships a default ruleset covering AUR builds, privilege escalation, and system config changes; editable from the GUI |
 
 ### Detection Layers
 
@@ -156,6 +158,8 @@ Every scan prints a per-check summary before the final verdict:
 | `--check-ldso` | `/etc/ld.so.preload` injection + recent `/etc/ld.so.conf.d/` changes | No |
 | `--check-autostart` | `~/.config/autostart`, user systemd services, shell RC download-and-exec patterns | No |
 | `--check-kmod` | Kernel modules not owned by pacman; untracked DKMS builds | Yes |
+| `--check-lynis` | Read last Lynis report — hardening index, warnings, scan date | Yes |
+| `--run-lynis` | Run `lynis audit system`, stream output; auto-installs archcanary Lynis plugin on first run | Yes |
 | `--full` | All of the above | Partial |
 | `--all-time` | Skip the June 9-12 install-date window — scan all history | — |
 | `--refresh` | Fetch the live package list from the Arch Linux HedgeDoc | — |
@@ -187,7 +191,9 @@ Every scan prints a per-check summary before the final verdict:
 `--system` sets up:
 - Root system timer: weekly + on boot + after each pacman transaction
 - User notifier: watches `/var/lib/archcanary/last-scan.log`, fires a desktop alert on `INFECTED`
-- pkexec root helper for GUI-triggered root checks (eBPF, bpftool, kmod)
+- pkexec root helper for GUI-triggered root checks (eBPF, bpftool, kmod, Lynis)
+- Lynis plugin at `/usr/lib/archcanary/lynis-plugin-archcanary.sh` (auto-installed to `/etc/lynis/plugins/` on first GUI audit run)
+- auditd ruleset at `/etc/audit/rules.d/30-archcanary.conf` when auditd is installed (seeded from template, editable via GUI)
 
 See [docs/systemd.md](docs/systemd.md) for unit file details and [docs/my-setup.md](docs/my-setup.md) for the full personal stack and reinstall steps.
 

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -328,11 +328,19 @@ run_doctor() {
         else
             pfx="sudo "
         fi
-        if [[ $scope == user ]] && ! systemctl --user show-environment >/dev/null 2>&1; then
-            _warn "$label" \
-                "in a desktop session run: systemctl --user enable --now $unit" \
-                "scope: user — no session bus (e.g. over SSH/sudo); can't verify"
-            return 0
+        if [[ $scope == user ]]; then
+            # Some terminals (Openbox, launch-from-menu) don't inherit
+            # DBUS_SESSION_BUS_ADDRESS. Try the well-known socket before giving up.
+            if [[ -z "${DBUS_SESSION_BUS_ADDRESS:-}" ]]; then
+                local _xrd="/run/user/$(id -u 2>/dev/null || echo 0)"
+                [[ -S "$_xrd/bus" ]] && export DBUS_SESSION_BUS_ADDRESS="unix:path=$_xrd/bus"
+            fi
+            if ! systemctl --user show-environment >/dev/null 2>&1; then
+                _warn "$label" \
+                    "in a desktop session run: systemctl --user enable --now $unit" \
+                    "scope: user — no session bus (SSH/sudo context); can't verify"
+                return 0
+            fi
         fi
         local state active
         state="$($sctl is-enabled "$unit" 2>/dev/null || true)"


### PR DESCRIPTION
## Summary

Two commits from feat/audit-rules-editor that were dropped during the squash merge of #10:

- `fix: resolve user unit WARN false positive in Openbox terminals` — archcanary.sh: auto-detect DBUS socket at `/run/user/UID/bus` before reporting can't-verify; fixes persistent WARN for user units in Openbox terminals launched from menus
- `docs: update README and CHANGELOG for v0.1.7` — README Projects Used + Checks table entries for Lynis and auditd; full v0.1.7 CHANGELOG entry

## Test plan

- [ ] `archcanary --doctor` in an Openbox terminal shows OK for user units (no false WARN)
- [ ] README has Lynis and auditd in Projects Used and Checks table
- [ ] CHANGELOG has v0.1.7 entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)