### PR TITLE
fix: lynis hardening report — no status icon, full scan stays green

### DIFF
--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -139,11 +139,13 @@ STATUS[12]="   "  # Edit DKMS allowlist
 STATUS[13]="   "  # traur — opens its own output window, no verdict here
 STATUS[14]="   "  # aurscan settings — config dialog, no scan verdict
 STATUS[15]="   "  # extra lists — config dialog, no scan verdict
+STATUS[16]="   "  # Lynis hardening report — informational, no pass/fail verdict
 STATUS[18]="   "  # Edit audit rules — config dialog, no scan verdict
 unset _i
 
 _update_status() {
     local idx=$1 code=$2
+    [[ $idx -eq 16 ]] && return  # Lynis hardening report — informational, stays blank
     case $code in
         0) STATUS[$idx]=" ✅" ;;
         1) STATUS[$idx]=" ⚠ " ;;
@@ -163,7 +165,7 @@ declare -A _SCAN_TAG=(
 # whole list. $1 = overall exit code (fallback), $2 = scan output file.
 _propagate_full_scan() {
     local code=$1 out="${2:-}" i tag block
-    for i in 1 2 3 4 5 6 7 8 9 10 11 16; do
+    for i in 1 2 3 4 5 6 7 8 9 10 11; do
         tag="${_SCAN_TAG[$i]:-}"
         block=""
         [[ -n "$out" && -r "$out" && -n "$tag" ]] && block=$(awk -v t="$tag" '

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -1809,10 +1809,9 @@ check_lynis() {
         for w in "${warnings[@]}"; do
             echo "    * $w"
         done
-        return 1
+    else
+        echo "  No warnings in last Lynis report."
     fi
-
-    echo "  No warnings in last Lynis report."
     return 0
 }
 


### PR DESCRIPTION
## Summary

- `check_lynis` now always returns 0: hardening suggestions from Lynis are informational, not security threats. Warnings are shown in the output window but no longer degrade the full scan exit code.
- GUI row 16 (Lynis hardening report) treated like dialog rows — status stays blank, lock icon in label is sufficient. Removed from `_update_status` and `_propagate_full_scan`.

## Result

- Full scan shows ✅ when all security checks pass, even if Lynis has hardening suggestions
- Lynis hardening report row shows only the 🔐 lock icon, no status triangle

🤖 Generated with [Claude Code](https://claude.com/claude-code)