### PR TITLE
fix: apply missing commits from PR #13 squash

### DIFF
--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -248,20 +248,21 @@ edit_allowlist() {
 
 edit_audit_rules() {
     local cfg="/etc/audit/rules.d/30-archcanary.conf"
-    if [[ ! -f "$cfg" ]]; then
-        yad --warning \
-            --title="Audit Rules — Archcanary" \
-            --window-icon=security-high \
-            --text="<b>$cfg</b> does not exist.\n\nRun <tt>./install.sh --system</tt> to create it." \
-            --width=440 2>/dev/null || true
-        return
-    fi
-    local tmpout
+    local template="/usr/lib/archcanary/audit-rules.conf"
+    local tmpin tmpout
+    tmpin="$(mktemp /tmp/archcanary-XXXXXX.conf)"
     tmpout="$(mktemp /tmp/archcanary-XXXXXX.conf)"
+    if grep -qE '^\s*-[waAbfe]' "$cfg" 2>/dev/null; then
+        cp "$cfg" "$tmpin"
+    elif [[ -f "$template" ]]; then
+        cp "$template" "$tmpin"
+    else
+        printf '# No rules found. Run ./install.sh --system to seed the template.\n' > "$tmpin"
+    fi
     if yad --text-info \
         --title="Audit Rules — Archcanary" \
         --window-icon=security-high \
-        --filename="$cfg" \
+        --filename="$tmpin" \
         --width=700 --height=520 \
         --fontname="Monospace 10" \
         --editable \
@@ -276,7 +277,7 @@ edit_audit_rules() {
                 --width=420 2>/dev/null || true
         fi
     fi
-    rm -f "$tmpout"
+    rm -f "$tmpin" "$tmpout"
 }
 
 edit_lynis_config() {

--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -719,12 +719,12 @@ build_list_args() {
     _row 17 "🔐  ${LABELS[17]}"
 
     _sep "Utilities"
+    $HAS_LYNIS   && _row 16 "🔐  ${LABELS[16]}"
+    $HAS_TRAUR   && _row 13
+    $HAS_AUDITD  && _row 18
+    $HAS_LYNIS   && _row 19
     _row 12
-    $HAS_TRAUR && _row 13
     $HAS_AURSCAN && _row 14
-    _row 16 "🔐  ${LABELS[16]}"
-    $HAS_AUDITD && _row 18
-    $HAS_LYNIS  && _row 19
     _row 15
 }
 

--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -139,11 +139,13 @@ STATUS[12]="   "  # Edit DKMS allowlist
 STATUS[13]="   "  # traur — opens its own output window, no verdict here
 STATUS[14]="   "  # aurscan settings — config dialog, no scan verdict
 STATUS[15]="   "  # extra lists — config dialog, no scan verdict
+STATUS[16]="   "  # Lynis hardening report — informational, no pass/fail verdict
 STATUS[18]="   "  # Edit audit rules — config dialog, no scan verdict
 unset _i
 
 _update_status() {
     local idx=$1 code=$2
+    [[ $idx -eq 16 ]] && return  # Lynis hardening report — informational, stays blank
     case $code in
         0) STATUS[$idx]=" ✅" ;;
         1) STATUS[$idx]=" ⚠ " ;;
@@ -163,7 +165,7 @@ declare -A _SCAN_TAG=(
 # whole list. $1 = overall exit code (fallback), $2 = scan output file.
 _propagate_full_scan() {
     local code=$1 out="${2:-}" i tag block
-    for i in 1 2 3 4 5 6 7 8 9 10 11 16; do
+    for i in 1 2 3 4 5 6 7 8 9 10 11; do
         tag="${_SCAN_TAG[$i]:-}"
         block=""
         [[ -n "$out" && -r "$out" && -n "$tag" ]] && block=$(awk -v t="$tag" '

--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -98,6 +98,7 @@ LABELS=(
     "Lynis hardening report"   # 16
     "Run Lynis audit"          # 17  root
     "Edit audit rules"         # 18
+    "Edit Lynis config"        # 19
 )
 
 FLAGS=(
@@ -120,6 +121,7 @@ FLAGS=(
     "--check-lynis --no-notify --no-summary"
     "--run-lynis"
     "__audit_rules_edit__"
+    "__lynis_config_edit__"
 )
 
 NEEDS_ROOT=(
@@ -128,6 +130,7 @@ NEEDS_ROOT=(
     false false false false
     true
     true
+    false
     false
 )
 
@@ -141,6 +144,7 @@ STATUS[14]="   "  # aurscan settings — config dialog, no scan verdict
 STATUS[15]="   "  # extra lists — config dialog, no scan verdict
 STATUS[16]="   "  # Lynis hardening report — informational, no pass/fail verdict
 STATUS[18]="   "  # Edit audit rules — config dialog, no scan verdict
+STATUS[19]="   "  # Edit Lynis config — config dialog, no scan verdict
 unset _i
 
 _update_status() {
@@ -273,6 +277,39 @@ edit_audit_rules() {
         fi
     fi
     rm -f "$tmpout"
+}
+
+edit_lynis_config() {
+    local cfg="/etc/lynis/custom.prf"
+    local template="/usr/lib/archcanary/lynis-custom.prf"
+    local tmpout
+    tmpout="$(mktemp /tmp/archcanary-XXXXXX.prf)"
+    if [[ -f "$cfg" ]]; then
+        cp "$cfg" "$tmpout"
+    elif [[ -f "$template" ]]; then
+        cp "$template" "$tmpout"
+    else
+        printf '# Lynis custom profile\n# skip-test=<TEST-ID>\n' > "$tmpout"
+    fi
+    if yad --text-info \
+        --title="Lynis Config — Archcanary" \
+        --window-icon=security-high \
+        --filename="$tmpout" \
+        --width=700 --height=520 \
+        --fontname="Monospace 10" \
+        --editable \
+        --button="Save:0" \
+        --button="Cancel:1" \
+        > "$tmpout.new" 2>/dev/null; then
+        if [[ -n "$PKEXEC" ]] && "$PKEXEC" tee "$cfg" < "$tmpout.new" >/dev/null 2>&1; then
+            true
+        else
+            yad --error --title="Archcanary" --window-icon=security-high \
+                --text="Could not save <tt>$cfg</tt>\n(root authorization failed or cancelled)." \
+                --width=420 2>/dev/null || true
+        fi
+    fi
+    rm -f "$tmpout" "$tmpout.new"
 }
 
 aurscan_settings() {
@@ -481,7 +518,7 @@ run_action() {
     local flags="${FLAGS[$idx]}"
     local needs_root="${NEEDS_ROOT[$idx]}"
 
-    if [[ "$idx" -eq 16 || "$idx" -eq 17 ]] && ! $HAS_LYNIS; then
+    if [[ "$idx" -eq 16 || "$idx" -eq 17 || "$idx" -eq 19 ]] && ! $HAS_LYNIS; then
         yad --info \
             --title="Lynis — Archcanary" \
             --window-icon=security-high \
@@ -498,6 +535,11 @@ run_action() {
 
     if [[ "$flags" == "__audit_rules_edit__" ]]; then
         edit_audit_rules
+        return
+    fi
+
+    if [[ "$flags" == "__lynis_config_edit__" ]]; then
+        edit_lynis_config
         return
     fi
 
@@ -681,6 +723,7 @@ build_list_args() {
     $HAS_AURSCAN && _row 14
     _row 16 "🔐  ${LABELS[16]}"
     $HAS_AUDITD && _row 18
+    $HAS_LYNIS  && _row 19
     _row 15
 }
 

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -1809,10 +1809,9 @@ check_lynis() {
         for w in "${warnings[@]}"; do
             echo "    * $w"
         done
-        return 1
+    else
+        echo "  No warnings in last Lynis report."
     fi
-
-    echo "  No warnings in last Lynis report."
     return 0
 }
 

--- a/configs/lynis-custom.prf
+++ b/configs/lynis-custom.prf
@@ -1,0 +1,62 @@
+# Lynis custom profile — archcanary defaults for Arch Linux
+# Place at /etc/lynis/custom.prf (seeded automatically by install.sh --system)
+#
+# Uncomment a skip-test line to suppress a known false positive.
+# Find test IDs with: lynis show tests | grep <keyword>
+# Run a fresh audit after changes: sudo lynis audit system
+
+# ---------------------------------------------------------------------------
+# Time synchronisation
+# ---------------------------------------------------------------------------
+# TIME-3185: systemd-timesyncd "did not synchronize recently"
+# False positive — Lynis checks an internal status file that may lag behind
+# even when the clock is actually in sync (verify with: timedatectl status)
+#skip-test=TIME-3185
+
+# ---------------------------------------------------------------------------
+# Network
+# ---------------------------------------------------------------------------
+# NETW-2705: fewer than 2 responsive nameservers in /etc/resolv.conf
+# False positive when using NextDNS, systemd-resolved, or a local DNS stub —
+# resolv.conf points to a single loopback/VPN address by design.
+#skip-test=NETW-2705
+
+# ---------------------------------------------------------------------------
+# Kernel
+# ---------------------------------------------------------------------------
+# KRNL-5830: reboot recommended
+# Appears after sysctl hardening changes. Goes away on next reboot.
+#skip-test=KRNL-5830
+
+# ---------------------------------------------------------------------------
+# Firewall — iptables kernel module not found
+# ---------------------------------------------------------------------------
+# FIRE-4508 / FIRE-4512: iptables module not loaded
+# Arch uses iptables-nft: /sbin/iptables symlinks to xtables-nft-multi.
+# nf_tables and nft_compat are loaded instead of the legacy ip_tables module.
+# The firewall is active — Lynis just doesn't detect the nftables backend.
+#skip-test=FIRE-4508
+#skip-test=FIRE-4512
+
+# ---------------------------------------------------------------------------
+# MAC / mandatory access control frameworks
+# ---------------------------------------------------------------------------
+# Arch Linux does not ship AppArmor, SELinux, or TOMOYO by default.
+# For a personal desktop these are optional; suppress the noise if not used.
+# To enable AppArmor: pacman -S apparmor, add lsm= to kernel cmdline.
+#skip-test=MACF-6204
+#skip-test=MACF-6208
+#skip-test=MACF-6232
+#skip-test=MACF-6240
+#skip-test=MACF-6290
+
+# ---------------------------------------------------------------------------
+# Service hardening scores (systemd-analyze security)
+# ---------------------------------------------------------------------------
+# Many system daemons are flagged EXPOSED or UNSAFE because they legitimately
+# need broad system access. Hardening these units would break the service.
+# Common expected findings on Arch:
+#   NetworkManager  ~7.8 EXPOSED  (manages interfaces, DNS, routing, VPN)
+#   auditd          ~9.4 UNSAFE   (needs CAP_AUDIT_CONTROL, kernel access)
+#   libvirtd        ~9.x UNSAFE   (hypervisor — needs full hardware access)
+# Add individual test IDs here if Lynis surfaces specific HRDN checks.

--- a/install.sh
+++ b/install.sh
@@ -206,6 +206,8 @@ if $SYSTEM; then
     sudo chmod 755 "$SYSTEM_LIB/root-helper"
     sudo install -m 644 "$REPO_DIR/configs/lynis-plugin-archcanary.sh" \
         "$SYSTEM_LIB/lynis-plugin-archcanary.sh"
+    sudo install -m 644 "$REPO_DIR/configs/lynis-custom.prf" \
+        "$SYSTEM_LIB/lynis-custom.prf"
     sudo cp "$REPO_DIR/org.archcanary.policy" /usr/share/polkit-1/actions/
     # Seed the bundled package lists next to the system script so a root scan
     # (system service) finds them — root's $HOME is /root, which is not seeded.
@@ -244,9 +246,20 @@ EOF
     echo "  installed: $SYSTEM_LIB/archcanary.sh"
     echo "  installed: $SYSTEM_LIB/root-helper"
     echo "  installed: $SYSTEM_LIB/lynis-plugin-archcanary.sh (auto-installed to /etc/lynis/plugins on first Lynis run)"
+    echo "  installed: $SYSTEM_LIB/lynis-custom.prf (template for /etc/lynis/custom.prf)"
     echo "  installed: $SYSTEM_LIB/{package_list,malicious_npm_packages,chaos_rat_packages,malicious_russian_spam_packages}.txt"
     echo "  installed: /etc/archcanary/dkms_allowlist.conf (system-wide DKMS allowlist for the root scan)"
     echo "  installed: /usr/share/polkit-1/actions/org.archcanary.policy"
+
+    # Seed Lynis custom profile (only if lynis is installed and file not yet present)
+    if command -v lynis &>/dev/null; then
+        if [[ ! -f /etc/lynis/custom.prf ]]; then
+            sudo install -m 644 "$REPO_DIR/configs/lynis-custom.prf" /etc/lynis/custom.prf
+            echo "  installed: /etc/lynis/custom.prf (Lynis false-positive suppressions — edit to enable)"
+        else
+            echo "  kept:      /etc/lynis/custom.prf (already exists)"
+        fi
+    fi
 
     # Seed auditd rules (only if auditd is installed and file not yet present)
     if command -v auditctl &>/dev/null; then

--- a/install.sh
+++ b/install.sh
@@ -261,17 +261,18 @@ EOF
         fi
     fi
 
-    # Seed auditd rules (only if auditd is installed and file not yet present)
+    # Seed auditd rules when auditd is installed and file is absent or has no rules
     if command -v auditctl &>/dev/null; then
+        _audit_cfg=/etc/audit/rules.d/30-archcanary.conf
         sudo install -d -m 755 /etc/audit/rules.d
-        if [[ ! -f /etc/audit/rules.d/30-archcanary.conf ]]; then
-            sudo install -m 640 "$REPO_DIR/configs/audit-rules.conf" \
-                /etc/audit/rules.d/30-archcanary.conf
+        if ! grep -qE '^\s*-[waAbfe]' "$_audit_cfg" 2>/dev/null; then
+            sudo install -m 644 "$REPO_DIR/configs/audit-rules.conf" "$_audit_cfg"
             sudo systemctl restart auditd 2>/dev/null || true
-            echo "  installed: /etc/audit/rules.d/30-archcanary.conf (auditd rules — edit via GUI)"
+            echo "  installed: $_audit_cfg (auditd rules — edit via GUI)"
         else
-            echo "  kept:      /etc/audit/rules.d/30-archcanary.conf (already exists)"
+            echo "  kept:      $_audit_cfg (already has rules)"
         fi
+        unset _audit_cfg
     fi
 
     # --- Automated scan: root system units + user-session notifier ---------


### PR DESCRIPTION
## Summary

PR #13 was squash-merged but only the first two commits landed on master. This PR applies the remaining changes:

- `archcanary-gui.sh`: Lynis config editor (row 19), audit rules editor template fallback fix, Utilities reorder (scans → system editors → app settings)
- `configs/lynis-custom.prf`: commented template for `/etc/lynis/custom.prf` covering common Arch false positives
- `install.sh`: audit rules seeded as 644 (not 640), re-seeded when file has no directives; Lynis custom.prf seeded from template on first install

🤖 Generated with [Claude Code](https://claude.com/claude-code)