### PR TITLE
fix: extend PATH with real user bin dirs in doctor under sudo

### DIFF
--- a/archcanary.sh
+++ b/archcanary.sh
@@ -203,6 +203,9 @@ run_doctor() {
     real_user="${SUDO_USER:-$USER}"
     real_home="$(getent passwd "$real_user" | cut -d: -f6)"
     [[ -z "$real_home" ]] && real_home="$HOME"
+    # Extend PATH with the real user's bin dirs so command -v finds their tools
+    # even when running under sudo (root's PATH omits ~/.local/bin).
+    export PATH="$real_home/.local/bin:$real_home/bin:$PATH"
     cfg_dir="${XDG_CONFIG_HOME:-$real_home/.config}/archcanary"
     user_bin="$real_home/.local/bin"
     user_sd="${XDG_CONFIG_HOME:-$real_home/.config}/systemd/user"


### PR DESCRIPTION
## Summary

- Prepends `$real_home/.local/bin` and `$real_home/bin` to PATH at the start of `run_doctor`
- `command -v` in `_dep`/`_opt_dep` now finds user-installed tools (claude, aurscan, traur) when running `sudo archcanary --doctor`

## Test plan

- [ ] `sudo archcanary --doctor` → Pre-install section shows `[ OK ]` for all installed tools, no spurious `[OPT ]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)