### PR TITLE
docs: fix stale refs after GUI layout change

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ See [docs/systemd.md](docs/systemd.md) for unit file details and [docs/my-setup.
 
 ## LLM Settings (aurscan)
 
-[aurscan](https://github.com/musqz/aurscan) scans PKGBUILDs with an LLM before `yay` or `paru` builds them. The GUI exposes its backend configuration under **Utilities → LLM settings**.
+[aurscan](https://github.com/musqz/aurscan) scans PKGBUILDs with an LLM before `yay` or `paru` builds them. The GUI exposes its backend configuration under **Settings → LLM settings**.
 
 > **AUR helper compatibility:** aurscan integrates natively with both **yay** and **paru** — one-time setup, no wrapper alias needed. yay uses its Lua editor-gate (`aurscan --install-yay-hook`); paru uses its native `PreBuildCommand` config key (`aurscan --install-paru-hook`), which paru invokes in the PKGBUILD directory before every build. Other helpers (pikaur, aurutils) have no equivalent hook yet. archcanary's post-install detection (all other checks) works with any AUR helper.
 

--- a/docs/my-setup.md
+++ b/docs/my-setup.md
@@ -125,7 +125,6 @@ sudo ~/.local/bin/archcanary --check-kmod
 # Full scan without the GUI — terminal output with structured summary table.
 # Extra flags pass through (e.g. --refresh).
 archcanary-gui --no-gui
-archcanary-gui --no-gui
 
 # Setup health check — is every element installed and configured? (no root,
 # no scan; auto-detects distro/AUR helpers and prints a fix command per gap).


### PR DESCRIPTION
- README: `Utilities → LLM settings` → `Settings → LLM settings`
- docs/my-setup.md: remove duplicated `archcanary-gui --no-gui` line