### PR TITLE
refactor: remove --all-time from archcanary_py and merge-lists script

### DIFF
--- a/archcanary-merge-lists.sh
+++ b/archcanary-merge-lists.sh
@@ -4,14 +4,10 @@
 #
 # Fetches the official HedgeDoc list (optional), merges with custom package
 # lists from URLs or files, deduplicates, and runs archcanary.sh.
-# By default the campaign date window applies.  Pass -- --all-time after
-# the options separator to scan regardless of install date.
-#
 # Usage:
 #   ./archcanary-merge-lists.sh -l ./historical_packages.txt
 #   ./archcanary-merge-lists.sh -l https://paste.example.org/list.txt -l ./more.txt
-#   ./archcanary-merge-lists.sh --skip-hedgedoc -l legacy.txt -- --all-time
-#   ./archcanary-merge-lists.sh --skip-hedgedoc -l legacy.txt -- --all-time --verbose
+#   ./archcanary-merge-lists.sh --skip-hedgedoc -l legacy.txt -- --verbose
 #
 # Options:
 #   -l, --list=URL|FILE          Additional AUR package list (repeatable)
@@ -24,8 +20,8 @@
 #
 #   --    Separator — all following arguments are passed through to
 #         archcanary.sh unchanged.
-#         Useful flags: --all-time (disable date window), --verbose,
-#         --check-systemd, --check-npm-cache, --check-bun-cache, --full.
+#         Useful flags: --verbose, --check-systemd, --check-npm-cache,
+#         --check-bun-cache, --full.
 
 set -euo pipefail
 

--- a/archcanary_py/__main__.py
+++ b/archcanary_py/__main__.py
@@ -70,9 +70,6 @@ def create_parser() -> argparse.ArgumentParser:
         help='Custom infected AUR package list (default: ./package_list.txt)')
     parser.add_argument('--malicious-npm-list', type=str, default=None,
         help='Custom malicious npm package name list (default: ./malicious_npm_packages.txt)')
-    parser.add_argument('--all-time', action='store_true',
-        help='Disable recency window -- flag any installed infected package regardless of install date')
-
     # Merge mode options
     parser.add_argument('--merge', action='store_true',
         help='Enable merge mode (use merger.py logic)')
@@ -87,14 +84,10 @@ def create_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def print_banner(infected_count: int, start_date: str, end_date: str, all_time: bool) -> None:
+def print_banner(infected_count: int) -> None:
     print('============================================================')
     print(f' Archcanary v{SCRIPT_VERSION}')
     print(' Campaign: malicious npm packages (malicious_npm_packages.txt) infostealer + eBPF rootkit')
-    if all_time:
-        print(' Date window: all-time (no recency filter)')
-    else:
-        print(f' Date window: {start_date} to {end_date}')
     print(f' Packages checked: {infected_count}')
     print('============================================================')
     print()
@@ -108,12 +101,9 @@ def format_date(d: date) -> str:
     return d.strftime('%a %d %b %Y %I:%M:%S %p')
 
 
-def print_current_packages(matches: list[PackageMatch], all_time: bool) -> None:
+def print_current_packages(matches: list[PackageMatch]) -> None:
     if not matches:
-        if all_time:
-            print('  Clean: no infected packages currently installed.')
-        else:
-            print('  Clean: no infected packages installed within campaign window.')
+        print('  Clean: no infected packages currently installed.')
     else:
         print(f'  WARNING: {len(matches)} possibly infected package(s):')
         for m in matches:
@@ -311,15 +301,9 @@ def main(argv: list[str] | None = None) -> int:
         logger.error('No infected packages loaded.')
         return 1
 
-    start_date = '2026-06-09'
-    end_date = '2026-06-12'
-
     scanner = AurScanner(
         infected_packages=infected_packages,
         malicious_npm_packages=malicious_npm_packages,
-        start_date=start_date,
-        end_date=end_date,
-        all_time=args.all_time,
     )
 
     check_systemd = args.check_systemd or args.full
@@ -337,10 +321,10 @@ def main(argv: list[str] | None = None) -> int:
     pacman_log_exists = Path('/var/log/pacman.log').is_file()
     bpf_accessible = Path('/sys/fs/bpf').is_dir()
 
-    print_banner(len(infected_packages), start_date, end_date, args.all_time)
+    print_banner(len(infected_packages))
 
     print_section(1, 'Currently installed foreign packages')
-    print_current_packages(list(result.current_packages), args.all_time)
+    print_current_packages(list(result.current_packages))
     print()
 
     print_section(2, 'Historical pacman logs')

--- a/archcanary_py/scanner.py
+++ b/archcanary_py/scanner.py
@@ -142,20 +142,9 @@ class AurScanner:
         self,
         infected_packages: set[str],
         malicious_npm_packages: set[str],
-        start_date: str = '2026-06-09',
-        end_date: str = '2026-06-12',
-        all_time: bool = False,
     ) -> None:
         self.infected_packages = infected_packages
         self.malicious_npm_packages = malicious_npm_packages
-        self._start = date.fromisoformat(start_date)
-        self._end = date.fromisoformat(end_date)
-        self.all_time = all_time
-
-    def _in_window(self, d: date) -> bool:
-        if self.all_time:
-            return True
-        return self._start <= d <= self._end
 
     def check_current(self) -> list[PackageMatch]:
         try:
@@ -186,7 +175,7 @@ class AurScanner:
                     raw = line.split(':', 1)[1].strip()
                     install_date = parse_pacman_date(raw)
                     break
-            if install_date is not None and self._in_window(install_date):
+            if install_date is not None:
                 matches.append(PackageMatch(pkg, install_date))
         return matches
 
@@ -204,8 +193,6 @@ class AurScanner:
                     if not dm:
                         continue
                     date_str = dm.group(1)
-                    if not self._in_window(date.fromisoformat(date_str)):
-                        continue
                     am = alpm_re.search(line)
                     if not am:
                         continue


### PR DESCRIPTION
## Summary

- `AurScanner.__init__`: removed `start_date`, `end_date`, `all_time` params and `self._start`/`self._end`/`self.all_time` attrs
- `_in_window()` method removed; `check_current` and `check_logs` now scan all packages unconditionally
- `print_banner()` and `print_current_packages()` signatures simplified (no `all_time` param, no date-window output)
- `archcanary-merge-lists.sh`: help text updated to remove `--all-time` examples

All-time was already the unconditional default in the main shell script. This aligns the Python port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)