### PR TITLE
fix: set main window default size to 599x413

### DIFF
--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -784,7 +784,7 @@ while true; do
         --list \
         --title="Archcanary" \
         --window-icon=security-high \
-        --width=580 --height=560 \
+        --width=599 --height=413 \
         --column="" \
         --column="Action" \
         --no-headers \


### PR DESCRIPTION
## Summary

- Main yad list window: `--width=580 --height=560` → `--width=599 --height=413`

🤖 Generated with [Claude Code](https://claude.com/claude-code)