### PR TITLE
fix: let separator lines set window width, height 550 for low-DPI

### DIFF
--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -784,7 +784,7 @@ while true; do
         --list \
         --title="Archcanary" \
         --window-icon=security-high \
-        --width=599 --height=413 \
+        --height=550 \
         --column="" \
         --column="Action" \
         --no-headers \


### PR DESCRIPTION
## Summary

- Removed `--width` from main yad list window — yad auto-sizes to the longest column entry (the separator lines), so the window width follows the separator line length naturally
- Set `--height=550` for a usable default on low-DPI displays

🤖 Generated with [Claude Code](https://claude.com/claude-code)