### PR TITLE
fix: set main window width to 440 to avoid content clipping

### DIFF
--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -784,7 +784,7 @@ while true; do
         --list \
         --title="Archcanary" \
         --window-icon=security-high \
-        --height=550 \
+        --width=440 --height=550 \
         --column="" \
         --column="Action" \
         --no-headers \


### PR DESCRIPTION
## Summary

- Without `--width` yad sizes the window too narrow, clipping labels and separator lines
- `--width=440` fits the separator lines and all item labels on low-DPI displays

🤖 Generated with [Claude Code](https://claude.com/claude-code)