### PR TITLE
fix: remove dead no-color.org link from man page

### DIFF
--- a/man/archcanary.1
+++ b/man/archcanary.1
@@ -178,9 +178,7 @@ Infected — malicious packages or artifacts detected.
 If set to any value, disables all ANSI color codes and Unicode symbols
 in output (equivalent to
 .BR \-\-color=never ).
-See
-.UR https://no-color.org
-.UE .
+This is a widely adopted convention for command-line tools.
 .TP
 .B PACMAN_LOG_GLOB
 Override the glob used to find pacman log files.


### PR DESCRIPTION
## Summary

- Replaced `.UR https://no-color.org` with a plain description of the NO_COLOR convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)