### PR TITLE
feat: suggest archcanary-gui --no-gui in sudo hint when invoked via G…

### DIFF
--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -22,6 +22,7 @@ fi
 
 # --no-gui: bypass yad, run a full scan in the terminal with structured output.
 if [[ "${1:-}" == "--no-gui" ]]; then
+    export ARCHCANARY_FROM_GUI=1
     exec "$MAIN_SCRIPT" --full --no-notify "${@:2}"
 fi
 

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -2067,7 +2067,11 @@ case $EXIT_CODE in
 esac
 if [[ ${#SKIPPED_ROOT[@]} -gt 0 ]]; then
     printf ' INCOMPLETE: %d root check(s) skipped (no root): %s\n' "${#SKIPPED_ROOT[@]}" "${SKIPPED_ROOT[*]}"
-    printf ' Re-run with sudo for the full picture: sudo %s --full\n' "$0"
+    if [[ -n "${ARCHCANARY_FROM_GUI:-}" ]]; then
+        printf ' Re-run with sudo for the full picture: sudo archcanary-gui --no-gui\n'
+    else
+        printf ' Re-run with sudo for the full picture: sudo %s --full\n' "$0"
+    fi
 fi
 printf '%s============================================================%s\n' "$_CB" "$_CN"
 


### PR DESCRIPTION
…UI wrapper

when --no-gui is used, sudo archcanary --full is confusing since the user started from the gui wrapper. export ARCHCANARY_FROM_GUI so archcanary.sh can tailor the "re-run with sudo" hint to match the invocation path.