### PR TITLE
feat: suggest archcanary-gui --no-gui in sudo hint when invoked via GUI wrapper

### DIFF
--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -22,6 +22,7 @@ fi
 
 # --no-gui: bypass yad, run a full scan in the terminal with structured output.
 if [[ "${1:-}" == "--no-gui" ]]; then
+    export ARCHCANARY_FROM_GUI=1
     exec "$MAIN_SCRIPT" --full --no-notify "${@:2}"
 fi
 

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -2067,7 +2067,11 @@ case $EXIT_CODE in
 esac
 if [[ ${#SKIPPED_ROOT[@]} -gt 0 ]]; then
     printf ' INCOMPLETE: %d root check(s) skipped (no root): %s\n' "${#SKIPPED_ROOT[@]}" "${SKIPPED_ROOT[*]}"
-    printf ' Re-run with sudo for the full picture: sudo %s --full\n' "$0"
+    if [[ -n "${ARCHCANARY_FROM_GUI:-}" ]]; then
+        printf ' Re-run with sudo for the full picture: sudo archcanary-gui --no-gui\n'
+    else
+        printf ' Re-run with sudo for the full picture: sudo %s --full\n' "$0"
+    fi
 fi
 printf '%s============================================================%s\n' "$_CB" "$_CN"
 


### PR DESCRIPTION
## Summary

- When `archcanary-gui --no-gui` runs and root checks are skipped, the incomplete-scan hint now reads `sudo archcanary-gui --no-gui` instead of `sudo /usr/local/bin/archcanary --full`
- `archcanary-gui.sh` exports `ARCHCANARY_FROM_GUI=1` before exec-ing the main script, so `archcanary.sh` can detect the invocation path
- The root guard in `archcanary-gui.sh` doesn't apply to `--no-gui` mode (exec happens before it), so `sudo archcanary-gui --no-gui` already works correctly

## Test plan

- [ ] Run `archcanary-gui --no-gui` as a normal user — confirm the incomplete-scan hint shows `sudo archcanary-gui --no-gui`
- [ ] Run `archcanary --no-notify --full` directly — confirm the hint still shows `sudo /usr/local/bin/archcanary --full`
- [ ] Run `sudo archcanary-gui --no-gui` — confirm it completes the root checks without the root-guard error

🤖 Generated with [Claude Code](https://claude.com/claude-code)