### PR TITLE
feat: add traur pacman hook sub-check to --doctor

### DIFF
--- a/archcanary.sh
+++ b/archcanary.sh
@@ -511,6 +511,12 @@ run_doctor() {
                 "$(command -v claude 2>/dev/null || echo 'not found — curl -fsSL https://claude.ai/install.sh | bash')"
         fi
         _opt_dep "traur (pre-install behavioral scanner)" traur traur "279-signal pre-install scanner"
+        if command -v traur >/dev/null 2>&1; then
+            _opt_item "traur pacman hook (auto-runs on every install)" \
+                "$(_file /usr/share/libalpm/hooks/traur.hook)" \
+                "" \
+                "path: /usr/share/libalpm/hooks/traur.hook"
+        fi
         _opt_dep "lynis (system hardening auditor)" lynis lynis "post-install hardening audit"
         _opt_item "yay hooks (auto-scan on yay install)" "$(_file "$real_home/.config/yay/init.lua")" "" "path: $real_home/.config/yay/init.lua"
         printf '\n'


### PR DESCRIPTION
## Summary

- `--doctor` now checks `/usr/share/libalpm/hooks/traur.hook` in addition to the traur binary
- Mirrors the aurscan/claude CLI pattern: sub-check only shown when the traur binary is found
- Binary in PATH alone doesn't confirm traur is actually intercepting pacman installs; the hook file is what wires it up

## Test plan

- [ ] `archcanary --doctor aurscan` with traur installed + hook present → both lines `[OK]`
- [ ] `archcanary --doctor aurscan` with traur installed + hook absent → traur binary `[OK]`, hook `[OPT]`
- [ ] `archcanary --doctor aurscan` with traur not installed → no sub-check shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)