### PR TITLE
fix: suppress false positive bpftool warning for systemd-loaded eBPF programs

### DIFF
--- a/archcanary.sh
+++ b/archcanary.sh
@@ -1171,20 +1171,23 @@ check_bpftool() {
 
         echo "  Loaded eBPF programs: $total"
         if [[ -n "$stealth" ]]; then
-            local non_lsm_stealth
+            local non_lsm_stealth unknown_loaders
             non_lsm_stealth=$(tr ',' '\n' <<<"$stealth" | grep -v '^lsm$' | paste -sd, -)
+            # systemd(1) and its child services (systemd-networkd, systemd-journald, etc.)
+            unknown_loaders=$(grep -E '^\s+pids ' <<<"$progs" \
+                | grep -Ev 'systemd[a-z-]*\([0-9]+\)|apparmor_parser\([0-9]+\)|selinuxd\([0-9]+\)' || true)
 
-            if [[ -z "$non_lsm_stealth" ]]; then
-                local unknown_loaders
-                unknown_loaders=$(grep -E '^\s+pids ' <<<"$progs" \
-                    | grep -Ev 'systemd\([0-9]+\)|apparmor_parser\([0-9]+\)|selinuxd\([0-9]+\)' || true)
-                if [[ -z "$unknown_loaders" ]]; then
+            if [[ -z "$unknown_loaders" ]]; then
+                # All programs (with pids) are owned by systemd / AppArmor / SELinux — safe regardless of type.
+                if [[ -z "$non_lsm_stealth" ]]; then
                     echo "  INFO: lsm eBPF programs present — expected (systemd sandboxing / AppArmor / SELinux)."
                 else
-                    echo "  WARNING: stealth-associated program types: $stealth (unknown loader)"
-                    echo "  Review: sudo bpftool prog show"
-                    worst_ret=1
+                    echo "  INFO: eBPF hook types present ($non_lsm_stealth) — all loaded by systemd / AppArmor / SELinux."
                 fi
+            elif [[ -z "$non_lsm_stealth" ]]; then
+                echo "  WARNING: lsm eBPF programs loaded by unknown process (expected systemd / AppArmor / SELinux)."
+                echo "  Review: sudo bpftool prog show"
+                worst_ret=1
             else
                 local warn_types="${non_lsm_stealth:-$stealth}"
                 echo "  WARNING: stealth-associated program types present: $warn_types"


### PR DESCRIPTION
## Summary

- Reported by a Mabox Linux user: archcanary falsely warned about stealth-associated eBPF hook types (tracepoint, perf_event, kprobe) on a clean system where systemd owned all programs
- Moves the known-loader check to apply to **all** stealth types, not just lsm-only; if every program with a `pids` field is owned by systemd/AppArmor/SELinux, output is INFO not WARNING
- Extends the loader pattern from `systemd\([0-9]+\)` to `systemd[a-z-]*\([0-9]+\)` to cover child services like `systemd-networkd`, `systemd-journald`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)