### PR TITLE
fix: prevent empty-save truncation and migrate legacy .conf on edit

### DIFF
--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -270,12 +270,15 @@ edit_allowlist() {
 
 edit_audit_rules() {
     local cfg="/etc/audit/rules.d/30-archcanary.rules"
+    local legacy_cfg="/etc/audit/rules.d/30-archcanary.conf"
     local template="/usr/lib/archcanary/audit-rules.conf"
     local tmpin tmpout
     tmpin="$(mktemp /tmp/archcanary-XXXXXX.conf)"
     tmpout="$(mktemp /tmp/archcanary-XXXXXX.conf)"
     if grep -qE '^\s*-[waAbfe]' "$cfg" 2>/dev/null; then
         cp "$cfg" "$tmpin"
+    elif grep -qE '^\s*-[waAbfe]' "$legacy_cfg" 2>/dev/null; then
+        cp "$legacy_cfg" "$tmpin"
     elif [[ -f "$template" ]]; then
         cp "$template" "$tmpin"
     else
@@ -291,7 +294,12 @@ edit_audit_rules() {
         --button="Save + restart auditd:0" \
         --button="Cancel:1" \
         > "$tmpout" 2>/dev/null; then
-        if [[ -n "$PKEXEC" ]] && "$PKEXEC" tee "$cfg" < "$tmpout" >/dev/null 2>&1; then
+        if [[ ! -s "$tmpout" ]]; then
+            yad --error --title="Archcanary" --window-icon=security-high \
+                --text="Not saved: rules file is empty." \
+                --width=420 2>/dev/null || true
+        elif [[ -n "$PKEXEC" ]] && "$PKEXEC" tee "$cfg" < "$tmpout" >/dev/null 2>&1; then
+            [[ -f "$legacy_cfg" ]] && "$PKEXEC" rm -f "$legacy_cfg" 2>/dev/null || true
             "$PKEXEC" systemctl restart auditd 2>/dev/null || true
         else
             yad --error --title="Archcanary" --window-icon=security-high \


### PR DESCRIPTION
## Summary

- **Truncation bug**: clearing all text in the audit rules editor and clicking Save would truncate `/etc/audit/rules.d/30-archcanary.rules` to zero bytes, then restart auditd with no rules — silently disabling all audit coverage. Fixed with a `[[ ! -s $tmpout ]]` guard that shows an error dialog instead.
- **Migration bug**: users who installed before the `.conf` → `.rules` rename and never re-ran `install.sh` still had their rules in `30-archcanary.conf`. The editor would ignore that file, open the placeholder template, and if saved, write a new `.rules` while the old `.conf` remained — which augenrules loads first (lexicographic order), silently shadowing the newly saved rules. Fixed by falling back to `.conf` in the load path, and removing it via `pkexec rm` after a successful save.

## Test plan

- [ ] Open Edit Audit Rules, delete all text, click Save — should show "Not saved: rules file is empty" error, file unchanged
- [ ] With only `/etc/audit/rules.d/30-archcanary.conf` present (no `.rules`), open editor — should load `.conf` content
- [ ] Save from that state — should write `.rules`, remove `.conf`, restart auditd
- [ ] Normal edit with `.rules` already present — behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)