### PR TITLE
fix: print unknown loader names in bpftool lsm warning

### DIFF
--- a/archcanary.sh
+++ b/archcanary.sh
@@ -1185,8 +1185,11 @@ check_bpftool() {
                     echo "  INFO: eBPF hook types present ($non_lsm_stealth) — all loaded by systemd / AppArmor / SELinux."
                 fi
             elif [[ -z "$non_lsm_stealth" ]]; then
+                local loader_names
+                loader_names=$(sed 's/^\s*pids\s*//' <<<"$unknown_loaders" | paste -sd', ' -)
                 echo "  WARNING: lsm eBPF programs loaded by unknown process (expected systemd / AppArmor / SELinux)."
-                echo "  Review: sudo bpftool prog show"
+                echo "  Unknown loaders: $loader_names"
+                echo "  If this looks like a false positive, report it at https://github.com/musqz/archcanary/issues"
                 worst_ret=1
             else
                 local warn_types="${non_lsm_stealth:-$stealth}"


### PR DESCRIPTION
## Summary

- The bpftool LSM warning previously said \"unknown process\" with no detail, forcing users to manually run and interpret `bpftool prog show`
- Now prints the actual loader process names inline so users can paste them into a bug report without BPF knowledge
- Adds a direct link to the issue tracker for false positive reports

## Test plan

- [ ] Trigger the warning on a system with LSM eBPF programs loaded by an unrecognised process
- [ ] Confirm the unknown loader names appear in the warning output
- [ ] Confirm the GitHub issues link is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)