### PR TITLE
fix: resolve unknown eBPF loaders via pacman to reduce false positives

### DIFF
--- a/archcanary.sh
+++ b/archcanary.sh
@@ -1185,12 +1185,40 @@ check_bpftool() {
                     echo "  INFO: eBPF hook types present ($non_lsm_stealth) — all loaded by systemd / AppArmor / SELinux."
                 fi
             elif [[ -z "$non_lsm_stealth" ]]; then
-                local loader_names
-                loader_names=$(sed 's/^\s*pids\s*//' <<<"$unknown_loaders" | paste -sd', ' -)
-                echo "  WARNING: lsm eBPF programs loaded by unknown process (expected systemd / AppArmor / SELinux)."
-                echo "  Unknown loaders: $loader_names"
-                echo "  If this looks like a false positive, report it at https://github.com/musqz/archcanary/issues"
-                worst_ret=1
+                # Resolve each loader: if /proc/<pid>/exe is a pacman-owned binary, it's a known package
+                # (e.g. VPN daemons, security tools written in Python/Go/etc.) — downgrade to INFO.
+                local all_known=true resolved_entries=()
+                while IFS= read -r entry; do
+                    entry="${entry//[[:space:]]/}"
+                    [[ -z "$entry" ]] && continue
+                    local pid exe pkg
+                    pid=$(grep -oP '\(\K[0-9]+(?=\))' <<<"$entry" || true)
+                    if [[ -n "$pid" ]] && exe=$(readlink -f "/proc/$pid/exe" 2>/dev/null); then
+                        pkg=$(pacman -Qo "$exe" 2>/dev/null | awk '{print $5}' || true)
+                        if [[ -n "$pkg" ]]; then
+                            resolved_entries+=("$entry ($pkg)")
+                        else
+                            resolved_entries+=("$entry")
+                            all_known=false
+                        fi
+                    else
+                        resolved_entries+=("$entry")
+                        all_known=false
+                    fi
+                done < <(sed 's/^\s*pids\s*//' <<<"$unknown_loaders" | tr ',' '\n')
+
+                local resolved_str
+                resolved_str=$(IFS=', '; echo "${resolved_entries[*]}")
+
+                if [[ "$all_known" == true ]]; then
+                    echo "  INFO: lsm eBPF programs loaded by non-systemd process (pacman-owned binary)."
+                    echo "  Loaders: $resolved_str"
+                else
+                    echo "  WARNING: lsm eBPF programs loaded by unknown process (expected systemd / AppArmor / SELinux)."
+                    echo "  Unknown loaders: $resolved_str"
+                    echo "  If this looks like a false positive, report it at https://github.com/musqz/archcanary/issues"
+                    worst_ret=1
+                fi
             else
                 local warn_types="${non_lsm_stealth:-$stealth}"
                 echo "  WARNING: stealth-associated program types present: $warn_types"


### PR DESCRIPTION
## Summary

- VPN daemons and security tools load lsm eBPF programs using whatever runtime they're built on (ProtonVPN uses `python3`, PIA uses a native binary, Mullvad uses `mullvad-daemon`, etc.)
- For each non-systemd loader, resolve `/proc/<pid>/exe` via `pacman -Qo` — if it's a pacman-owned binary it's a known installed package, not malware
- If all unknown loaders resolve to pacman-owned binaries: downgrade to INFO and show the package name
- If any loader can't be resolved (pid gone, not in pacman): keep the WARNING as before

**Before:**
```
WARNING: lsm eBPF programs loaded by unknown process (expected systemd / AppArmor / SELinux).
Unknown loaders: python3(556)
```

**After (VPN daemon case):**
```
INFO: lsm eBPF programs loaded by non-systemd process (pacman-owned binary).
Loaders: python3(556) (python)
```

Reported by a Mabox user running ProtonVPN — closes the false positive without hardcoding any specific process names.

## Test plan

- [ ] Run on a system with a VPN daemon that loads eBPF (ProtonVPN, etc.) — expect INFO with package name
- [ ] Run on a clean system with no non-systemd eBPF loaders — existing INFO/clean paths unchanged
- [ ] Manually test with a process whose exe is not in pacman — expect WARNING preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)