### PR TITLE
fix: scope infected-package extraction to the package-check section

### DIFF
--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -215,23 +215,30 @@ _propagate_full_scan() {
 
 _show_infected_dialog() {
     local pkgs="${1:-}"
-    local remove_cmd
+    local step1
     if [[ -n "$pkgs" ]]; then
-        remove_cmd="${AUR_HELPER} -R ${pkgs}"
+        step1="Remove the package(s):\n      <tt>${AUR_HELPER} -R ${pkgs}</tt>"
     else
-        remove_cmd="${AUR_HELPER} -R &lt;package-name&gt;"
+        step1="Review and remove/disable the flagged artifact(s) shown in the\n      scan output (systemd unit, eBPF program, autostart entry, etc.)."
     fi
     yad --error \
         --title="Infected — Archcanary" \
         --window-icon=security-high \
         --width=520 \
-        --text="<b>Infected or compromised packages detected.</b>\n\n<b>1.</b>  Remove the package(s):\n      <tt>${remove_cmd}</tt>\n\n<b>2.</b>  Check persistence — run <i>Systemd persistence</i> and\n      <i>XDG autostart + shell RCs</i> from this menu.\n\n<b>3.</b>  Rotate credentials: SSH keys, GitHub PATs, Discord\n      tokens, npm tokens, browser sessions.\n\nSee README → <i>What to Do If Infected</i>" \
+        --text="<b>Infected or compromised indicators detected.</b>\n\n<b>1.</b>  ${step1}\n\n<b>2.</b>  Check persistence — run <i>Systemd persistence</i> and\n      <i>XDG autostart + shell RCs</i> from this menu.\n\n<b>3.</b>  Rotate credentials: SSH keys, GitHub PATs, Discord\n      tokens, npm tokens, browser sessions.\n\nSee README → <i>What to Do If Infected</i>" \
         --button="OK:0" 2>/dev/null || true
 }
 
-# Extract infected package names from scan output (lines: "  - pkgname (installed: ...)")
+# Extract infected package names from scan output (lines: "  - pkgname (installed: ...)").
+# Scoped to section [1] "Currently installed foreign packages" only — other checks
+# (systemd, ebpf, autostart, etc.) also emit "  - " lines via print_list, but those
+# aren't AUR package names and must never be fed to `yay -R`.
 _extract_infected_pkgs() {
-    grep -oP '^  - \K\S+' "$1" 2>/dev/null | head -20 | tr '\n' ' ' | sed 's/ $//' || true
+    awk '
+        /^--- \[1\] / { grab=1; next }
+        grab && /^--- \[/ { exit }
+        grab { print }
+    ' "$1" 2>/dev/null | grep -oP '^  - \K\S+' | head -20 | tr '\n' ' ' | sed 's/ $//' || true
 }
 
 edit_allowlist() {

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -2205,8 +2205,19 @@ printf '%s============================================================%s\n' "$_C
 
 if [[ $EXIT_CODE -eq 2 ]] && ! $NO_NOTIFY; then
     if command -v notify-send &>/dev/null; then
+        # Only checks [1]/[2] (currently-installed / historically-installed foreign
+        # packages) confirm an actual malicious package. Other checks at this exit
+        # code (systemd, ebpf, autostart, etc.) flag suspicious artifacts, not
+        # packages, so the notification wording must not claim "package" for those.
+        _notify_title="archcanary: security indicator detected"
+        for _i in "${!_SUMMARY_NAMES[@]}"; do
+            case "${_SUMMARY_NAMES[$_i]}" in
+                "Package list "*|"pacman.log history")
+                    [[ "${_SUMMARY_CODES[$_i]}" -eq 2 ]] && _notify_title="archcanary: malicious package detected" ;;
+            esac
+        done
         notify-send -u critical -i dialog-warning \
-            "archcanary: malicious package detected" \
+            "$_notify_title" \
             "Indicators found. Open Archcanary to review."
     fi
 fi


### PR DESCRIPTION
## Summary
- `_extract_infected_pkgs` grepped every `  - ` line across the whole scan output, but `print_list` is shared by all checks (systemd, ebpf, autostart, etc.). A non-package finding could get fed into the GUI's `yay -R` remediation command as if it were an AUR package — e.g. a stale/dangling systemd unit produced `yay -R /etc/systemd/system/forgejo.service`, which isn't a valid `yay` invocation.
- Same bug class in `archcanary.sh`'s desktop notification: the title always said "malicious package detected" regardless of which check actually fired.
- Fix: extraction is now scoped to section `[1]` (currently-installed foreign packages) only; the GUI dialog's step 1 and the notification title are conditional on whether a real package hit occurred.

## Test plan
- [x] `bash -n` on both changed files
- [x] Verified `_extract_infected_pkgs` returns empty for a systemd-only finding and returns just the package name when a real package hit is also present
- [x] Verified notify-send title logic picks "malicious package detected" only when the package-check section reports exit code 2
- [x] Ran `tests/run_matching_tests.sh` — same pre-existing failures as on `master` (unrelated, missing `package_list.txt` fixture), no new failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)