### PR TITLE
feat: add systemd unit allowlist for the persistence check

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 > If you run into anything, please open an [issue](https://github.com/musqz/archcanary/issues) or start a [discussion](https://github.com/musqz/archcanary/discussions).
 
 > **Read-only by design.** The scanner detects and reports — it never deletes, quarantines, or disables anything.
-> Remediation is left to you. The only writes are its own logs and config lists. `install.sh`, `--refresh`, and the DKMS allowlist editor are the exceptions — all explicit.
+> Remediation is left to you. The only writes are its own logs and config lists. `install.sh`, `--refresh`, and the DKMS/systemd allowlist editors are the exceptions — all explicit.
 
 > **Developed with Claude AI (Anthropic).** All AI-assisted code and documentation is reviewed by the developer before commit. Treat all detections as advisory, not authoritative.
 

--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -73,6 +73,7 @@ command -v auditctl &>/dev/null && HAS_AUDITD=true
 AUR_HELPER="yay"
 command -v yay  &>/dev/null || { command -v paru &>/dev/null && AUR_HELPER="paru"; } || AUR_HELPER="pacman"
 _SHOW_OUTPUT_INFECTED_PKGS=""
+_SHOW_OUTPUT_SYSTEMD_HINT=""
 
 # True once the package list has been refreshed this session.
 # The first run of the full scan (idx 0) auto-adds --refresh and sets this.
@@ -102,6 +103,7 @@ LABELS=(
     "Edit Lynis config"        # 19
     "Pacman integrity"         # 20
     "About"                    # 21
+    "Edit systemd allowlist"   # 22
 )
 
 FLAGS=(
@@ -127,6 +129,7 @@ FLAGS=(
     "__lynis_config_edit__"
     "--check-pkginteg --no-notify --no-summary"
     "__about__"
+    "__systemd_allowlist_edit__"
 )
 
 NEEDS_ROOT=(
@@ -138,6 +141,7 @@ NEEDS_ROOT=(
     false
     false
     true
+    false
     false
 )
 
@@ -154,6 +158,7 @@ STATUS[16]="   "  # Lynis hardening report — informational, no pass/fail verdi
 STATUS[18]="   "  # Edit audit rules — config dialog, no scan verdict
 STATUS[19]="   "  # Edit Lynis config — config dialog, no scan verdict
 STATUS[21]="   "  # About — no scan verdict
+STATUS[22]="   "  # Edit systemd allowlist — config dialog, no scan verdict
 unset _i
 
 # Derive full-scan status (row 0) from whichever individual checks have results.
@@ -214,10 +219,12 @@ _propagate_full_scan() {
 }
 
 _show_infected_dialog() {
-    local pkgs="${1:-}"
+    local pkgs="${1:-}" systemd_hint="${2:-}"
     local step1
     if [[ -n "$pkgs" ]]; then
         step1="Remove the package(s):\n      <tt>${AUR_HELPER} -R ${pkgs}</tt>"
+    elif [[ -n "$systemd_hint" ]]; then
+        step1="Review the flagged systemd unit(s) in the scan output above.\n      Known-good custom service, not an AUR package? Allowlist it instead\n      of removing it: <i>Edit systemd allowlist</i> (Settings menu)."
     else
         step1="Review and remove/disable the flagged artifact(s) shown in the\n      scan output (systemd unit, eBPF program, autostart entry, etc.)."
     fi
@@ -241,6 +248,17 @@ _extract_infected_pkgs() {
     ' "$1" 2>/dev/null | grep -oP '^  - \K\S+' | head -20 | tr '\n' ' ' | sed 's/ $//' || true
 }
 
+# Non-empty if section [3] (systemd persistence check) reported a WARNING —
+# used by _show_infected_dialog to point at the systemd allowlist instead of
+# the generic "review the artifact" wording.
+_systemd_finding_present() {
+    awk '
+        /^--- \[3\] / { grab=1; next }
+        grab && /^--- \[/ { exit }
+        grab { print }
+    ' "$1" 2>/dev/null | grep -q 'WARNING' && echo 1 || true
+}
+
 edit_allowlist() {
     # Single system-wide allowlist (the kmod audit only runs as root). The file
     # is world-readable, so yad loads it directly; the save writes back as root.
@@ -257,6 +275,41 @@ edit_allowlist() {
     tmpout="$(mktemp /tmp/archcanary-XXXXXX.txt)"
     if yad --text-info \
         --title="DKMS Allowlist (system) — Archcanary" \
+        --window-icon=security-high \
+        --filename="$cfg" \
+        --width=640 --height=380 \
+        --fontname="Monospace 10" \
+        --editable \
+        --button="Save (root):0" \
+        --button="Cancel:1" \
+        > "$tmpout" 2>/dev/null; then
+        # Write back to /etc as root — pkexec prompts via the polkit agent.
+        if [[ -z "$PKEXEC" ]] || ! "$PKEXEC" tee "$cfg" < "$tmpout" >/dev/null 2>&1; then
+            yad --error --title="Archcanary" --window-icon=security-high \
+                --text="Could not save <tt>$cfg</tt>\n(root authorization failed or cancelled)." \
+                --width=420 2>/dev/null || true
+        fi
+    fi
+    rm -f "$tmpout"
+}
+
+edit_systemd_allowlist() {
+    # Single system-wide allowlist (mirrors edit_allowlist / DKMS above). The
+    # file is world-readable, so yad loads it directly; the save writes back
+    # as root.
+    local cfg="/etc/archcanary/systemd_allowlist.conf"
+    if [[ ! -f "$cfg" ]]; then
+        yad --warning \
+            --title="Systemd Allowlist — Archcanary" \
+            --window-icon=security-high \
+            --text="<b>$cfg</b> does not exist.\n\nRun <tt>./install.sh --system</tt> first to create it." \
+            --width=440 2>/dev/null || true
+        return
+    fi
+    local tmpout
+    tmpout="$(mktemp /tmp/archcanary-XXXXXX.txt)"
+    if yad --text-info \
+        --title="Systemd Allowlist (system) — Archcanary" \
         --window-icon=security-high \
         --filename="$cfg" \
         --width=640 --height=380 \
@@ -521,6 +574,7 @@ show_output() {
     wait "$yad_pid" 2>/dev/null || true
     exec 8>&-
     _SHOW_OUTPUT_INFECTED_PKGS="$(_extract_infected_pkgs "$tmpout")"
+    _SHOW_OUTPUT_SYSTEMD_HINT="$(_systemd_finding_present "$tmpout")"
     rm -f "$tmpout"
     return $scan_exit
 }
@@ -586,6 +640,11 @@ run_action() {
 
     if [[ "$flags" == "__dkms_edit__" ]]; then
         edit_allowlist
+        return
+    fi
+
+    if [[ "$flags" == "__systemd_allowlist_edit__" ]]; then
+        edit_systemd_allowlist
         return
     fi
 
@@ -752,17 +811,21 @@ run_action() {
         exec 8>&-
         _update_status "$idx" "$scan_exit"
         if [[ "$idx" -eq 0 ]]; then _propagate_full_scan "$scan_exit" "$tmpout"; fi
-        local _inf_pkgs=""
-        [[ "$scan_exit" -eq 2 ]] && _inf_pkgs="$(_extract_infected_pkgs "$tmpout")"
+        local _inf_pkgs="" _inf_systemd_hint=""
+        if [[ "$scan_exit" -eq 2 ]]; then
+            _inf_pkgs="$(_extract_infected_pkgs "$tmpout")"
+            _inf_systemd_hint="$(_systemd_finding_present "$tmpout")"
+        fi
         rm -f "$tmpout"
-        if [[ "$scan_exit" -eq 2 ]]; then _show_infected_dialog "$_inf_pkgs"; fi
+        if [[ "$scan_exit" -eq 2 ]]; then _show_infected_dialog "$_inf_pkgs" "$_inf_systemd_hint"; fi
     else
         local scan_exit=0
         _SHOW_OUTPUT_INFECTED_PKGS=""
+        _SHOW_OUTPUT_SYSTEMD_HINT=""
         show_output "$label" "$MAIN_SCRIPT" "${flag_arr[@]}" && scan_exit=0 || scan_exit=$?
         _update_status "$idx" "$scan_exit"
         if [[ "$idx" -eq 0 ]]; then _propagate_full_scan "$scan_exit"; fi
-        if [[ "$scan_exit" -eq 2 ]]; then _show_infected_dialog "$_SHOW_OUTPUT_INFECTED_PKGS"; fi
+        if [[ "$scan_exit" -eq 2 ]]; then _show_infected_dialog "$_SHOW_OUTPUT_INFECTED_PKGS" "$_SHOW_OUTPUT_SYSTEMD_HINT"; fi
     fi
 }
 
@@ -793,6 +856,7 @@ build_list_args() {
     $HAS_AUDITD  && _row 18
     $HAS_LYNIS   && _row 19
     _row 12
+    _row 22
     $HAS_AURSCAN && _row 14
     _row 15
     _row 21

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -481,6 +481,7 @@ run_doctor() {
         _item "root helper (enables root checks in GUI)" "$(_file /usr/lib/archcanary/root-helper)"           "bash $installer_sys" "path: /usr/lib/archcanary/root-helper"
         _item "polkit policy (authorizes the root helper)" "$(_file /usr/share/polkit-1/actions/org.archcanary.policy)" "bash $installer_sys" "path: /usr/share/polkit-1/actions/org.archcanary.policy"
         _item "DKMS allowlist"                           "$(_file /etc/archcanary/dkms_allowlist.conf)"       "bash $installer_sys" "path: /etc/archcanary/dkms_allowlist.conf"
+        _item "systemd allowlist"                        "$(_file /etc/archcanary/systemd_allowlist.conf)"    "bash $installer_sys" "path: /etc/archcanary/systemd_allowlist.conf"
         printf '\n'
     fi
 
@@ -683,6 +684,24 @@ if [[ -r "$_dkms_cfg" ]]; then    # skip if missing/unreadable (don't abort unde
     done < "$_dkms_cfg"
 fi
 unset _dkms_cfg _dl
+
+# Merge the systemd allowlist into SYSTEMD_ALLOWLIST (colon-separated; the env
+# var, if set, takes precedence and is appended to). Single system-wide file,
+# same rationale as the DKMS allowlist above — for unit names that are
+# legitimately unowned by pacman (self-hosted apps installed from upstream
+# binary releases, e.g. forgejo) and shouldn't trip the systemd persistence check.
+# Override the path with SYSTEMD_ALLOWLIST_FILE (used by the tests).
+SYSTEMD_ALLOWLIST="${SYSTEMD_ALLOWLIST:-}"
+_svc_cfg="${SYSTEMD_ALLOWLIST_FILE:-/etc/archcanary/systemd_allowlist.conf}"
+if [[ -r "$_svc_cfg" ]]; then    # skip if missing/unreadable (don't abort under set -e)
+    while IFS= read -r _sl || [[ -n "$_sl" ]]; do
+        _sl="${_sl%%#*}"       # strip inline comments
+        read -r _sl _ <<< "$_sl"  # take first token only (ignores trailing descriptions)
+        [[ -z "$_sl" ]] && continue
+        SYSTEMD_ALLOWLIST="${SYSTEMD_ALLOWLIST:+${SYSTEMD_ALLOWLIST}:}${_sl}"
+    done < "$_svc_cfg"
+fi
+unset _svc_cfg _sl
 
 if [[ ! -f "$MALICIOUS_NPM_LIST" ]]; then
     _bundled="$(dirname "$(realpath "$0")")/lists/malicious_npm_packages.txt"
@@ -1030,9 +1049,41 @@ _find_service_file() {
     return 1
 }
 
+# Resolve a scanned .service/.timer/.conf path to the unit name a
+# SYSTEMD_ALLOWLIST entry would refer to it by. A drop-in override
+# (".../unitname.service.d/override.conf") resolves to "unitname.service" so
+# one allowlist entry covers the unit and all its drop-ins.
+_systemd_unit_name() {
+    local path="$1" base
+    base="$(basename "$path")"
+    if [[ "$base" == *.service || "$base" == *.timer ]]; then
+        printf '%s\n' "$base"
+    else
+        base="$(basename "$(dirname "$path")")"
+        printf '%s\n' "${base%.d}"
+    fi
+}
+
+# True if $1 (a unit name from _systemd_unit_name) is in the SYSTEMD_ALLOWLIST
+# array named $2 (passed by name since bash can't return arrays).
+_systemd_allowlisted() {
+    local name="$1" allow_arr_name="$2" _a
+    local -n _allow="$allow_arr_name"
+    for _a in "${_allow[@]}"; do
+        [[ "$_a" == "$name" ]] && return 0
+    done
+    return 1
+}
+
 check_systemd() {
     local found=()
     local re_restart='^Restart=(always|on-failure|on-abnormal|on-abort)'
+    # SYSTEMD_ALLOWLIST: colon-separated list of unit names that are known-good
+    # but not tracked by pacman and not vetted by the standard-prefix check
+    # (e.g. a self-hosted app installed from an upstream binary release).
+    # Example: SYSTEMD_ALLOWLIST=forgejo.service:forgejo.timer
+    local -a _svc_allow
+    IFS=: read -ra _svc_allow <<< "${SYSTEMD_ALLOWLIST:-}"
 
     IFS=: read -ra dirs <<< "${SYSTEMD_SCAN_DIRS:-/etc/systemd/system:$HOME/.config/systemd/user}"
 
@@ -1064,6 +1115,10 @@ check_systemd() {
                 fi
                 local match
                 match=$(grep -oE "$re_restart" "$svc" | head -1)
+                if _systemd_allowlisted "$(_systemd_unit_name "$svc")" _svc_allow; then
+                    echo "  INFO: systemd unit allowlisted (not vetted): $svc ($match)"
+                    continue
+                fi
                 found+=("$svc ($match)")
             fi
         done < <(find "$dir" \( -name '*.service' -o -name '*.conf' \) -type f 2>/dev/null)
@@ -1083,6 +1138,10 @@ check_systemd() {
                 svc_file=$(_find_service_file "$target" "$dir") || svc_file=""
                 # Vetted target → benign timer; skip. Otherwise flag it.
                 [[ -n "$svc_file" ]] && _service_vetted "$svc_file" && continue
+                if _systemd_allowlisted "$(_systemd_unit_name "$timer")" _svc_allow; then
+                    echo "  INFO: systemd timer allowlisted (not vetted): $timer (timer → ${target})"
+                    continue
+                fi
                 found+=("$timer (timer → ${target}${svc_file:+, unvetted})")
             fi
         done < <(find "$dir" -name '*.timer' -type f 2>/dev/null)

--- a/docs/my-setup.md
+++ b/docs/my-setup.md
@@ -186,7 +186,8 @@ triggers (timer + `.path` units) are in [systemd.md](systemd.md).
     ├── malicious_russian_spam_packages.txt
     └── root-helper                   # pkexec target (validates flags, restores XDG env)
 /etc/archcanary/
-    └── dkms_allowlist.conf           # the single DKMS allowlist (edit via GUI/sudoedit)
+    ├── dkms_allowlist.conf           # the single DKMS allowlist (edit via GUI/sudoedit)
+    └── systemd_allowlist.conf        # the single systemd unit allowlist (edit via GUI/sudoedit)
 /usr/share/polkit-1/actions/
     └── org.archcanary.policy  # polkit policy allowing GUI to call root-helper
 

--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -33,7 +33,7 @@ The root scan can't notify (no desktop session), so a user `.path` unit watches 
 
 ## Quick setup (recommended)
 
-`./install.sh --system` does all of this for you — it installs the system scan units, the user-level scan, and the notifier; creates `/var/lib/archcanary/`; seeds the package lists and the system-wide DKMS allowlist; enables the system timer + pacman-trigger, the user timer, and the notifier; and migrates away any old user-scope scan units:
+`./install.sh --system` does all of this for you — it installs the system scan units, the user-level scan, and the notifier; creates `/var/lib/archcanary/`; seeds the package lists and the system-wide DKMS and systemd allowlists; enables the system timer + pacman-trigger, the user timer, and the notifier; and migrates away any old user-scope scan units:
 
 ```bash
 ./install.sh --system

--- a/install.sh
+++ b/install.sh
@@ -266,11 +266,29 @@ EOF
         rm -f "$CONFIG_DIR/dkms_allowlist.conf"
         echo "  migrated:  ~/.config dkms_allowlist.conf → /etc (per-user copy removed)"
     fi
+    # systemd allowlist — same rationale and seeding rules as the DKMS allowlist
+    # above (mode 644, never clobber an existing /etc copy).
+    if [[ ! -f /etc/archcanary/systemd_allowlist.conf ]]; then
+        sudo tee /etc/archcanary/systemd_allowlist.conf >/dev/null << 'EOF'
+# systemd units to skip during the systemd persistence check (--check-systemd),
+# system-wide allowlist. One unit name per line. Everything after # is a comment.
+# Add units that are known-good but not tracked by pacman and not vetted by the
+# standard-prefix check (e.g. a self-hosted app installed from an upstream
+# binary release rather than a package). A .timer is matched by its OWN name,
+# not its target .service — allowlist both if you want to silence both findings.
+#
+# Example:
+# forgejo.service  # self-hosted git, installed from upstream binary release
+# forgejo.timer    # only needed if forgejo also ships a persistent timer
+EOF
+        sudo chmod 644 /etc/archcanary/systemd_allowlist.conf
+    fi
     echo "  installed: $SYSTEM_LIB/archcanary.sh"
     echo "  installed: $SYSTEM_LIB/root-helper"
     echo "  installed: $SYSTEM_LIB/lynis-custom.prf (template for /etc/lynis/custom.prf)"
     echo "  installed: $SYSTEM_LIB/{package_list,malicious_npm_packages,chaos_rat_packages,malicious_russian_spam_packages}.txt"
     echo "  installed: /etc/archcanary/dkms_allowlist.conf (system-wide DKMS allowlist for the root scan)"
+    echo "  installed: /etc/archcanary/systemd_allowlist.conf (system-wide systemd allowlist for the persistence check)"
     echo "  installed: /usr/share/polkit-1/actions/org.archcanary.policy"
 
     # Seed Lynis custom profile (only if lynis is installed and file not yet present)

--- a/tests/run_matching_tests.sh
+++ b/tests/run_matching_tests.sh
@@ -247,7 +247,7 @@ test_npm_cli_flag() {
 # ---------------------------------------------------------------------------
 test_actual_list_integrity() {
     local infected=()
-    load_list "$REPO_DIR/package_list.txt" infected
+    load_list "$REPO_DIR/lists/package_list.txt" infected
 
     if [[ ${#infected[@]} -gt 500 ]]; then
         pass "actual_list: parsed ${#infected[@]} packages from package_list.txt"

--- a/tests/run_matching_tests.sh
+++ b/tests/run_matching_tests.sh
@@ -339,6 +339,21 @@ test_check_systemd_hardened() {
         fail "check_systemd: empty dir → expected clean, got: $out"
     fi
     rm -rf "$tmpdir"
+
+    # Sub-test D: allowlisted unit names → INFO, no WARNING, exit 0 (clean)
+    local allow_file
+    allow_file=$(mktemp)
+    printf 'fake-persist.service\nfake-persist.timer\n' > "$allow_file"
+    rc=0
+    out=$(SYSTEMD_SCAN_DIRS="$fixture_dir" SYSTEMD_ALLOWLIST_FILE="$allow_file" \
+        "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
+    if [[ $rc -eq 0 && "$out" == *"INFO: systemd unit allowlisted"* \
+          && "$out" == *"INFO: systemd timer allowlisted"* && "$out" != *"WARNING"* ]]; then
+        pass "check_systemd: allowlisted unit/timer → INFO only, exit 0 (clean)"
+    else
+        fail "check_systemd: allowlisted unit/timer → expected INFO+exit0, got rc=$rc, out: $out"
+    fi
+    rm -f "$allow_file"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `check_systemd` had no escape hatch: a legitimate custom service that isn't pacman-owned, has `Restart=always`, and points at a binary outside the standard prefixes (or whose binary is now missing) is indistinguishable from malware persistence and always gets flagged — with no way to mark it known-good short of restructuring the service. This came up directly from the forgejo false-positive discussion in #51.
- Adds `/etc/archcanary/systemd_allowlist.conf`, mirroring the existing DKMS allowlist: a colon-separated `SYSTEMD_ALLOWLIST` env var merged from the root-owned config file, checked in `check_systemd()` before a unit is added to the findings list.
- A drop-in override (`unitname.service.d/override.conf`) resolves to its parent unit's name so one allowlist entry covers both. A `.timer` is matched by its own name, not its target `.service` — allowlisting one does not silence the other; the seeded template calls this out explicitly.
- Wired into `install.sh` (seeding, mode 644, never clobbers an existing file), the GUI (new "Edit systemd allowlist" action — same pkexec-write pattern as the DKMS editor), and the infected-dialog wording (hints at the allowlist specifically when the systemd check is what fired, instead of the generic "remove the artifact" text from #51).
- Also includes an unrelated one-line fix (separate commit) for a pre-existing stale test path (`package_list.txt` → `lists/package_list.txt`, from the #40 reorg) that was aborting the whole test suite before it ever reached the systemd tests.

## Test plan
- [x] `bash -n` on all changed files
- [x] Manual `check_systemd` runs: non-allowlisted unit → WARNING+exit 2; allowlisted unit+timer → INFO lines only, exit 0 (clean)
- [x] New automated test case (`SYSTEMD_ALLOWLIST_FILE` env override) added to `tests/run_matching_tests.sh`, passing
- [x] Full test suite run: 24 PASS, 1 FAIL (pre-existing, unrelated `cli_flag` failure present before this change too)
- [x] Verified LABELS/FLAGS/NEEDS_ROOT arrays stay index-consistent (23 entries) after appending the new GUI action
- [ ] **Not verified by execution:** GUI "Edit systemd allowlist → Save" pkexec write path — logic is a line-for-line mirror of the working DKMS editor, but couldn't authenticate polkit in this session. Please click through it once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)