### PR TITLE
feat: bpftool allowlist + GUI menu consolidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 > If you run into anything, please open an [issue](https://github.com/musqz/archcanary/issues) or start a [discussion](https://github.com/musqz/archcanary/discussions).
 
 > **Read-only by design.** The scanner detects and reports — it never deletes, quarantines, or disables anything.
-> Remediation is left to you. The only writes are its own logs and config lists. `install.sh`, `--refresh`, and the DKMS/systemd allowlist editors are the exceptions — all explicit.
+> Remediation is left to you. The only writes are its own logs and config lists. `install.sh`, `--refresh`, and the allowlist editors (DKMS, systemd, bpftool) are the exceptions — all explicit.
 
 > **Developed with Claude AI (Anthropic).** All AI-assisted code and documentation is reviewed by the developer before commit. Treat all detections as advisory, not authoritative.
 

--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -96,13 +96,11 @@ LABELS=(
     "Manage allowlists"         # 12
     "Trust scan (traur)"        # 13
     "LLM settings (aurscan)"   # 14
-    "Extra lists"               # 15
+    "Edit config"               # 15
     "Lynis hardening report"   # 16
     "Run Lynis audit"          # 17  root
-    "Edit audit rules"         # 18
-    "Edit Lynis config"        # 19
-    "Pacman integrity"         # 20
-    "About"                    # 21
+    "Pacman integrity"         # 18
+    "About"                    # 19
 )
 
 FLAGS=(
@@ -121,11 +119,9 @@ FLAGS=(
     "__manage_allowlists__"
     "__traur__"
     "__aurscan_settings__"
-    "__extra_lists__"
+    "__edit_config__"
     "--check-lynis --no-notify --no-summary"
     "--run-lynis"
-    "__audit_rules_edit__"
-    "__lynis_config_edit__"
     "--check-pkginteg --no-notify --no-summary"
     "__about__"
 )
@@ -136,8 +132,6 @@ NEEDS_ROOT=(
     false false false false
     true
     true
-    false
-    false
     true
     false
 )
@@ -150,11 +144,9 @@ STATUS[0]="   "   # Full scan — blank until first run
 STATUS[12]="   "  # Manage allowlists — config dialog, no scan verdict
 STATUS[13]="   "  # traur — opens its own output window, no verdict here
 STATUS[14]="   "  # aurscan settings — config dialog, no scan verdict
-STATUS[15]="   "  # extra lists — config dialog, no scan verdict
+STATUS[15]="   "  # Edit config — config dialog, no scan verdict
 STATUS[16]="   "  # Lynis hardening report — informational, no pass/fail verdict
-STATUS[18]="   "  # Edit audit rules — config dialog, no scan verdict
-STATUS[19]="   "  # Edit Lynis config — config dialog, no scan verdict
-STATUS[21]="   "  # About — no scan verdict
+STATUS[19]="   "  # About — no scan verdict
 unset _i
 
 # Derive full-scan status (row 0) from whichever individual checks have results.
@@ -330,6 +322,37 @@ manage_allowlists() {
         "DKMS"*)    _edit_conf_file "DKMS Allowlist"    /etc/archcanary/dkms_allowlist.conf ;;
         "Systemd"*) _edit_conf_file "Systemd Allowlist" /etc/archcanary/systemd_allowlist.conf ;;
         "bpftool"*) _edit_conf_file "bpftool Allowlist" /etc/archcanary/bpftool_allowlist.conf ;;
+    esac
+}
+
+# Picker in front of the individual config editors below (audit rules, Lynis
+# config, extra malware lists) — same consolidation pattern as
+# manage_allowlists(), but each choice still calls its own distinct function
+# (different save targets/side-effects: pkexec+restart auditd, plain copy, a
+# user-owned file) rather than being forced through one generic editor.
+# Skips entries whose tool isn't installed, matching the old row-hiding
+# behavior. Add a new config editor here, not as another top-level row.
+edit_config() {
+    local -a choices=()
+    $HAS_AUDITD && choices+=("Audit rules")
+    $HAS_LYNIS  && choices+=("Lynis config")
+    choices+=("Extra malware lists")
+
+    local choice
+    choice=$(yad --list \
+        --title="Edit Config — Archcanary" \
+        --window-icon=security-high --center \
+        --width=460 --height=220 \
+        --no-headers \
+        --column="Config" \
+        "${choices[@]}" \
+        --button="Edit:0" --button="Close:1" \
+        --print-column=1 2>/dev/null) || return
+    choice="${choice%|}"
+    case "$choice" in
+        "Audit rules")        edit_audit_rules ;;
+        "Lynis config")       edit_lynis_config ;;
+        "Extra malware lists") extra_lists_manager ;;
     esac
 }
 
@@ -605,7 +628,7 @@ CONF
     local tmpout
     tmpout="$(mktemp /tmp/archcanary-XXXXXX.txt)"
     if yad --text-info \
-        --title="Extra package lists — Archcanary" \
+        --title="Extra Malware Lists — Archcanary" \
         --window-icon=security-high --center \
         --width=600 --height=360 \
         --fontname="Monospace 10" \
@@ -618,7 +641,7 @@ CONF
         local n
         n=$(grep -c '^[^#[:space:]]' "$conf" 2>/dev/null || true)
         yad --info \
-            --title="Extra lists — Archcanary" \
+            --title="Extra Malware Lists — Archcanary" \
             --window-icon=security-high --center \
             --text="Saved to <tt>$conf</tt>\n$n active entries.\n\nRun <b>Full scan</b> to fetch any new URLs." \
             --width=420 \
@@ -633,7 +656,7 @@ run_action() {
     local flags="${FLAGS[$idx]}"
     local needs_root="${NEEDS_ROOT[$idx]}"
 
-    if [[ "$idx" -eq 16 || "$idx" -eq 17 || "$idx" -eq 19 ]] && ! $HAS_LYNIS; then
+    if [[ "$idx" -eq 16 || "$idx" -eq 17 ]] && ! $HAS_LYNIS; then
         yad --info \
             --title="Lynis — Archcanary" \
             --window-icon=security-high --center \
@@ -648,13 +671,8 @@ run_action() {
         return
     fi
 
-    if [[ "$flags" == "__audit_rules_edit__" ]]; then
-        edit_audit_rules
-        return
-    fi
-
-    if [[ "$flags" == "__lynis_config_edit__" ]]; then
-        edit_lynis_config
+    if [[ "$flags" == "__edit_config__" ]]; then
+        edit_config
         return
     fi
 
@@ -665,11 +683,6 @@ run_action() {
 
     if [[ "$flags" == "__aurscan_settings__" ]]; then
         aurscan_settings
-        return
-    fi
-
-    if [[ "$flags" == "__extra_lists__" ]]; then
-        extra_lists_manager
         return
     fi
 
@@ -856,14 +869,12 @@ build_list_args() {
     _sep "Utilities"
     $HAS_LYNIS   && _row 16 "🔐  ${LABELS[16]}"
     $HAS_TRAUR   && _row 13
-    _row 20 "🔐  ${LABELS[20]}"
+    _row 18 "🔐  ${LABELS[18]}"
     _sep "Settings"
-    $HAS_AUDITD  && _row 18
-    $HAS_LYNIS   && _row 19
     _row 12
-    $HAS_AURSCAN && _row 14
     _row 15
-    _row 21
+    $HAS_AURSCAN && _row 14
+    _row 19
 }
 
 # Main loop

--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -73,7 +73,7 @@ command -v auditctl &>/dev/null && HAS_AUDITD=true
 AUR_HELPER="yay"
 command -v yay  &>/dev/null || { command -v paru &>/dev/null && AUR_HELPER="paru"; } || AUR_HELPER="pacman"
 _SHOW_OUTPUT_INFECTED_PKGS=""
-_SHOW_OUTPUT_SYSTEMD_HINT=""
+_SHOW_OUTPUT_ALLOWLIST_HINT=""
 
 # True once the package list has been refreshed this session.
 # The first run of the full scan (idx 0) auto-adds --refresh and sets this.
@@ -93,7 +93,7 @@ LABELS=(
     "eBPF rootkit traces"       # 9  root
     "eBPF programs – bpftool"   # 10 root
     "Kernel modules"            # 11 root
-    "Edit DKMS allowlist"       # 12
+    "Manage allowlists"         # 12
     "Trust scan (traur)"        # 13
     "LLM settings (aurscan)"   # 14
     "Extra lists"               # 15
@@ -103,7 +103,6 @@ LABELS=(
     "Edit Lynis config"        # 19
     "Pacman integrity"         # 20
     "About"                    # 21
-    "Edit systemd allowlist"   # 22
 )
 
 FLAGS=(
@@ -119,7 +118,7 @@ FLAGS=(
     "--check-ebpf --no-summary"
     "--check-bpftool --no-summary"
     "--check-kmod --no-summary"
-    "__dkms_edit__"
+    "__manage_allowlists__"
     "__traur__"
     "__aurscan_settings__"
     "__extra_lists__"
@@ -129,7 +128,6 @@ FLAGS=(
     "__lynis_config_edit__"
     "--check-pkginteg --no-notify --no-summary"
     "__about__"
-    "__systemd_allowlist_edit__"
 )
 
 NEEDS_ROOT=(
@@ -142,7 +140,6 @@ NEEDS_ROOT=(
     false
     true
     false
-    false
 )
 
 # Per-session status for each check index.
@@ -150,7 +147,7 @@ NEEDS_ROOT=(
 declare -A STATUS
 for _i in "${!LABELS[@]}"; do STATUS[$_i]="  ?"; done
 STATUS[0]="   "   # Full scan — blank until first run
-STATUS[12]="   "  # Edit DKMS allowlist
+STATUS[12]="   "  # Manage allowlists — config dialog, no scan verdict
 STATUS[13]="   "  # traur — opens its own output window, no verdict here
 STATUS[14]="   "  # aurscan settings — config dialog, no scan verdict
 STATUS[15]="   "  # extra lists — config dialog, no scan verdict
@@ -158,7 +155,6 @@ STATUS[16]="   "  # Lynis hardening report — informational, no pass/fail verdi
 STATUS[18]="   "  # Edit audit rules — config dialog, no scan verdict
 STATUS[19]="   "  # Edit Lynis config — config dialog, no scan verdict
 STATUS[21]="   "  # About — no scan verdict
-STATUS[22]="   "  # Edit systemd allowlist — config dialog, no scan verdict
 unset _i
 
 # Derive full-scan status (row 0) from whichever individual checks have results.
@@ -219,12 +215,12 @@ _propagate_full_scan() {
 }
 
 _show_infected_dialog() {
-    local pkgs="${1:-}" systemd_hint="${2:-}"
+    local pkgs="${1:-}" allowlist_hint="${2:-}"
     local step1
     if [[ -n "$pkgs" ]]; then
         step1="Remove the package(s):\n      <tt>${AUR_HELPER} -R ${pkgs}</tt>"
-    elif [[ -n "$systemd_hint" ]]; then
-        step1="Review the flagged systemd unit(s) in the scan output above.\n      Known-good custom service, not an AUR package? Allowlist it instead\n      of removing it: <i>Edit systemd allowlist</i> (Settings menu)."
+    elif [[ -n "$allowlist_hint" ]]; then
+        step1="Review the flagged ${allowlist_hint} finding(s) in the scan output\n      above. Known-good and not an AUR package? Allowlist it instead of\n      removing it: <i>Manage allowlists</i> (Settings menu)."
     else
         step1="Review and remove/disable the flagged artifact(s) shown in the\n      scan output (systemd unit, eBPF program, autostart entry, etc.)."
     fi
@@ -248,24 +244,33 @@ _extract_infected_pkgs() {
     ' "$1" 2>/dev/null | grep -oP '^  - \K\S+' | head -20 | tr '\n' ' ' | sed 's/ $//' || true
 }
 
-# Non-empty if section [3] (systemd persistence check) reported a WARNING —
-# used by _show_infected_dialog to point at the systemd allowlist instead of
-# the generic "review the artifact" wording.
-_systemd_finding_present() {
-    awk '
-        /^--- \[3\] / { grab=1; next }
-        grab && /^--- \[/ { exit }
-        grab { print }
-    ' "$1" 2>/dev/null | grep -q 'WARNING' && echo 1 || true
+# Names the check (e.g. "systemd") if its section reported a WARNING — used by
+# _show_infected_dialog to point at "Manage allowlists" instead of the generic
+# "review the artifact" wording. Covers every check with a real allowlist
+# escape hatch; add a "tag:name" pair here when a new one gets one.
+_allowlistable_finding_present() {
+    local out="$1" pair tag desc
+    for pair in "3:systemd" "8:bpftool" "11:DKMS"; do
+        tag="${pair%%:*}" desc="${pair#*:}"
+        if awk -v t="$tag" '
+            $0 ~ ("^--- \\[" t "\\] ") { grab=1; next }
+            grab && /^--- \[/ { exit }
+            grab { print }
+        ' "$out" 2>/dev/null | grep -q 'WARNING'; then
+            printf '%s\n' "$desc"
+            return
+        fi
+    done
 }
 
-edit_allowlist() {
-    # Single system-wide allowlist (the kmod audit only runs as root). The file
-    # is world-readable, so yad loads it directly; the save writes back as root.
-    local cfg="/etc/archcanary/dkms_allowlist.conf"
+# Generic root-owned config-file editor: view/edit via yad text-info, write
+# back via pkexec. Shared by every allowlist editor (DKMS, systemd, bpftool,
+# ...) so adding a new allowlist never means copy-pasting this dialog again.
+_edit_conf_file() {
+    local title="$1" cfg="$2"
     if [[ ! -f "$cfg" ]]; then
         yad --warning \
-            --title="DKMS Allowlist — Archcanary" \
+            --title="$title — Archcanary" \
             --window-icon=security-high \
             --text="<b>$cfg</b> does not exist.\n\nRun <tt>./install.sh --system</tt> first to create it." \
             --width=440 2>/dev/null || true
@@ -274,7 +279,7 @@ edit_allowlist() {
     local tmpout
     tmpout="$(mktemp /tmp/archcanary-XXXXXX.txt)"
     if yad --text-info \
-        --title="DKMS Allowlist (system) — Archcanary" \
+        --title="$title (system) — Archcanary" \
         --window-icon=security-high \
         --filename="$cfg" \
         --width=640 --height=380 \
@@ -293,39 +298,28 @@ edit_allowlist() {
     rm -f "$tmpout"
 }
 
-edit_systemd_allowlist() {
-    # Single system-wide allowlist (mirrors edit_allowlist / DKMS above). The
-    # file is world-readable, so yad loads it directly; the save writes back
-    # as root.
-    local cfg="/etc/archcanary/systemd_allowlist.conf"
-    if [[ ! -f "$cfg" ]]; then
-        yad --warning \
-            --title="Systemd Allowlist — Archcanary" \
-            --window-icon=security-high \
-            --text="<b>$cfg</b> does not exist.\n\nRun <tt>./install.sh --system</tt> first to create it." \
-            --width=440 2>/dev/null || true
-        return
-    fi
-    local tmpout
-    tmpout="$(mktemp /tmp/archcanary-XXXXXX.txt)"
-    if yad --text-info \
-        --title="Systemd Allowlist (system) — Archcanary" \
+# Picker in front of _edit_conf_file — keeps the main menu at one row no
+# matter how many allowlist-backed checks exist. Add a new allowlist here,
+# not as another top-level LABELS/FLAGS row.
+manage_allowlists() {
+    local choice
+    choice=$(yad --list \
+        --title="Manage Allowlists — Archcanary" \
         --window-icon=security-high \
-        --filename="$cfg" \
-        --width=640 --height=380 \
-        --fontname="Monospace 10" \
-        --editable \
-        --button="Save (root):0" \
-        --button="Cancel:1" \
-        > "$tmpout" 2>/dev/null; then
-        # Write back to /etc as root — pkexec prompts via the polkit agent.
-        if [[ -z "$PKEXEC" ]] || ! "$PKEXEC" tee "$cfg" < "$tmpout" >/dev/null 2>&1; then
-            yad --error --title="Archcanary" --window-icon=security-high \
-                --text="Could not save <tt>$cfg</tt>\n(root authorization failed or cancelled)." \
-                --width=420 2>/dev/null || true
-        fi
-    fi
-    rm -f "$tmpout"
+        --width=460 --height=220 \
+        --no-headers \
+        --column="Allowlist" \
+        "DKMS (kernel modules)" \
+        "Systemd (persistence check)" \
+        "bpftool (eBPF loaders)" \
+        --button="Edit:0" --button="Close:1" \
+        --print-column=1 2>/dev/null) || return
+    choice="${choice%|}"
+    case "$choice" in
+        "DKMS"*)    _edit_conf_file "DKMS Allowlist"    /etc/archcanary/dkms_allowlist.conf ;;
+        "Systemd"*) _edit_conf_file "Systemd Allowlist" /etc/archcanary/systemd_allowlist.conf ;;
+        "bpftool"*) _edit_conf_file "bpftool Allowlist" /etc/archcanary/bpftool_allowlist.conf ;;
+    esac
 }
 
 edit_audit_rules() {
@@ -574,7 +568,7 @@ show_output() {
     wait "$yad_pid" 2>/dev/null || true
     exec 8>&-
     _SHOW_OUTPUT_INFECTED_PKGS="$(_extract_infected_pkgs "$tmpout")"
-    _SHOW_OUTPUT_SYSTEMD_HINT="$(_systemd_finding_present "$tmpout")"
+    _SHOW_OUTPUT_ALLOWLIST_HINT="$(_allowlistable_finding_present "$tmpout")"
     rm -f "$tmpout"
     return $scan_exit
 }
@@ -638,13 +632,8 @@ run_action() {
         return
     fi
 
-    if [[ "$flags" == "__dkms_edit__" ]]; then
-        edit_allowlist
-        return
-    fi
-
-    if [[ "$flags" == "__systemd_allowlist_edit__" ]]; then
-        edit_systemd_allowlist
+    if [[ "$flags" == "__manage_allowlists__" ]]; then
+        manage_allowlists
         return
     fi
 
@@ -811,21 +800,21 @@ run_action() {
         exec 8>&-
         _update_status "$idx" "$scan_exit"
         if [[ "$idx" -eq 0 ]]; then _propagate_full_scan "$scan_exit" "$tmpout"; fi
-        local _inf_pkgs="" _inf_systemd_hint=""
+        local _inf_pkgs="" _inf_allowlist_hint=""
         if [[ "$scan_exit" -eq 2 ]]; then
             _inf_pkgs="$(_extract_infected_pkgs "$tmpout")"
-            _inf_systemd_hint="$(_systemd_finding_present "$tmpout")"
+            _inf_allowlist_hint="$(_allowlistable_finding_present "$tmpout")"
         fi
         rm -f "$tmpout"
-        if [[ "$scan_exit" -eq 2 ]]; then _show_infected_dialog "$_inf_pkgs" "$_inf_systemd_hint"; fi
+        if [[ "$scan_exit" -eq 2 ]]; then _show_infected_dialog "$_inf_pkgs" "$_inf_allowlist_hint"; fi
     else
         local scan_exit=0
         _SHOW_OUTPUT_INFECTED_PKGS=""
-        _SHOW_OUTPUT_SYSTEMD_HINT=""
+        _SHOW_OUTPUT_ALLOWLIST_HINT=""
         show_output "$label" "$MAIN_SCRIPT" "${flag_arr[@]}" && scan_exit=0 || scan_exit=$?
         _update_status "$idx" "$scan_exit"
         if [[ "$idx" -eq 0 ]]; then _propagate_full_scan "$scan_exit"; fi
-        if [[ "$scan_exit" -eq 2 ]]; then _show_infected_dialog "$_SHOW_OUTPUT_INFECTED_PKGS" "$_SHOW_OUTPUT_SYSTEMD_HINT"; fi
+        if [[ "$scan_exit" -eq 2 ]]; then _show_infected_dialog "$_SHOW_OUTPUT_INFECTED_PKGS" "$_SHOW_OUTPUT_ALLOWLIST_HINT"; fi
     fi
 }
 
@@ -856,7 +845,6 @@ build_list_args() {
     $HAS_AUDITD  && _row 18
     $HAS_LYNIS   && _row 19
     _row 12
-    _row 22
     $HAS_AURSCAN && _row 14
     _row 15
     _row 21

--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -14,7 +14,7 @@ done
 if [[ -z "$MAIN_SCRIPT" ]]; then
     yad --error \
         --title="Archcanary" \
-        --window-icon=security-high \
+        --window-icon=security-high --center \
         --text="<b>archcanary not found.</b>\n\nRun <tt>./install.sh</tt> first." \
         --width=400
     exit 1
@@ -226,7 +226,7 @@ _show_infected_dialog() {
     fi
     yad --error \
         --title="Infected — Archcanary" \
-        --window-icon=security-high \
+        --window-icon=security-high --center \
         --width=520 \
         --text="<b>Infected or compromised indicators detected.</b>\n\n<b>1.</b>  ${step1}\n\n<b>2.</b>  Check persistence — run <i>Systemd persistence</i> and\n      <i>XDG autostart + shell RCs</i> from this menu.\n\n<b>3.</b>  Rotate credentials: SSH keys, GitHub PATs, Discord\n      tokens, npm tokens, browser sessions.\n\nSee README → <i>What to Do If Infected</i>" \
         --button="OK:0" 2>/dev/null || true
@@ -271,7 +271,7 @@ _edit_conf_file() {
     if [[ ! -f "$cfg" ]]; then
         yad --warning \
             --title="$title — Archcanary" \
-            --window-icon=security-high \
+            --window-icon=security-high --center \
             --text="<b>$cfg</b> does not exist.\n\nRun <tt>./install.sh --system</tt> first to create it." \
             --width=440 2>/dev/null || true
         return
@@ -280,7 +280,7 @@ _edit_conf_file() {
     tmpout="$(mktemp /tmp/archcanary-XXXXXX.txt)"
     if yad --text-info \
         --title="$title (system) — Archcanary" \
-        --window-icon=security-high \
+        --window-icon=security-high --center \
         --filename="$cfg" \
         --width=640 --height=380 \
         --fontname="Monospace 10" \
@@ -290,7 +290,7 @@ _edit_conf_file() {
         > "$tmpout" 2>/dev/null; then
         # Write back to /etc as root — pkexec prompts via the polkit agent.
         if [[ -z "$PKEXEC" ]] || ! "$PKEXEC" tee "$cfg" < "$tmpout" >/dev/null 2>&1; then
-            yad --error --title="Archcanary" --window-icon=security-high \
+            yad --error --title="Archcanary" --window-icon=security-high --center \
                 --text="Could not save <tt>$cfg</tt>\n(root authorization failed or cancelled)." \
                 --width=420 2>/dev/null || true
         fi
@@ -305,7 +305,7 @@ manage_allowlists() {
     local choice
     choice=$(yad --list \
         --title="Manage Allowlists — Archcanary" \
-        --window-icon=security-high \
+        --window-icon=security-high --center \
         --width=460 --height=220 \
         --no-headers \
         --column="Allowlist" \
@@ -340,7 +340,7 @@ edit_audit_rules() {
     fi
     if yad --text-info \
         --title="Audit Rules — Archcanary" \
-        --window-icon=security-high \
+        --window-icon=security-high --center \
         --filename="$tmpin" \
         --width=700 --height=520 \
         --fontname="Monospace 10" \
@@ -349,14 +349,14 @@ edit_audit_rules() {
         --button="Cancel:1" \
         > "$tmpout" 2>/dev/null; then
         if [[ ! -s "$tmpout" ]]; then
-            yad --error --title="Archcanary" --window-icon=security-high \
+            yad --error --title="Archcanary" --window-icon=security-high --center \
                 --text="Not saved: rules file is empty." \
                 --width=420 2>/dev/null || true
         elif [[ -n "$PKEXEC" ]] && "$PKEXEC" tee "$cfg" < "$tmpout" >/dev/null 2>&1; then
             [[ -f "$legacy_cfg" ]] && "$PKEXEC" rm -f "$legacy_cfg" 2>/dev/null || true
             "$PKEXEC" systemctl restart auditd 2>/dev/null || true
         else
-            yad --error --title="Archcanary" --window-icon=security-high \
+            yad --error --title="Archcanary" --window-icon=security-high --center \
                 --text="Could not save <tt>$cfg</tt>\n(root authorization failed or cancelled)." \
                 --width=420 2>/dev/null || true
         fi
@@ -378,7 +378,7 @@ edit_lynis_config() {
     fi
     if yad --text-info \
         --title="Lynis Config — Archcanary" \
-        --window-icon=security-high \
+        --window-icon=security-high --center \
         --filename="$tmpout" \
         --width=700 --height=520 \
         --fontname="Monospace 10" \
@@ -389,7 +389,7 @@ edit_lynis_config() {
         if [[ -n "$PKEXEC" ]] && "$PKEXEC" tee "$cfg" < "$tmpout.new" >/dev/null 2>&1; then
             true
         else
-            yad --error --title="Archcanary" --window-icon=security-high \
+            yad --error --title="Archcanary" --window-icon=security-high --center \
                 --text="Could not save <tt>$cfg</tt>\n(root authorization failed or cancelled)." \
                 --width=420 2>/dev/null || true
         fi
@@ -402,7 +402,7 @@ show_about() {
     version=$(grep -oP '(?<=SCRIPT_VERSION=")[^"]+' "$MAIN_SCRIPT" 2>/dev/null || echo "unknown")
     yad --info \
         --title="About Archcanary" \
-        --window-icon=security-high \
+        --window-icon=security-high --center \
         --width=440 --height=240 \
         --no-wrap \
         --button="Close":0 \
@@ -450,7 +450,7 @@ aurscan_settings() {
         # (set -e exempts the left side of && from exit-on-error).
         result=$(yad --form \
             --title="LLM Settings — aurscan" \
-            --window-icon=security-high \
+            --window-icon=security-high --center \
             --width=540 \
             --separator="|" \
             --field="Backend:CB" "$backends" \
@@ -467,7 +467,7 @@ aurscan_settings() {
         if [[ $rc -eq 2 ]]; then
             yad --text-info \
                 --title="Local model guide — aurscan" \
-                --window-icon=security-high \
+                --window-icon=security-high --center \
                 --width=580 --height=440 \
                 --fontname="Monospace 10" \
                 --button="OK:0" \
@@ -528,7 +528,7 @@ GUIDE
 
     yad --info \
         --title="aurscan" \
-        --window-icon=security-high \
+        --window-icon=security-high --center \
         --text="Settings saved to\n<tt>$env_file</tt>" \
         --width=380 \
         --button="OK:0" 2>/dev/null || true
@@ -545,7 +545,7 @@ show_output() {
 
     yad --text-info \
         --title="$title — Archcanary" \
-        --window-icon=security-high \
+        --window-icon=security-high --center \
         --width=1000 --height=660 \
         --fontname="Monospace 10" \
         --wrap --tail --editable \
@@ -595,7 +595,7 @@ CONF
     tmpout="$(mktemp /tmp/archcanary-XXXXXX.txt)"
     if yad --text-info \
         --title="Extra package lists — Archcanary" \
-        --window-icon=security-high \
+        --window-icon=security-high --center \
         --width=600 --height=360 \
         --fontname="Monospace 10" \
         --editable \
@@ -608,7 +608,7 @@ CONF
         n=$(grep -c '^[^#[:space:]]' "$conf" 2>/dev/null || true)
         yad --info \
             --title="Extra lists — Archcanary" \
-            --window-icon=security-high \
+            --window-icon=security-high --center \
             --text="Saved to <tt>$conf</tt>\n$n active entries.\n\nRun <b>Full scan</b> to fetch any new URLs." \
             --width=420 \
             --button="OK:0" 2>/dev/null || true
@@ -625,7 +625,7 @@ run_action() {
     if [[ "$idx" -eq 16 || "$idx" -eq 17 || "$idx" -eq 19 ]] && ! $HAS_LYNIS; then
         yad --info \
             --title="Lynis — Archcanary" \
-            --window-icon=security-high \
+            --window-icon=security-high --center \
             --text="<b>Lynis</b> is not installed.\n\nInstall from official repos:\n  <tt>sudo pacman -S lynis</tt>" \
             --width=420 \
             --button="OK:0" 2>/dev/null || true
@@ -666,7 +666,7 @@ run_action() {
         if ! $HAS_TRAUR; then
             yad --warning \
                 --title="traur not installed" \
-                --window-icon=security-high \
+                --window-icon=security-high --center \
                 --text="<b>traur</b> is not installed.\n\nInstall it from AUR:\n  <tt>${AUR_HELPER} -S traur</tt>" \
                 --width=360 2>/dev/null || true
             return
@@ -690,7 +690,7 @@ run_action() {
         if ! $HAS_ROOT; then
             yad --warning \
                 --title="Root helper not installed" \
-                --window-icon=security-high \
+                --window-icon=security-high --center \
                 --text="The system root helper is not installed.\n\nRun:\n  <b>./install.sh --system</b>\n\nto enable root-requiring checks." \
                 --width=440 2>/dev/null || true
             return
@@ -704,7 +704,7 @@ run_action() {
         mkfifo "$fifo"
         yad --text-info \
             --title="$label — Archcanary" \
-            --window-icon=security-high \
+            --window-icon=security-high --center \
             --width=1000 --height=660 \
             --fontname="Monospace 10" \
             --wrap --tail --editable \
@@ -772,7 +772,7 @@ run_action() {
             rm -f "$tmpout"
             [[ $pkexec_exit -ne 0 && $pkexec_exit -ne 126 ]] && \
                 yad --error --title="Archcanary" \
-                    --window-icon=security-high \
+                    --window-icon=security-high --center \
                     --text="pkexec failed (exit $pkexec_exit)" \
                     --width=360 2>/dev/null || true
             if [[ "$idx" -eq 0 ]]; then _infer_full_status; fi
@@ -858,7 +858,7 @@ while true; do
     selected=$(yad \
         --list \
         --title="Archcanary" \
-        --window-icon=security-high \
+        --window-icon=security-high --center \
         --width=440 --height=550 \
         --column="" \
         --column="Action" \

--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -244,19 +244,30 @@ _extract_infected_pkgs() {
     ' "$1" 2>/dev/null | grep -oP '^  - \K\S+' | head -20 | tr '\n' ' ' | sed 's/ $//' || true
 }
 
-# Names the check (e.g. "systemd") if its section reported a WARNING — used by
-# _show_infected_dialog to point at "Manage allowlists" instead of the generic
-# "review the artifact" wording. Covers every check with a real allowlist
-# escape hatch; add a "tag:name" pair here when a new one gets one.
+# Names the check (e.g. "systemd") if its section reported a WARNING that the
+# allowlist can actually silence — used by _show_infected_dialog to point at
+# "Manage allowlists" instead of the generic "review the artifact" wording.
+# Each section's match pattern is scoped to ONLY its allowlist-gated warning
+# text — systemd's "found" list is entirely allowlist-gated so any WARNING
+# there qualifies, but bpftool and DKMS each also emit WARNINGs with no
+# allowlist escape hatch at all (bpftool: stealth program types, suspicious
+# kprobes, XDP/TC network attachments; DKMS: lsmod modules untraceable to
+# pacman/DKMS) — matching generic "WARNING" there would point the user at a
+# fix that doesn't apply to their finding. Add a "tag:name:pattern" entry here
+# when a new check gets a real allowlist; pattern must be unique to that
+# check's allowlist-gated branch, not shared with its unconditional WARNINGs.
 _allowlistable_finding_present() {
-    local out="$1" pair tag desc
-    for pair in "3:systemd" "8:bpftool" "11:DKMS"; do
-        tag="${pair%%:*}" desc="${pair#*:}"
+    local out="$1" pair tag rest desc pattern
+    for pair in "3:systemd:WARNING" "8:bpftool:unknown process" "11:DKMS:untracked source"; do
+        tag="${pair%%:*}"
+        rest="${pair#*:}"
+        desc="${rest%%:*}"
+        pattern="${rest#*:}"
         if awk -v t="$tag" '
             $0 ~ ("^--- \\[" t "\\] ") { grab=1; next }
             grab && /^--- \[/ { exit }
             grab { print }
-        ' "$out" 2>/dev/null | grep -q 'WARNING'; then
+        ' "$out" 2>/dev/null | grep -q "$pattern"; then
             printf '%s\n' "$desc"
             return
         fi
@@ -699,12 +710,17 @@ run_action() {
         tmpout="$(mktemp /tmp/archcanary-XXXXXX.txt)"
 
         # Open the output window immediately — no blank screen after clicking Run.
+        # Deliberately NOT --center: this window's focus behavior around the
+        # polkit dialog is fragile (see the xdotool loop + sleep below) and has
+        # regressed ~5 times in history; --center is an unvetted variable in
+        # that interaction on click-to-focus WMs (Openbox) and stays off here
+        # even though every other dialog in this file is centered.
         local fifo
         fifo="$(mktemp -u /tmp/archcanary-fifo-XXXXXX)"
         mkfifo "$fifo"
         yad --text-info \
             --title="$label — Archcanary" \
-            --window-icon=security-high --center \
+            --window-icon=security-high \
             --width=1000 --height=660 \
             --fontname="Monospace 10" \
             --wrap --tail --editable \

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -482,6 +482,7 @@ run_doctor() {
         _item "polkit policy (authorizes the root helper)" "$(_file /usr/share/polkit-1/actions/org.archcanary.policy)" "bash $installer_sys" "path: /usr/share/polkit-1/actions/org.archcanary.policy"
         _item "DKMS allowlist"                           "$(_file /etc/archcanary/dkms_allowlist.conf)"       "bash $installer_sys" "path: /etc/archcanary/dkms_allowlist.conf"
         _item "systemd allowlist"                        "$(_file /etc/archcanary/systemd_allowlist.conf)"    "bash $installer_sys" "path: /etc/archcanary/systemd_allowlist.conf"
+        _item "bpftool allowlist"                        "$(_file /etc/archcanary/bpftool_allowlist.conf)"    "bash $installer_sys" "path: /etc/archcanary/bpftool_allowlist.conf"
         printf '\n'
     fi
 
@@ -702,6 +703,24 @@ if [[ -r "$_svc_cfg" ]]; then    # skip if missing/unreadable (don't abort under
     done < "$_svc_cfg"
 fi
 unset _svc_cfg _sl
+
+# Merge the bpftool allowlist into BPFTOOL_ALLOWLIST (colon-separated; the env
+# var, if set, takes precedence and is appended to). Same rationale as DKMS/
+# systemd above — for eBPF loader binaries that are legitimately not
+# pacman-owned (e.g. a self-built or manually-installed security/monitoring
+# tool that loads LSM hooks) and shouldn't trip the bpftool loader check.
+# Override the path with BPFTOOL_ALLOWLIST_FILE (used by the tests).
+BPFTOOL_ALLOWLIST="${BPFTOOL_ALLOWLIST:-}"
+_bpf_cfg="${BPFTOOL_ALLOWLIST_FILE:-/etc/archcanary/bpftool_allowlist.conf}"
+if [[ -r "$_bpf_cfg" ]]; then    # skip if missing/unreadable (don't abort under set -e)
+    while IFS= read -r _bl || [[ -n "$_bl" ]]; do
+        _bl="${_bl%%#*}"       # strip inline comments
+        read -r _bl _ <<< "$_bl"  # take first token only (ignores trailing descriptions)
+        [[ -z "$_bl" ]] && continue
+        BPFTOOL_ALLOWLIST="${BPFTOOL_ALLOWLIST:+${BPFTOOL_ALLOWLIST}:}${_bl}"
+    done < "$_bpf_cfg"
+fi
+unset _bpf_cfg _bl
 
 if [[ ! -f "$MALICIOUS_NPM_LIST" ]]; then
     _bundled="$(dirname "$(realpath "$0")")/lists/malicious_npm_packages.txt"
@@ -1064,9 +1083,10 @@ _systemd_unit_name() {
     fi
 }
 
-# True if $1 (a unit name from _systemd_unit_name) is in the SYSTEMD_ALLOWLIST
-# array named $2 (passed by name since bash can't return arrays).
-_systemd_allowlisted() {
+# True if $1 (a name — unit, DKMS module, loader binary) is in the allowlist
+# array named $2 (passed by name since bash can't return arrays). Shared by
+# every allowlist-backed check (systemd, DKMS, bpftool).
+_allowlist_contains() {
     local name="$1" allow_arr_name="$2" _a
     local -n _allow="$allow_arr_name"
     for _a in "${_allow[@]}"; do
@@ -1115,7 +1135,7 @@ check_systemd() {
                 fi
                 local match
                 match=$(grep -oE "$re_restart" "$svc" | head -1)
-                if _systemd_allowlisted "$(_systemd_unit_name "$svc")" _svc_allow; then
+                if _allowlist_contains "$(_systemd_unit_name "$svc")" _svc_allow; then
                     echo "  INFO: systemd unit allowlisted (not vetted): $svc ($match)"
                     continue
                 fi
@@ -1138,7 +1158,7 @@ check_systemd() {
                 svc_file=$(_find_service_file "$target" "$dir") || svc_file=""
                 # Vetted target → benign timer; skip. Otherwise flag it.
                 [[ -n "$svc_file" ]] && _service_vetted "$svc_file" && continue
-                if _systemd_allowlisted "$(_systemd_unit_name "$timer")" _svc_allow; then
+                if _allowlist_contains "$(_systemd_unit_name "$timer")" _svc_allow; then
                     echo "  INFO: systemd timer allowlisted (not vetted): $timer (timer → ${target})"
                     continue
                 fi
@@ -1204,14 +1224,23 @@ check_ebpf() {
 #   (e.g. hide C2 traffic). On a typical Arch workstation this should be empty.
 # ---------------------------------------------------------------------------
 check_bpftool() {
-    if ! command -v bpftool &>/dev/null; then
+    # BPFTOOL_CMD overrides the real command for testing.
+    local bpftool_cmd="${BPFTOOL_CMD:-bpftool}"
+    # BPFTOOL_ALLOWLIST: colon-separated list of loader binary basenames that
+    # are known-good but not pacman-owned (a self-built or manually-installed
+    # security/monitoring tool that legitimately loads LSM eBPF hooks).
+    # Example: BPFTOOL_ALLOWLIST=falco:my-lsm-tool
+    local -a _bpf_allow
+    IFS=: read -ra _bpf_allow <<< "${BPFTOOL_ALLOWLIST:-}"
+
+    if ! command -v "$bpftool_cmd" &>/dev/null; then
         echo "  Skipped: bpftool not installed (pacman -S bpf)."
         return 0
     fi
 
     # Enumerating BPF objects requires CAP_BPF / CAP_SYS_ADMIN.
     local progs
-    if ! progs=$(bpftool prog show 2>/dev/null); then
+    if ! progs=$("$bpftool_cmd" prog show 2>/dev/null); then
         echo "  Cannot enumerate BPF programs — needs root."
         echo "  → Try: sudo $0 --check-bpftool"
         return 77
@@ -1256,6 +1285,8 @@ check_bpftool() {
                         pkg=$(pacman -Qo "$exe" 2>/dev/null | awk '{print $5}' || true)
                         if [[ -n "$pkg" ]]; then
                             resolved_entries+=("$entry ($pkg)")
+                        elif _allowlist_contains "$(basename "$exe")" _bpf_allow; then
+                            resolved_entries+=("$entry (allowlisted)")
                         else
                             resolved_entries+=("$entry")
                             all_known=false
@@ -1270,7 +1301,7 @@ check_bpftool() {
                 resolved_str=$(IFS=', '; echo "${resolved_entries[*]}")
 
                 if [[ "$all_known" == true ]]; then
-                    echo "  INFO: lsm eBPF programs loaded by non-systemd process (pacman-owned binary)."
+                    echo "  INFO: lsm eBPF programs loaded by non-systemd process (pacman-owned or allowlisted)."
                     echo "  Loaders: $resolved_str"
                 else
                     echo "  WARNING: lsm eBPF programs loaded by unknown process (expected systemd / AppArmor / SELinux)."
@@ -1293,7 +1324,7 @@ check_bpftool() {
 
     # --- perf show: kprobe/tracepoint attachments with owning PID and target ---
     local perf_out
-    perf_out=$(bpftool perf show 2>/dev/null) || true
+    perf_out=$("$bpftool_cmd" perf show 2>/dev/null) || true
     if [[ -z "$perf_out" ]]; then
         echo "  Perf attachments (kprobe/tracepoint): none."
     else
@@ -1317,7 +1348,7 @@ check_bpftool() {
 
     # --- net show: XDP / TC programs attached to network interfaces ---
     local net_out
-    net_out=$(bpftool net show 2>/dev/null) || true
+    net_out=$("$bpftool_cmd" net show 2>/dev/null) || true
     local net_entries
     net_entries=$(grep -vE '^(xdp:|tc:|flow_dissector:|netfilter:|tcx:|netkit:)\s*$' <<<"$net_out" \
                   | grep -v '^\s*$' || true)
@@ -1887,12 +1918,7 @@ check_kmod() {
                 pkg_name=$(awk -F'[/,]' '{print $1}' <<< "$entry" | xargs)
                 # Skip if pacman-tracked
                 pacman -Qi "$pkg_name" &>/dev/null 2>&1 && continue
-                # Skip if in user-supplied allowlist
-                local allowed=false
-                for _a in "${_dkms_allow[@]}"; do
-                    [[ "$_a" == "$pkg_name" ]] && allowed=true && break
-                done
-                if $allowed; then
+                if _allowlist_contains "$pkg_name" _dkms_allow; then
                     echo "  INFO: DKMS module allowlisted (not pacman-tracked): $entry"
                 else
                     echo "  WARNING: DKMS module from untracked source: $entry"

--- a/docs/my-setup.md
+++ b/docs/my-setup.md
@@ -186,8 +186,10 @@ triggers (timer + `.path` units) are in [systemd.md](systemd.md).
     ├── malicious_russian_spam_packages.txt
     └── root-helper                   # pkexec target (validates flags, restores XDG env)
 /etc/archcanary/
-    ├── dkms_allowlist.conf           # the single DKMS allowlist (edit via GUI/sudoedit)
-    └── systemd_allowlist.conf        # the single systemd unit allowlist (edit via GUI/sudoedit)
+    ├── dkms_allowlist.conf           # DKMS allowlist
+    ├── systemd_allowlist.conf        # systemd unit allowlist
+    └── bpftool_allowlist.conf        # bpftool eBPF loader allowlist
+                                       # (all three: GUI → Manage allowlists, or sudoedit directly)
 /usr/share/polkit-1/actions/
     └── org.archcanary.policy  # polkit policy allowing GUI to call root-helper
 

--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -33,7 +33,7 @@ The root scan can't notify (no desktop session), so a user `.path` unit watches 
 
 ## Quick setup (recommended)
 
-`./install.sh --system` does all of this for you — it installs the system scan units, the user-level scan, and the notifier; creates `/var/lib/archcanary/`; seeds the package lists and the system-wide DKMS and systemd allowlists; enables the system timer + pacman-trigger, the user timer, and the notifier; and migrates away any old user-scope scan units:
+`./install.sh --system` does all of this for you — it installs the system scan units, the user-level scan, and the notifier; creates `/var/lib/archcanary/`; seeds the package lists and the system-wide DKMS, systemd, and bpftool allowlists; enables the system timer + pacman-trigger, the user timer, and the notifier; and migrates away any old user-scope scan units:
 
 ```bash
 ./install.sh --system

--- a/install.sh
+++ b/install.sh
@@ -283,12 +283,29 @@ EOF
 EOF
         sudo chmod 644 /etc/archcanary/systemd_allowlist.conf
     fi
+    # bpftool allowlist — same rationale and seeding rules as the DKMS/systemd
+    # allowlists above (mode 644, never clobber an existing /etc copy).
+    if [[ ! -f /etc/archcanary/bpftool_allowlist.conf ]]; then
+        sudo tee /etc/archcanary/bpftool_allowlist.conf >/dev/null << 'EOF'
+# eBPF loader binaries to skip during the bpftool LSM-loader check
+# (--check-bpftool), system-wide allowlist. One binary basename per line.
+# Everything after # is a comment.
+# Add loaders that are known-good but not pacman-owned (a self-built or
+# manually-installed security/monitoring tool that legitimately loads LSM
+# eBPF hooks) — matched against the basename of /proc/<pid>/exe.
+#
+# Example:
+# falco  # runtime security monitoring, installed from upstream binary release
+EOF
+        sudo chmod 644 /etc/archcanary/bpftool_allowlist.conf
+    fi
     echo "  installed: $SYSTEM_LIB/archcanary.sh"
     echo "  installed: $SYSTEM_LIB/root-helper"
     echo "  installed: $SYSTEM_LIB/lynis-custom.prf (template for /etc/lynis/custom.prf)"
     echo "  installed: $SYSTEM_LIB/{package_list,malicious_npm_packages,chaos_rat_packages,malicious_russian_spam_packages}.txt"
     echo "  installed: /etc/archcanary/dkms_allowlist.conf (system-wide DKMS allowlist for the root scan)"
     echo "  installed: /etc/archcanary/systemd_allowlist.conf (system-wide systemd allowlist for the persistence check)"
+    echo "  installed: /etc/archcanary/bpftool_allowlist.conf (system-wide bpftool allowlist for the eBPF loader check)"
     echo "  installed: /usr/share/polkit-1/actions/org.archcanary.policy"
 
     # Seed Lynis custom profile (only if lynis is installed and file not yet present)

--- a/tests/run_matching_tests.sh
+++ b/tests/run_matching_tests.sh
@@ -522,6 +522,71 @@ test_check_kmod() {
 }
 
 # ---------------------------------------------------------------------------
+# Test 14: check_bpftool — unknown LSM loader detection + allowlist
+# ---------------------------------------------------------------------------
+test_check_bpftool_allowlist() {
+    local base_args=(
+        --package-list="$SCRIPT_DIR/fake_package_lists/simple.txt"
+        --malicious-npm-list="$SCRIPT_DIR/fake_npm_lists/malicious_npm.txt"
+        --check-bpftool --no-notify
+    )
+    local out rc=0
+
+    # A real, long-running, non-pacman-owned binary so /proc/<pid>/exe
+    # resolves to something `pacman -Qo` genuinely doesn't own.
+    local tmpdir loader_bin loader_pid
+    tmpdir=$(mktemp -d)
+    loader_bin="$tmpdir/test-loader"
+    cp "$(command -v sleep)" "$loader_bin"
+    "$loader_bin" 30 &
+    loader_pid=$!
+    sleep 0.3
+
+    local fake_bpftool
+    fake_bpftool=$(mktemp)
+    cat > "$fake_bpftool" <<SCRIPT
+#!/bin/sh
+if [ "\$1" = "prog" ]; then
+  cat <<PROGS
+5: lsm  name my_hook  tag 1234567890abcdef  gpl
+        loaded_at 2026-07-03T12:00:00+0200  uid 0
+        xlated 100B  jited 100B  memlock 4096B
+        pids test-loader($loader_pid)
+PROGS
+fi
+SCRIPT
+    chmod +x "$fake_bpftool"
+
+    # Sub-test A: unknown non-pacman LSM loader, no allowlist → WARNING (exit 1)
+    rc=0
+    out=$(BPFTOOL_CMD="$fake_bpftool" \
+        "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
+    if [[ $rc -eq 1 && "$out" == *"WARNING"* && "$out" == *"test-loader"* ]]; then
+        pass "check_bpftool: unknown lsm loader → WARNING (exit 1)"
+    else
+        fail "check_bpftool: unknown lsm loader → expected WARNING+exit1, got rc=$rc, out: $out"
+    fi
+
+    # Sub-test B: same loader, allowlisted by basename → INFO only, exit 0
+    local allow_file
+    allow_file=$(mktemp)
+    printf 'test-loader\n' > "$allow_file"
+    rc=0
+    out=$(BPFTOOL_CMD="$fake_bpftool" BPFTOOL_ALLOWLIST_FILE="$allow_file" \
+        "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
+    if [[ $rc -eq 0 && "$out" == *"allowlisted"* && "$out" != *"WARNING"* ]]; then
+        pass "check_bpftool: allowlisted lsm loader → INFO only, exit 0 (clean)"
+    else
+        fail "check_bpftool: allowlisted lsm loader → expected INFO+exit0, got rc=$rc, out: $out"
+    fi
+
+    kill "$loader_pid" 2>/dev/null || true
+    wait "$loader_pid" 2>/dev/null || true
+    rm -f "$fake_bpftool" "$allow_file"
+    rm -rf "$tmpdir"
+}
+
+# ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
 echo "=== Matching Tests ==="
@@ -566,6 +631,9 @@ test_pkgbuild_obfuscation
 
 $VERBOSE && msg "--- Test 13: check_kmod ---"
 test_check_kmod
+
+$VERBOSE && msg "--- Test 14: check_bpftool allowlist ---"
+test_check_bpftool_allowlist
 
 echo "=== Results: $PASS_COUNT PASS, $FAIL_COUNT FAIL ==="
 [[ $FAIL_COUNT -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary
- Adds a bpftool eBPF-loader allowlist (`/etc/archcanary/bpftool_allowlist.conf`, `BPFTOOL_ALLOWLIST`/`BPFTOOL_ALLOWLIST_FILE`), following the DKMS/systemd allowlist pattern from #51/#52 — chosen because `check_bpftool` has real false-positive incident history (#47, #49, #50), unlike other checks considered and deliberately left alone.
- Adds `BPFTOOL_CMD` test override (mirrors existing `LSMOD_CMD`/`DKMS_CMD`) so `check_bpftool` can be unit tested; generalizes `_systemd_allowlisted` → `_allowlist_contains`, reused by `check_kmod`'s DKMS lookup too.
- GUI consolidation: collapses the near-duplicate `edit_allowlist`/`edit_systemd_allowlist` dialogs into one generic `_edit_conf_file`, replaces their two menu rows with a single "Manage allowlists" picker (DKMS/systemd/bpftool). Further collapses "Edit audit rules"/"Edit Lynis config"/"Extra lists" (renamed "Extra malware lists") into an "Edit config" picker — each choice still calls its own distinct function since their save behavior genuinely differs (pkexec+restart auditd vs. plain copy vs. user-owned file). Menu is now 20 rows, down from 23.
- Centers all yad dialogs (`--center`) — except deliberately excludes the FIFO-backed root-scan output window, whose focus interaction with the polkit dialog is a documented, previously-oscillating regression (see code comment + xdotool loop).
- Ran a full 8-angle code review against this branch; fixed the two most severe findings: `_allowlistable_finding_present` now matches each check's specific allowlist-gated warning text instead of generic "WARNING" (bpftool/DKMS both also emit warnings with no allowlist escape hatch at all — the old code pointed users at a fix that didn't apply), and the `--center` exclusion above.
- Also fixes a stale, unrelated pre-existing test path bug (`package_list.txt` → `lists/package_list.txt`, from the #40 reorg) that was aborting the whole test suite before it ever reached the new tests.

## Test plan
- [x] `bash -n` on all changed files
- [x] New `check_bpftool` allowlist test (spawns a real non-pacman-owned binary to test loader resolution) — passing
- [x] Full test suite: 26 PASS, 1 FAIL (pre-existing, unrelated `cli_flag` failure present before this branch too)
- [x] Verified LABELS/FLAGS/NEEDS_ROOT arrays stay index-consistent (20 entries) through two rounds of menu restructuring
- [x] Manually verified `_allowlistable_finding_present`'s narrowed matching against all 6 warning-type combinations (gated vs ungated) for bpftool/DKMS/systemd
- [ ] **Not verified by execution:** the new "Edit config" picker's Save→pkexec paths for audit rules specifically (Lynis config / DKMS / systemd / bpftool allowlist paths were already click-tested working in earlier PRs this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)