### PR TITLE
fix: closing Manage allowlists / Edit config without a choice quits the GUI

### DIFF
--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -316,7 +316,7 @@ manage_allowlists() {
         "Systemd (persistence check)" \
         "bpftool (eBPF loaders)" \
         --button="Edit:0" --button="Close:1" \
-        --print-column=1 2>/dev/null) || return
+        --print-column=1 2>/dev/null) || return 0
     choice="${choice%|}"
     case "$choice" in
         "DKMS"*)    _edit_conf_file "DKMS Allowlist"    /etc/archcanary/dkms_allowlist.conf ;;
@@ -347,7 +347,7 @@ edit_config() {
         --column="Config" \
         "${choices[@]}" \
         --button="Edit:0" --button="Close:1" \
-        --print-column=1 2>/dev/null) || return
+        --print-column=1 2>/dev/null) || return 0
     choice="${choice%|}"
     case "$choice" in
         "Audit rules")        edit_audit_rules ;;


### PR DESCRIPTION
## Summary
- Both the "Manage allowlists" and "Edit config" pickers used `choice=$(yad --list ...) || return` to handle the Close button / window-close case.
- A bare `return` inherits the exit status of the last command run — the failed `yad` call — so the function returned non-zero.
- Since `run_action()` calls these pickers as plain statements (not inside an `if`/`&&`/`||`), `set -e` treated that non-zero return as a fatal error and killed the whole `archcanary-gui` process instead of just returning to the menu.

## Test plan
- [x] Manually verified: closing "Manage allowlists" via the Close button no longer exits the GUI
- [x] Manually verified: closing "Edit config" via the window X no longer exits the GUI
- [x] Confirmed normal selection flow still works for both pickers

🤖 Generated with [Claude Code](https://claude.com/claude-code)