### PR TITLE
fix: curl/wget pipe-to-shell patterns match across newlines

### DIFF
--- a/configs/yay-init.lua
+++ b/configs/yay-init.lua
@@ -41,10 +41,10 @@ yay.create_autocmd("AURPreInstall", {
     local patterns = {
       "npm install atomic%-lockfile",   -- Atomic Arch campaign wave 1
       "bun install js%-digest",         -- wave 2
-      "curl.*|.*bash",
-      "curl.*|.*sh",
-      "wget.*|.*bash",
-      "wget.*|.*sh",
+      "curl[^\n]*|[^\n]*bash",
+      "curl[^\n]*|[^\n]*sh",
+      "wget[^\n]*|[^\n]*bash",
+      "wget[^\n]*|[^\n]*sh",
     }
 
     for _, pattern in ipairs(patterns) do


### PR DESCRIPTION
Lua patterns' `.` matches any byte including newlines, so `curl.*|.*sh` spanned the whole multi-line PKGBUILD instead of one line. Any PKGBUILD with a curl/wget in a comment plus "sh" anywhere later (squashfs, unsquashfs, a .sh launcher, etc.) tripped the block with no real pipe-to-shell present. Switching to [^\n]* keeps the match on a single line.