### PR TITLE
feat: autostart allowlist + non-PATH binary resolution fix

### DIFF
--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -250,7 +250,7 @@ _extract_infected_pkgs() {
 # check's allowlist-gated branch, not shared with its unconditional WARNINGs.
 _allowlistable_finding_present() {
     local out="$1" pair tag rest desc pattern
-    for pair in "3:systemd:WARNING" "8:bpftool:unknown process" "11:DKMS:untracked source"; do
+    for pair in "3:systemd:WARNING" "8:bpftool:unknown process" "10:Autostart:suspicious autostart entry" "11:DKMS:untracked source"; do
         tag="${pair%%:*}"
         rest="${pair#*:}"
         desc="${rest%%:*}"
@@ -309,19 +309,21 @@ manage_allowlists() {
     choice=$(yad --list \
         --title="Manage Allowlists — Archcanary" \
         --window-icon=security-high --center \
-        --width=460 --height=220 \
+        --width=460 --height=250 \
         --no-headers \
         --column="Allowlist" \
         "DKMS (kernel modules)" \
         "Systemd (persistence check)" \
         "bpftool (eBPF loaders)" \
+        "Autostart (XDG persistence check)" \
         --button="Edit:0" --button="Close:1" \
         --print-column=1 2>/dev/null) || return 0
     choice="${choice%|}"
     case "$choice" in
-        "DKMS"*)    _edit_conf_file "DKMS Allowlist"    /etc/archcanary/dkms_allowlist.conf ;;
-        "Systemd"*) _edit_conf_file "Systemd Allowlist" /etc/archcanary/systemd_allowlist.conf ;;
-        "bpftool"*) _edit_conf_file "bpftool Allowlist" /etc/archcanary/bpftool_allowlist.conf ;;
+        "DKMS"*)      _edit_conf_file "DKMS Allowlist"      /etc/archcanary/dkms_allowlist.conf ;;
+        "Systemd"*)   _edit_conf_file "Systemd Allowlist"   /etc/archcanary/systemd_allowlist.conf ;;
+        "bpftool"*)   _edit_conf_file "bpftool Allowlist"   /etc/archcanary/bpftool_allowlist.conf ;;
+        "Autostart"*) _edit_conf_file "Autostart Allowlist" /etc/archcanary/autostart_allowlist.conf ;;
     esac
 }
 

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -483,6 +483,7 @@ run_doctor() {
         _item "DKMS allowlist"                           "$(_file /etc/archcanary/dkms_allowlist.conf)"       "bash $installer_sys" "path: /etc/archcanary/dkms_allowlist.conf"
         _item "systemd allowlist"                        "$(_file /etc/archcanary/systemd_allowlist.conf)"    "bash $installer_sys" "path: /etc/archcanary/systemd_allowlist.conf"
         _item "bpftool allowlist"                        "$(_file /etc/archcanary/bpftool_allowlist.conf)"    "bash $installer_sys" "path: /etc/archcanary/bpftool_allowlist.conf"
+        _item "autostart allowlist"                      "$(_file /etc/archcanary/autostart_allowlist.conf)"  "bash $installer_sys" "path: /etc/archcanary/autostart_allowlist.conf"
         printf '\n'
     fi
 
@@ -721,6 +722,25 @@ if [[ -r "$_bpf_cfg" ]]; then    # skip if missing/unreadable (don't abort under
     done < "$_bpf_cfg"
 fi
 unset _bpf_cfg _bl
+
+# Merge the autostart allowlist into AUTOSTART_ALLOWLIST (colon-separated; the
+# env var, if set, takes precedence and is appended to). Same rationale as
+# DKMS/systemd/bpftool above — for autostart Exec= binaries that are
+# legitimately not resolvable via $PATH or a standard system prefix (e.g. a
+# package-private helper the resolution fallback still can't find, or an
+# AppImage/Flatpak export) and shouldn't trip the XDG autostart check.
+# Override the path with AUTOSTART_ALLOWLIST_FILE (used by the tests).
+AUTOSTART_ALLOWLIST="${AUTOSTART_ALLOWLIST:-}"
+_auto_cfg="${AUTOSTART_ALLOWLIST_FILE:-/etc/archcanary/autostart_allowlist.conf}"
+if [[ -r "$_auto_cfg" ]]; then    # skip if missing/unreadable (don't abort under set -e)
+    while IFS= read -r _al || [[ -n "$_al" ]]; do
+        _al="${_al%%#*}"       # strip inline comments
+        read -r _al _ <<< "$_al"  # take first token only (ignores trailing descriptions)
+        [[ -z "$_al" ]] && continue
+        AUTOSTART_ALLOWLIST="${AUTOSTART_ALLOWLIST:+${AUTOSTART_ALLOWLIST}:}${_al}"
+    done < "$_auto_cfg"
+fi
+unset _auto_cfg _al
 
 if [[ ! -f "$MALICIOUS_NPM_LIST" ]]; then
     _bundled="$(dirname "$(realpath "$0")")/lists/malicious_npm_packages.txt"
@@ -1747,6 +1767,22 @@ check_autostart() {
     # XDG autostart .desktop files
     # Flag absolute paths outside standard system prefixes; for bare names, resolve
     # via command -v and apply the same prefix check.
+    # AUTOSTART_ALLOWLIST: colon-separated list of Exec= names/basenames that
+    # are known-good but can't be resolved via $PATH or a standard prefix
+    # (e.g. an AppImage/Flatpak export, or a package-private helper the
+    # non-PATH fallback below still can't find).
+    # Example: AUTOSTART_ALLOWLIST=zeitgeist-datahub
+    local -a _autostart_allow
+    IFS=: read -ra _autostart_allow <<< "${AUTOSTART_ALLOWLIST:-}"
+    # Non-PATH dirs to search for a bare Exec= name before giving up.
+    # Many desktop packages (zeitgeist, various indicator/tray helpers) ship
+    # their autostart binary in a package-private dir like /usr/lib/<pkg>/ or
+    # /usr/libexec/ rather than on $PATH — command -v alone can't see those,
+    # producing a false "suspicious" verdict for a perfectly legitimate,
+    # pacman-owned binary. Override with AUTOSTART_LIBDIRS for testing.
+    local -a _autostart_libdirs
+    IFS=: read -ra _autostart_libdirs <<< "${AUTOSTART_LIBDIRS:-/usr/lib:/usr/libexec}"
+
     local desktop_dir="$home_dir/.config/autostart"
     if [[ -d "$desktop_dir" ]]; then
         while IFS= read -r desktop; do
@@ -1766,19 +1802,32 @@ check_autostart() {
                 else
                     local resolved
                     resolved=$(command -v "$exec_val" 2>/dev/null) || true
-                    if [[ -z "$resolved" ]]; then
-                        suspicious=true
-                    elif [[ "$resolved" != /usr/* && "$resolved" != /opt/* && \
-                            "$resolved" != /bin/* && "$resolved" != /sbin/* && \
-                            "$resolved" != /usr/local/* ]]; then
-                        suspicious=true
+                    if [[ -n "$resolved" ]]; then
+                        if [[ "$resolved" != /usr/* && "$resolved" != /opt/* && \
+                              "$resolved" != /bin/* && "$resolved" != /sbin/* && \
+                              "$resolved" != /usr/local/* ]]; then
+                            suspicious=true
+                        fi
+                    else
+                        # Not on $PATH — search the curated non-PATH system
+                        # libdirs. A hit there is trusted outright (that's
+                        # what the dir list represents); no prefix recheck.
+                        local libhit
+                        libhit=$(find "${_autostart_libdirs[@]}" -mindepth 1 -maxdepth 3 \
+                            -type f -name "$exec_val" -perm -u+x 2>/dev/null | head -1)
+                        [[ -z "$libhit" ]] && suspicious=true
                     fi
                 fi
 
                 if $suspicious; then
-                    echo "  WARNING: suspicious autostart entry: $desktop"
-                    echo "    Exec=$exec_val (outside standard system path)"
-                    found=2
+                    if _allowlist_contains "$exec_val" _autostart_allow; then
+                        echo "  INFO: autostart entry allowlisted (unresolved binary): $desktop"
+                        echo "    Exec=$exec_val"
+                    else
+                        echo "  WARNING: suspicious autostart entry: $desktop"
+                        echo "    Exec=$exec_val (outside standard system path)"
+                        found=2
+                    fi
                 fi
             done < "$desktop"
         done < <(find "$desktop_dir" -name '*.desktop' -type f 2>/dev/null)

--- a/docs/my-setup.md
+++ b/docs/my-setup.md
@@ -188,8 +188,9 @@ triggers (timer + `.path` units) are in [systemd.md](systemd.md).
 /etc/archcanary/
     ├── dkms_allowlist.conf           # DKMS allowlist
     ├── systemd_allowlist.conf        # systemd unit allowlist
-    └── bpftool_allowlist.conf        # bpftool eBPF loader allowlist
-                                       # (all three: GUI → Manage allowlists, or sudoedit directly)
+    ├── bpftool_allowlist.conf        # bpftool eBPF loader allowlist
+    └── autostart_allowlist.conf      # XDG autostart Exec= allowlist
+                                       # (all four: GUI → Manage allowlists, or sudoedit directly)
 /usr/share/polkit-1/actions/
     └── org.archcanary.policy  # polkit policy allowing GUI to call root-helper
 

--- a/install.sh
+++ b/install.sh
@@ -299,6 +299,25 @@ EOF
 EOF
         sudo chmod 644 /etc/archcanary/bpftool_allowlist.conf
     fi
+    # autostart allowlist — same rationale and seeding rules as the DKMS/
+    # systemd/bpftool allowlists above (mode 644, never clobber an existing
+    # /etc copy).
+    if [[ ! -f /etc/archcanary/autostart_allowlist.conf ]]; then
+        sudo tee /etc/archcanary/autostart_allowlist.conf >/dev/null << 'EOF'
+# Autostart Exec= names to skip during the XDG autostart check
+# (--check-autostart), system-wide allowlist. One Exec= name/basename per
+# line. Everything after # is a comment.
+# Add entries that are known-good but can't be resolved via $PATH or a
+# standard system prefix — e.g. a package-private helper binary the
+# non-PATH fallback (search of /usr/lib, /usr/libexec) still can't find, or
+# an AppImage/Flatpak export. Matched against the bare Exec= value as
+# written in the .desktop file (not a resolved path).
+#
+# Example:
+# zeitgeist-datahub  # desktop activity logging, ships in a non-PATH libdir
+EOF
+        sudo chmod 644 /etc/archcanary/autostart_allowlist.conf
+    fi
     echo "  installed: $SYSTEM_LIB/archcanary.sh"
     echo "  installed: $SYSTEM_LIB/root-helper"
     echo "  installed: $SYSTEM_LIB/lynis-custom.prf (template for /etc/lynis/custom.prf)"
@@ -306,6 +325,7 @@ EOF
     echo "  installed: /etc/archcanary/dkms_allowlist.conf (system-wide DKMS allowlist for the root scan)"
     echo "  installed: /etc/archcanary/systemd_allowlist.conf (system-wide systemd allowlist for the persistence check)"
     echo "  installed: /etc/archcanary/bpftool_allowlist.conf (system-wide bpftool allowlist for the eBPF loader check)"
+    echo "  installed: /etc/archcanary/autostart_allowlist.conf (system-wide autostart allowlist for the XDG persistence check)"
     echo "  installed: /usr/share/polkit-1/actions/org.archcanary.policy"
 
     # Seed Lynis custom profile (only if lynis is installed and file not yet present)

--- a/tests/run_matching_tests.sh
+++ b/tests/run_matching_tests.sh
@@ -405,6 +405,65 @@ test_check_autostart() {
         fail "check_autostart: empty home → expected clean, got: $out"
     fi
     rm -rf "$tmpdir"
+
+    # Sub-test E: bare Exec= name unresolvable via $PATH but found in a
+    # non-PATH libdir (simulates e.g. /usr/lib/zeitgeist/zeitgeist-datahub) → clean
+    local tmpdir2 libdir
+    tmpdir2=$(mktemp -d)
+    libdir=$(mktemp -d)
+    mkdir -p "$tmpdir2/.config/autostart" "$libdir/fakepkg"
+    cat > "$tmpdir2/.config/autostart/fakepkg.desktop" << 'DESK'
+[Desktop Entry]
+Type=Application
+Name=FakePkg
+Exec=fakepkg-helper
+DESK
+    printf '#!/bin/sh\n' > "$libdir/fakepkg/fakepkg-helper"
+    chmod +x "$libdir/fakepkg/fakepkg-helper"
+    rc=0
+    out=$(AUTOSTART_HOME="$tmpdir2" AUTOSTART_LIBDIRS="$libdir" \
+        "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
+    if [[ "$out" == *"Clean"* && "$out" != *"WARNING"* ]]; then
+        pass "check_autostart: bare Exec= resolved via non-PATH libdir fallback → clean"
+    else
+        fail "check_autostart: non-PATH fallback resolution failed, rc=$rc, out: $out"
+    fi
+    rm -rf "$tmpdir2" "$libdir"
+
+    # Sub-test F: bare Exec= name unresolvable anywhere, not allowlisted → WARNING
+    local tmpdir3
+    tmpdir3=$(mktemp -d)
+    mkdir -p "$tmpdir3/.config/autostart"
+    cat > "$tmpdir3/.config/autostart/unresolved.desktop" << 'DESK'
+[Desktop Entry]
+Type=Application
+Name=Unresolved
+Exec=totally-unresolvable-binary
+DESK
+    rc=0
+    out=$(AUTOSTART_HOME="$tmpdir3" AUTOSTART_LIBDIRS="/nonexistent-dir-xyz" \
+        "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
+    if [[ $rc -eq 2 && "$out" == *"WARNING: suspicious autostart entry"* ]]; then
+        pass "check_autostart: unresolved bare Exec=, not allowlisted → WARNING"
+    else
+        fail "check_autostart: unresolved bare Exec= regression, rc=$rc, out: $out"
+    fi
+
+    # Sub-test G: same unresolvable binary, but allowlisted → INFO only, exit 0
+    local allow_file2
+    allow_file2=$(mktemp)
+    printf 'totally-unresolvable-binary\n' > "$allow_file2"
+    rc=0
+    out=$(AUTOSTART_HOME="$tmpdir3" AUTOSTART_LIBDIRS="/nonexistent-dir-xyz" \
+        AUTOSTART_ALLOWLIST_FILE="$allow_file2" \
+        "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
+    if [[ $rc -eq 0 && "$out" == *"INFO: autostart entry allowlisted"* && "$out" != *"WARNING"* ]]; then
+        pass "check_autostart: allowlisted unresolved Exec= → INFO only, exit 0 (clean)"
+    else
+        fail "check_autostart: allowlisted unresolved Exec= → expected INFO+exit0, got rc=$rc, out: $out"
+    fi
+    rm -rf "$tmpdir3"
+    rm -f "$allow_file2"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fixes a false-positive class in `check_autostart()`: bare `Exec=` names were only resolved via `command -v` ($PATH), so package-private helper binaries (e.g. `zeitgeist-datahub` living in `/usr/lib/zeitgeist/`) got flagged as suspicious persistence even though they're legitimate, pacman-owned binaries. Now falls back to searching curated non-PATH dirs (`/usr/lib`, `/usr/libexec`, overridable via `AUTOSTART_LIBDIRS`) before declaring a name unresolved.
- Adds a 4th allowlist (`/etc/archcanary/autostart_allowlist.conf`, `AUTOSTART_ALLOWLIST`/`AUTOSTART_ALLOWLIST_FILE`), mirroring the existing DKMS/systemd/bpftool allowlist pattern, for entries that still can't be auto-resolved.
- GUI: "Manage allowlists" picker gains an "Autostart (XDG persistence check)" row; `_allowlistable_finding_present` hint updated.
- Triggered by a real Mabox Linux user report (zeitgeist-datahub false positive).

## Test plan
- [x] `tests/run_matching_tests.sh` — 29/30 pass (1 pre-existing, unrelated `cli_flag` failure confirmed on master via `git stash`)
- [x] New sub-tests: libdir-fallback resolves → clean; unresolved+not-allowlisted → still WARNING (regression guard); unresolved+allowlisted → INFO/exit 0
- [x] Manually reproduced the reported false positive (zeitgeist-datahub bare Exec= outside $PATH) and confirmed the fix resolves it
- [x] `bash -n` syntax check on archcanary.sh, archcanary-gui.sh, install.sh

🤖 Generated with [Claude Code](https://claude.com/claude-code)