### PR TITLE
fix: escape glob metacharacters in autostart non-PATH resolution

### DIFF
--- a/archcanary.sh
+++ b/archcanary.sh
@@ -1812,9 +1812,19 @@ check_autostart() {
                         # Not on $PATH — search the curated non-PATH system
                         # libdirs. A hit there is trusted outright (that's
                         # what the dir list represents); no prefix recheck.
+                        # find(1) -name treats its argument as a glob, not a
+                        # literal string — escape */?/[/] and backslash so an
+                        # attacker-controlled Exec=* (or similar) can't match
+                        # an arbitrary executable and bypass this check.
+                        local exec_glob_safe="$exec_val"
+                        exec_glob_safe="${exec_glob_safe//\\/\\\\}"
+                        exec_glob_safe="${exec_glob_safe//\*/\\*}"
+                        exec_glob_safe="${exec_glob_safe//\?/\\?}"
+                        exec_glob_safe="${exec_glob_safe//\[/\\[}"
+                        exec_glob_safe="${exec_glob_safe//\]/\\]}"
                         local libhit
                         libhit=$(find "${_autostart_libdirs[@]}" -mindepth 1 -maxdepth 3 \
-                            -type f -name "$exec_val" -perm -u+x 2>/dev/null | head -1)
+                            -type f -name "$exec_glob_safe" -perm -u+x 2>/dev/null | head -1)
                         [[ -z "$libhit" ]] && suspicious=true
                     fi
                 fi

--- a/tests/run_matching_tests.sh
+++ b/tests/run_matching_tests.sh
@@ -464,6 +464,33 @@ DESK
     fi
     rm -rf "$tmpdir3"
     rm -f "$allow_file2"
+
+    # Sub-test H: glob metacharacters in Exec= must not act as a find(1)
+    # wildcard — a literal "*" must not match an unrelated executable in the
+    # libdir and silently bypass the check (regression test for the
+    # glob-injection fix: find -name treats its argument as a pattern unless
+    # escaped, so an unescaped "*" would match the first executable found).
+    local tmpdir4 libdir2
+    tmpdir4=$(mktemp -d)
+    libdir2=$(mktemp -d)
+    mkdir -p "$tmpdir4/.config/autostart" "$libdir2/somepkg"
+    printf '#!/bin/sh\n' > "$libdir2/somepkg/some-real-helper"
+    chmod +x "$libdir2/somepkg/some-real-helper"
+    cat > "$tmpdir4/.config/autostart/glob.desktop" << 'DESK'
+[Desktop Entry]
+Type=Application
+Name=GlobAttempt
+Exec=*
+DESK
+    rc=0
+    out=$(AUTOSTART_HOME="$tmpdir4" AUTOSTART_LIBDIRS="$libdir2" \
+        "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
+    if [[ $rc -eq 2 && "$out" == *"WARNING: suspicious autostart entry"* ]]; then
+        pass "check_autostart: glob metacharacter Exec=* does not bypass via find wildcard match"
+    else
+        fail "check_autostart: glob-injection regression — Exec=* should still WARNING, got rc=$rc, out: $out"
+    fi
+    rm -rf "$tmpdir4" "$libdir2"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- PR #58's non-PATH libdir fallback in `check_autostart()` passed the raw `Exec=` token into `find -name`, which treats it as an fnmatch glob rather than a literal string. An autostart entry with `Exec=*` (or containing `?`/`[`/`]`) would match the first executable file under `/usr/lib`/`/usr/libexec` and be wrongly "resolved" — a full bypass of the persistence check found during post-merge review of #58.
- Fixes it by escaping `*`, `?`, `[`, `]`, and `\` in the Exec= value before it reaches `find -name`, so matching is always literal.

## Test plan
- [x] Reproduced the bypass pre-fix: `Exec=*` in an autostart `.desktop` → `RESULT: CLEAN` (should have been flagged)
- [x] Confirmed fixed: same fixture now → `WARNING: suspicious autostart entry` (exit 2)
- [x] New regression test (`tests/run_matching_tests.sh`, check_autostart sub-test H): `Exec=*` with a real executable present in the libdir must still WARNING, not match the wildcard
- [x] Full suite: 30/31 pass (1 pre-existing, unrelated `cli_flag` failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)