### PR TITLE
fix: notify-send fails silently under Openbox and root scans

### DIFF
--- a/archcanary.sh
+++ b/archcanary.sh
@@ -2349,6 +2349,26 @@ printf '%s============================================================%s\n' "$_C
 
 if [[ $EXIT_CODE -eq 2 ]] && ! $NO_NOTIFY; then
     if command -v notify-send &>/dev/null; then
+        # Some terminals (Openbox, launch-from-menu) don't inherit
+        # DBUS_SESSION_BUS_ADDRESS, and a root scan (sudo archcanary --full)
+        # has no session bus of its own at all — same SUDO_USER pattern used
+        # elsewhere (check_autostart's home-dir resolution, log ownership
+        # around line 612). Without this, notify-send falls back to spawning
+        # dbus-launch --autolaunch, which fails outright in both contexts and
+        # prints "Failed to show notification" instead of popping up.
+        _notify_runner=()
+        _notify_uid="$EUID"
+        if [[ $EUID -eq 0 && -n "${SUDO_USER:-}" && "$SUDO_USER" != "root" ]]; then
+            _notify_uid=$(id -u "$SUDO_USER" 2>/dev/null) || _notify_uid=""
+            if [[ -n "$_notify_uid" && -S "/run/user/$_notify_uid/bus" ]]; then
+                _notify_runner=(sudo -u "$SUDO_USER" env "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$_notify_uid/bus")
+            fi
+        elif [[ -z "${DBUS_SESSION_BUS_ADDRESS:-}" ]]; then
+            _notify_xrd="/run/user/$_notify_uid"
+            [[ -S "$_notify_xrd/bus" ]] && export DBUS_SESSION_BUS_ADDRESS="unix:path=$_notify_xrd/bus"
+            unset _notify_xrd
+        fi
+        unset _notify_uid
         # Only checks [1]/[2] (currently-installed / historically-installed foreign
         # packages) confirm an actual malicious package. Other checks at this exit
         # code (systemd, ebpf, autostart, etc.) flag suspicious artifacts, not
@@ -2360,9 +2380,10 @@ if [[ $EXIT_CODE -eq 2 ]] && ! $NO_NOTIFY; then
                     [[ "${_SUMMARY_CODES[$_i]}" -eq 2 ]] && _notify_title="archcanary: malicious package detected" ;;
             esac
         done
-        notify-send -u critical -i dialog-warning \
+        "${_notify_runner[@]}" notify-send -u critical -i dialog-warning \
             "$_notify_title" \
             "Indicators found. Open Archcanary to review."
+        unset _notify_runner
     fi
 fi
 

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -2357,18 +2357,22 @@ if [[ $EXIT_CODE -eq 2 ]] && ! $NO_NOTIFY; then
         # dbus-launch --autolaunch, which fails outright in both contexts and
         # prints "Failed to show notification" instead of popping up.
         _notify_runner=()
-        _notify_uid="$EUID"
         if [[ $EUID -eq 0 && -n "${SUDO_USER:-}" && "$SUDO_USER" != "root" ]]; then
             _notify_uid=$(id -u "$SUDO_USER" 2>/dev/null) || _notify_uid=""
             if [[ -n "$_notify_uid" && -S "/run/user/$_notify_uid/bus" ]]; then
                 _notify_runner=(sudo -u "$SUDO_USER" env "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$_notify_uid/bus")
             fi
-        elif [[ -z "${DBUS_SESSION_BUS_ADDRESS:-}" ]]; then
-            _notify_xrd="/run/user/$_notify_uid"
+            unset _notify_uid
+        fi
+        # No SUDO_USER-targeted runner (not root, or the invoking user has no
+        # active session/runtime dir, or a systemd-timer root scan where
+        # SUDO_USER is unset) — fall back to our own uid's socket rather than
+        # leaving DBUS_SESSION_BUS_ADDRESS unset outright.
+        if [[ ${#_notify_runner[@]} -eq 0 && -z "${DBUS_SESSION_BUS_ADDRESS:-}" ]]; then
+            _notify_xrd="/run/user/$EUID"
             [[ -S "$_notify_xrd/bus" ]] && export DBUS_SESSION_BUS_ADDRESS="unix:path=$_notify_xrd/bus"
             unset _notify_xrd
         fi
-        unset _notify_uid
         # Only checks [1]/[2] (currently-installed / historically-installed foreign
         # packages) confirm an actual malicious package. Other checks at this exit
         # code (systemd, ebpf, autostart, etc.) flag suspicious artifacts, not


### PR DESCRIPTION
## Summary
Reported by a Mabox user's scan output: `Failed to show notification: Error spawning command line "dbus-launch --autolaunch=<id> --binary-syntax --close-stderr": Child process exited with code 1`.

`notify-send` (called at `archcanary.sh:2350` on an INFECTED result) needs `DBUS_SESSION_BUS_ADDRESS` to reach the session bus. Two contexts archcanary regularly runs in don't have it:
- Some terminals (Openbox, launch-from-menu) don't inherit the var even though the user's own session bus exists — already documented/handled for the `--doctor` systemd check (`_unit()`) but never applied to the actual `notify-send` call.
- A root scan (`sudo archcanary --full`) has no session bus of its own at all — root isn't in a graphical session.

Without the address, `notify-send` falls back to spawning `dbus-launch --autolaunch`, which fails outright in both contexts and prints the error above instead of popping up.

## Fix
- Non-root: fall back to the well-known socket at `/run/user/<uid>/bus`, same pattern already used by `_unit()`'s doctor check.
- Root: resolve the invoking user via `SUDO_USER` (same pattern already used by `check_autostart`'s home-dir resolution and log-ownership handling) and run `notify-send` as that user against their own session bus, via `sudo -u "$SUDO_USER" env DBUS_SESSION_BUS_ADDRESS=... notify-send ...`.
- Gracefully falls through to the old behavior (no crash) if the resolved socket doesn't exist in either case.

## Test plan
- [x] Reproduced the exact reported error in isolation (`notify-send` with no session bus reachable — simulated via `XDG_RUNTIME_DIR=/run/user/0`)
- [x] Verified the non-root libdir/env fallback resolves and sets the address correctly
- [x] Verified the root/`SUDO_USER` branch resolves the correct uid and builds the right `sudo -u ... env ...` invocation, including graceful fallback when the target socket doesn't exist
- [x] Full end-to-end run (real environment) still completes cleanly with no dbus error
- [x] Full suite: 30/31 pass (1 pre-existing, unrelated `cli_flag` failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)