### PR TITLE
docs: fix PostInstall hook ordering in overview.md diagram

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -14,12 +14,15 @@ flowchart TD
     end
 
     subgraph AT["2 · AT install — automatic"]
-        U["yay -S pkg / yay -Syu / yay &lt;term&gt;"] --> GATE["aurscan editor-gate<br/>static rules + Claude LLM"]
+        U["yay -S pkg / yay -Syu / yay &lt;term&gt;"] --> SEL["UpgradeSelect<br/>age warn"]
+        SEL --> GATE["aurscan editor-gate<br/>static rules + Claude LLM"]
         GATE -->|non-CLEAN| AB["build / install aborted"]
-        GATE -->|CLEAN| LUA["yay init.lua hooks<br/>age warn · pattern block · log"]
-        LUA --> TH["traur pacman hook<br/>trust score · AbortOnFail"]
+        GATE -->|CLEAN| PRI["AURPreInstall<br/>pattern block"]
+        PRI -->|blocked| AB
+        PRI -->|OK| TH["traur pacman hook<br/>trust score · AbortOnFail"]
         TH -->|low trust| AB
-        TH -->|OK| OK["package installed"]
+        TH -->|OK| POST["PostInstall<br/>log AUR installs"]
+        POST --> OK["package installed"]
     end
 
     subgraph AFTER["3 · AFTER install / always — automatic, root"]


### PR DESCRIPTION
## Summary
While checking `docs/overview.md`'s detection-layers diagram for consistency with `README.md`'s (which was missing the `traur` layer entirely, fixed separately), found a real sequencing inaccuracy: the mermaid diagram bundled all three yay `init.lua` hooks (`UpgradeSelect`, `AURPreInstall`, `PostInstall`) into one node placed entirely *before* traur's pacman hook.

Per `configs/yay-init.lua:59-67`, `PostInstall`'s callback logs `event.data.packages` as **already installed** — it fires after the real pacman transaction completes, which is *after* traur's `PreTransaction` hook, not before it.

## Fix
Split the bundled `LUA` node into three chronologically correct points:
- `UpgradeSelect` — before the build starts (package selection)
- `AURPreInstall` — before the pacman transaction (pattern block)
- `PostInstall` — moved after traur's hook (`TH`), since it only fires post-transaction

## Test plan
- [x] Manual review of `configs/yay-init.lua` hook callbacks to confirm actual firing semantics
- [x] Verified mermaid node IDs are unique, no dangling edges
- Documentation-only change, no code/test impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)