### PR TITLE
docs: de-duplicate yay editor-gate/lua-hooks explanation

### DIFF
--- a/docs/my-setup.md
+++ b/docs/my-setup.md
@@ -72,19 +72,8 @@ traur — runs three ways:
           the GUI has no package name input
 
 yay install/upgrade  (yay -S <pkg>, yay -Syu, bare yay <term>)  — transparent, no alias
-    └── yay invokes its editor on each AUR PKGBUILD before building
-            ├── editor = aurscan-gate   (config.json editor= + editmenu=true)
-            │       └── aurscan-gate → aurscan-edit  (EDITOR/VISUAL cleared, gate-only)
-            │               ├── offline static rules — known campaign signatures
-            │               ├── Claude LLM reads the PKGBUILD — novel / obfuscated patterns
-            │               └── non-CLEAN → exit non-zero → yay aborts the build
-            │                              CLEAN → build proceeds (no manual editor opens)
-            └── yay 13.0 init.lua hooks (~/.config/yay/init.lua) — independent offline layer
-                    ├── UpgradeSelect  — warn if PKGBUILD modified < 3 days ago
-                    ├── AURPreInstall  — abort on malicious patterns
-                    │                    (npm atomic-lockfile, bun js-digest,
-                    │                     curl|bash / wget|sh download-exec)
-                    └── PostInstall    — log AUR installs (name + version)
+    └── editor-gate (aurscan / Claude) + yay init.lua hooks fire on every build
+            — see "yay 13.0 integration" below for the full breakdown
 
 standalone aurscan (manual — audit without installing)
     ├── aurscan <pkg>            — scan a single package


### PR DESCRIPTION
## Summary
`docs/my-setup.md`'s "How the pieces connect" ASCII tree and its dedicated "## yay 13.0 integration" section both explained the editor-gate and all three yay lua hooks (`UpgradeSelect`, `AURPreInstall`, `PostInstall`) in comparable detail — same facts, two places.

Collapsed the tree's `yay install/upgrade` entry to a one-line summary that points at "yay 13.0 integration", which stays the single canonical explanation (table + exact bash one-liner).

**Note:** this exact change was already written and pushed to PR #62's branch before it was merged, but GitHub's squash-merge for that PR only picked up the first of its two commits — this fix never actually landed on `master`. Reapplying it standalone here, step 1 of working through the doc-duplication findings from this session (this is finding "C" from that review — the my-setup.md-internal one; the two bigger structural findings — README vs overview.md's duplicated lifecycle diagram, and README vs my-setup.md's duplicated components table — are still open follow-ups).

## Test plan
- [x] Diff verified identical to the previously-pushed (but lost) commit
- [x] Full test suite: 30/31 pass (1 pre-existing, unrelated `cli_flag` failure)
- Documentation-only change, no code/test impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)