### PR TITLE
fix: add --version/-V flag

### DIFF
--- a/archcanary.sh
+++ b/archcanary.sh
@@ -126,6 +126,10 @@ for arg in "$@"; do
         --doctor)                DOCTOR=true ;;
         --doctor=*)              DOCTOR=true; DOCTOR_SECTIONS="${arg#*=}" ;;
         --run-lynis)             RUN_LYNIS=true ;;
+        --version|-V)
+            echo "Archcanary v${SCRIPT_VERSION}"
+            exit 0
+            ;;
         --help|-h)
             echo "Usage: $0 [OPTIONS]"
             echo "Options:"
@@ -164,6 +168,7 @@ for arg in "$@"; do
             echo "                            (tool names like aurscan/traur/yad also map to a section)"
             echo "                            Comma- or space-separated, e.g.:"
             echo "                            --doctor=user,system   --doctor user system   --doctor=deps"
+            echo "  --version, -V             Show version and exit"
             echo "  --help, -h                Show this help"
             exit 0
             ;;

--- a/man/archcanary.1
+++ b/man/archcanary.1
@@ -173,6 +173,9 @@ Tool names
 .RB ( aurscan ", " traur ", " yad \&...)
 are also accepted.
 .TP
+.B \-\-version ", " \-V
+Print the version and exit.
+.TP
 .B \-\-help ", " \-h
 Print a short usage summary and exit.
 .SH EXIT STATUS


### PR DESCRIPTION
## Summary
- `archcanary` had no `--version`/`-V` handling, so it silently fell through to a full default scan instead of printing the version — surprising a user who ran `archcanary --version` expecting standard CLI behavior.
- Adds `--version`/`-V` (`-v` stays `--verbose`, unchanged) that prints `Archcanary v${SCRIPT_VERSION}` and exits 0, mirroring the existing `--help` early-exit pattern.
- Updates `--help` usage text and the man page accordingly.

## Test plan
- [x] `./archcanary.sh --version` prints version, exits 0
- [x] `./archcanary.sh -V` prints version, exits 0
- [x] `./archcanary.sh --verbose --help` still works (confirms `-v`/verbose untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)