### PR TITLE
fix: chown root-owned log/config files back to invoking user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix: `sudo archcanary ...` and GUI root scans (pkexec) left their log file — and, via the same `_chown_to_invoker` gap, the package-list cache and config-editor writes — owned by root inside the invoking user's `~/.cache`/`~/.config`. `_chown_to_invoker` only checked `SUDO_USER`, so the pkexec path (`PKEXEC_UID` only) was a silent no-op, and `LOG_FILE` itself was never passed through it at all. Users upgrading should run `sudo chown $USER:$USER ~/.cache/archcanary/*.log` once to clean up logs left behind by earlier versions.
+
 ## v0.1.11 (2026-07-12)
 
 - New: **autostart allowlist** (`/etc/archcanary/autostart_allowlist.conf`) — mirrors the DKMS/systemd/bpftool allowlists for `check_autostart` entries that can't be auto-resolved. `check_autostart` also gained a non-PATH fallback (searches `/usr/lib`, `/usr/libexec`) before flagging a bare `Exec=` name as suspicious, fixing false positives for package-private helper binaries (e.g. `zeitgeist-datahub`) that never sit on `$PATH`.

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -627,11 +627,19 @@ if [[ $EUID -eq 0 ]]; then
     unset _invoker_home
 fi
 
-# When running under sudo, chown a written file back to the invoking user so
-# that user-space config files are not left owned by root.
+# When running under sudo or pkexec, chown a written file back to the invoking
+# user so that user-space config/log files are not left owned by root. Mirrors
+# the SUDO_USER/PKEXEC_UID resolution used for _invoker_home above — the
+# pkexec root-helper execs straight into this script with no code path of its
+# own left to fix ownership afterward.
 _chown_to_invoker() {
-    [[ $EUID -eq 0 && -n "${SUDO_USER:-}" && "$SUDO_USER" != "root" ]] \
-        && chown "$SUDO_USER" "$1" 2>/dev/null || true
+    [[ $EUID -ne 0 ]] && return 0
+    if [[ -n "${SUDO_USER:-}" && "$SUDO_USER" != "root" ]]; then
+        chown "$SUDO_USER" "$1" 2>/dev/null
+    elif [[ -n "${PKEXEC_UID:-}" ]]; then
+        chown "$PKEXEC_UID" "$1" 2>/dev/null
+    fi
+    return 0
 }
 
 # systemd *system* services (and some cron contexts) start with no $HOME, which
@@ -2395,5 +2403,9 @@ if [[ $EXIT_CODE -eq 2 ]] && ! $NO_NOTIFY; then
         unset _notify_runner
     fi
 fi
+
+# Log was created while running as root (sudo/pkexec) but lives under the
+# invoking user's ~/.cache — hand it back so it isn't left root-owned there.
+_chown_to_invoker "$LOG_FILE"
 
 exit "$EXIT_CODE"


### PR DESCRIPTION
## Summary
- `sudo archcanary ...` and GUI root scans (pkexec) correctly resolve `HOME`/`XDG_CACHE_HOME` to the invoking user, so files land under `~/.cache`/`~/.config`, but they were still created by root and never handed back.
- `_chown_to_invoker()` only checked `SUDO_USER`, so the pkexec path (`PKEXEC_UID` only, no `SUDO_USER`) was a silent no-op — the GUI's "run as root" checks always left files root-owned.
- `LOG_FILE` was never passed through `_chown_to_invoker` at all, even on the `SUDO_USER` path.
- Fixes both: `_chown_to_invoker` now handles `PKEXEC_UID` as well as `SUDO_USER`, and is called on `LOG_FILE` before exit.
- Changelog entry added under Unreleased, including the one-time cleanup command (`sudo chown $USER:$USER ~/.cache/archcanary/*.log`) existing users need for logs left behind by earlier versions.

## Test plan
- [x] `bash -n archcanary.sh` — syntax check passes
- [ ] Manual: `sudo ./archcanary.sh --full` then confirm the resulting log under `~/.cache/archcanary/` is owned by the invoking user, not root
- [ ] Manual: GUI "run root checks" (pkexec) path, same ownership check

🤖 Generated with [Claude Code](https://claude.com/claude-code)