### PR TITLE
fix: restore group-reset and pkexec chown fixes dropped by early merge

### DIFF
--- a/archcanary.sh
+++ b/archcanary.sh
@@ -635,9 +635,9 @@ fi
 _chown_to_invoker() {
     [[ $EUID -ne 0 ]] && return 0
     if [[ -n "${SUDO_USER:-}" && "$SUDO_USER" != "root" ]]; then
-        chown "$SUDO_USER" "$1" 2>/dev/null
+        chown "$SUDO_USER": "$1" 2>/dev/null
     elif [[ -n "${PKEXEC_UID:-}" ]]; then
-        chown "$PKEXEC_UID" "$1" 2>/dev/null
+        chown "$PKEXEC_UID": "$1" 2>/dev/null
     fi
     return 0
 }

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -634,11 +634,15 @@ fi
 # own left to fix ownership afterward.
 _chown_to_invoker() {
     [[ $EUID -ne 0 ]] && return 0
+    local _invoker=""
     if [[ -n "${SUDO_USER:-}" && "$SUDO_USER" != "root" ]]; then
-        chown "$SUDO_USER": "$1" 2>/dev/null
+        _invoker="$SUDO_USER"
     elif [[ -n "${PKEXEC_UID:-}" ]]; then
-        chown "$PKEXEC_UID": "$1" 2>/dev/null
+        # chown rejects a bare numeric "UID:" spec ("invalid spec") — resolve
+        # to the login name first so the trailing-colon group reset works.
+        _invoker="$(getent passwd "$PKEXEC_UID" | cut -d: -f1)"
     fi
+    [[ -n "$_invoker" ]] && chown "$_invoker": "$1" 2>/dev/null
     return 0
 }
 


### PR DESCRIPTION
## Summary
PR #66 was squash-merged before its last two follow-up commits landed on the branch, so `master` currently has the incomplete version of the chown fix. This PR carries the two missing commits forward (cherry-picked, verified clean apply + `bash -n`):

- `_chown_to_invoker` now resets group too (`chown USER: FILE`), not just owner — manual `sudo` test showed the log stayed group `root` otherwise.
- The `PKEXEC_UID` branch is resolved to a login name via `getent passwd` before chowning — `chown "$PKEXEC_UID": file` (bare numeric UID + trailing colon) fails outright with `chown: invalid spec: '1000:'`, silently swallowed by the existing `2>/dev/null`, so the pkexec path was a complete no-op until this fix. Confirmed by manual `pkexec` test showing `root:root` before, `vogel:vogel` after.

## Test plan
- [x] `bash -n archcanary.sh`
- [x] Manual `sudo ./archcanary.sh --check-npm-cache --no-notify` — new log is `vogel:vogel`
- [x] Manual `pkexec ./archcanary.sh --check-npm-cache --no-notify` — new log is `vogel:vogel`

🤖 Generated with [Claude Code](https://claude.com/claude-code)