### PR TITLE
fix: honor Hidden=true / X-GNOME-Autostart-enabled=false in autostart…

### DIFF
--- a/archcanary.sh
+++ b/archcanary.sh
@@ -1829,6 +1829,15 @@ check_autostart() {
     local desktop_dir="$home_dir/.config/autostart"
     if [[ -d "$desktop_dir" ]]; then
         while IFS= read -r desktop; do
+            # Hidden=true / X-GNOME-Autostart-enabled=false is how DE autostart
+            # managers (incl. Mabox's) disable an entry without deleting the
+            # file — per the XDG spec, it must be treated as if the file does
+            # not exist. Such an entry can never actually execute, so there is
+            # nothing to warn about regardless of whether Exec= resolves.
+            if grep -qE '^[[:space:]]*Hidden[[:space:]]*=[[:space:]]*true[[:space:]]*$' "$desktop" 2>/dev/null || \
+               grep -qE '^[[:space:]]*X-GNOME-Autostart-enabled[[:space:]]*=[[:space:]]*false[[:space:]]*$' "$desktop" 2>/dev/null; then
+                continue
+            fi
             while IFS= read -r line; do
                 [[ "$line" =~ ^Exec= ]] || continue
                 local exec_val="${line#Exec=}"

--- a/tests/run_matching_tests.sh
+++ b/tests/run_matching_tests.sh
@@ -491,6 +491,51 @@ DESK
         fail "check_autostart: glob-injection regression — Exec=* should still WARNING, got rc=$rc, out: $out"
     fi
     rm -rf "$tmpdir4" "$libdir2"
+
+    # Sub-test I: Hidden=true entry with an unresolvable Exec= must NOT warn —
+    # per the XDG spec this is how DE autostart managers (Mabox included)
+    # disable an entry without deleting the file; it can never execute, so
+    # there is nothing to flag regardless of whether Exec= resolves.
+    local tmpdir5
+    tmpdir5=$(mktemp -d)
+    mkdir -p "$tmpdir5/.config/autostart"
+    cat > "$tmpdir5/.config/autostart/hidden.desktop" << 'DESK'
+[Desktop Entry]
+Type=Application
+Name=Hidden
+Exec=totally-unresolvable-binary
+Hidden=true
+DESK
+    rc=0
+    out=$(AUTOSTART_HOME="$tmpdir5" AUTOSTART_LIBDIRS="/nonexistent-dir-xyz" \
+        "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
+    if [[ "$out" == *"Clean"* && "$out" != *"WARNING"* ]]; then
+        pass "check_autostart: Hidden=true entry skipped even with unresolvable Exec="
+    else
+        fail "check_autostart: Hidden=true entry should be skipped, rc=$rc, out: $out"
+    fi
+    rm -rf "$tmpdir5"
+
+    # Sub-test J: X-GNOME-Autostart-enabled=false behaves the same as Hidden=true
+    local tmpdir6
+    tmpdir6=$(mktemp -d)
+    mkdir -p "$tmpdir6/.config/autostart"
+    cat > "$tmpdir6/.config/autostart/gnome-disabled.desktop" << 'DESK'
+[Desktop Entry]
+Type=Application
+Name=GnomeDisabled
+Exec=totally-unresolvable-binary
+X-GNOME-Autostart-enabled=false
+DESK
+    rc=0
+    out=$(AUTOSTART_HOME="$tmpdir6" AUTOSTART_LIBDIRS="/nonexistent-dir-xyz" \
+        "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
+    if [[ "$out" == *"Clean"* && "$out" != *"WARNING"* ]]; then
+        pass "check_autostart: X-GNOME-Autostart-enabled=false entry skipped"
+    else
+        fail "check_autostart: X-GNOME-Autostart-enabled=false should be skipped, rc=$rc, out: $out"
+    fi
+    rm -rf "$tmpdir6"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
… check

DE autostart managers (Mabox's included) disable an entry by writing Hidden=true rather than deleting the .desktop file — per the XDG spec this must be treated as if the file doesn't exist. check_autostart() never looked at this key, so disabled entries whose Exec= happened to be unresolvable (binary genuinely not installed) were flagged as suspicious persistence even though they can never actually execute.