### PR TITLE
fix: guard About dialog against set -e killing the GUI

### DIFF
--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -448,7 +448,8 @@ Security scanner for Arch Linux — detects malicious packages,
 suspicious systemd units, eBPF backdoors, rogue kernel modules,
 and more.
 
-Source: <a href=\"${repo}\">${repo}</a>"
+Source: <a href=\"${repo}\">${repo}</a>" \
+        2>/dev/null || true
 }
 
 aurscan_settings() {


### PR DESCRIPTION
## Summary
- `show_about()` in `archcanary-gui.sh` called `yad --info` without a `2>/dev/null || true` guard, unlike every other `yad` call in the file.
- With `set -euo pipefail` active, dismissing the About dialog any way other than clicking "Close" (window-manager X, Escape) made `yad` return non-zero, tripping `set -e` and killing the entire GUI process instead of just the dialog.

## Fix
Add the same `2>/dev/null || true` guard used elsewhere in the file.

## Test plan
- [x] `bash -n archcanary-gui.sh`
- [ ] Manually open GUI → About → close via window X → GUI stays open

🤖 Generated with [Claude Code](https://claude.com/claude-code)