### PR TITLE
fix: /usr/lib/archcanary created with umask-dependent perms, not 755

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -223,7 +223,7 @@ if $SYSTEM; then
     echo
     echo "Installing system components (requires root)..."
     SYSTEM_LIB="/usr/lib/archcanary"
-    sudo mkdir -p "$SYSTEM_LIB"
+    sudo install -d -m 755 "$SYSTEM_LIB"
     sudo cp "$REPO_DIR/archcanary.sh" "$SYSTEM_LIB/archcanary.sh"
     sudo chmod 755 "$SYSTEM_LIB/archcanary.sh"
     sudo cp "$REPO_DIR/lib/archcanary-root-helper" "$SYSTEM_LIB/root-helper"


### PR DESCRIPTION
## Summary
- `--system` created `/usr/lib/archcanary` with `sudo mkdir -p` and no explicit mode, so its permissions came from the invoking sudo shell's umask rather than a fixed value.
- On a system with a stricter umask (e.g. `027`), this produced `0750 root:root` — no "other" execute bit — so a regular user can't even traverse into the directory to `stat`/`-x` test `root-helper`, let alone run it via `pkexec`.
- Result: `archcanary-gui`'s `HAS_ROOT` check (`-x "$ROOT_HELPER"`) silently fails and the GUI reports "root helper not installed" even after a successful `./install.sh --system`.

## Fix
Every other directory this script creates already uses `install -d -m 755`; `$SYSTEM_LIB` was the one holdout using bare `mkdir -p`. Switched to `sudo install -d -m 755 "$SYSTEM_LIB"`.

`install -d` also fixes the mode on an already-existing directory (verified), so re-running `--system` self-heals machines already affected — no manual `chmod` needed after upgrading, though `sudo chmod 755 /usr/lib/archcanary` unblocks immediately without a reinstall.

## Test plan
- [x] `bash -n install.sh`
- [x] Verified `install -d -m 755` corrects an existing directory's mode regardless of prior permissions/umask

🤖 Generated with [Claude Code](https://claude.com/claude-code)