### PR TITLE
fix: SCRIPT_VERSION drifted from version.txt, showing stale -V/About

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix: `archcanary -V`/`--version` and the GUI's About dialog reported a stale version after upgrading — `archcanary.sh` carried its own hardcoded `SCRIPT_VERSION`, separate from `version.txt`, and the v0.1.12 bump only updated `version.txt`. `install.sh` now stamps the real version from `version.txt` into every installed copy of `archcanary.sh` (user bin, system bin, and `/usr/lib/archcanary`) at install time, making `version.txt` the actual single source of truth; running the script unstamped straight from a git checkout falls back to reading the sibling `version.txt` directly. The GUI's About dialog now calls `archcanary --version` instead of grepping the script's source for `SCRIPT_VERSION=`.
+
 ## v0.1.12 (2026-07-13)
 
 - Fix: `sudo archcanary ...` and GUI root scans (pkexec) left their log file — and, via the same `_chown_to_invoker` gap, the package-list cache and config-editor writes — owned by root inside the invoking user's `~/.cache`/`~/.config`. `_chown_to_invoker` only checked `SUDO_USER`, so the pkexec path (`PKEXEC_UID` only) was a silent no-op, and `LOG_FILE` itself was never passed through it at all. Also fixed: the chown only reset owner, not group (`chown user:` now resets both), and the `PKEXEC_UID` branch resolves to a login name via `getent passwd` first since `chown` rejects a bare numeric `UID:` spec outright (`invalid spec`). Users upgrading should run `sudo chown $USER:$USER ~/.cache/archcanary/*.log` once to clean up logs left behind by earlier versions.

--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -435,7 +435,7 @@ edit_lynis_config() {
 
 show_about() {
     local version repo="https://github.com/musqz/archcanary"
-    version=$(grep -oP '(?<=SCRIPT_VERSION=")[^"]+' "$MAIN_SCRIPT" 2>/dev/null || echo "unknown")
+    version=$("$MAIN_SCRIPT" --version 2>/dev/null | grep -oP '(?<=Archcanary v).+' || echo "unknown")
     yad --image=dialog-information \
         --title="About Archcanary" \
         --window-icon=security-high --center \

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -41,7 +41,15 @@
 
 set -euo pipefail
 
-SCRIPT_VERSION="0.1.11"
+SCRIPT_VERSION="@VERSION@"
+if [[ "$SCRIPT_VERSION" == *"@"* ]]; then
+    # Unstamped — running straight from a git checkout rather than an
+    # install.sh-installed copy. Fall back to the sibling version.txt.
+    # (Checked via a literal "@" rather than comparing against "@VERSION@"
+    # itself — install.sh's sed for the placeholder would otherwise also
+    # rewrite that string here and break the check on stamped copies.)
+    SCRIPT_VERSION=$(cat "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/version.txt" 2>/dev/null || echo "unknown")
+fi
 
 # ---------------------------------------------------------------------------
 # Configuration

--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,7 @@ if [[ $EUID -eq 0 ]]; then
 fi
 
 REPO_DIR="$(dirname "$(realpath "$0")")"
+_ver=$(cat "$REPO_DIR/version.txt" 2>/dev/null || echo "unknown")
 
 # Determine install dir: prefer the XDG ~/.local/bin, fall back to ~/bin
 DEFAULT_BIN=""
@@ -152,6 +153,7 @@ mkdir -p "$CONFIG_DIR"
 if $SYSTEM; then
     sudo install -m 755 "$REPO_DIR/archcanary.sh"    "$SYSTEM_BIN/archcanary"
     sudo install -m 755 "$REPO_DIR/archcanary-gui.sh" "$SYSTEM_BIN/archcanary-gui"
+    sudo sed -i "s/@VERSION@/$_ver/" "$SYSTEM_BIN/archcanary"
     echo "  installed: $SYSTEM_BIN/archcanary"
     echo "  installed: $SYSTEM_BIN/archcanary-gui"
     _removed_user=false
@@ -163,7 +165,6 @@ if $SYSTEM; then
         fi
     done
     sudo install -d -m 755 /usr/share/man/man1
-    _ver=$(cat "$REPO_DIR/version.txt" 2>/dev/null || echo "unknown")
     sed "s/@VERSION@/$_ver/" "$REPO_DIR/man/archcanary.1" \
         | sudo tee /usr/share/man/man1/archcanary.1 >/dev/null
     sudo chmod 644 /usr/share/man/man1/archcanary.1
@@ -172,6 +173,7 @@ else
     mkdir -p "$USER_BIN"
     install -m 755 "$REPO_DIR/archcanary.sh"    "$USER_BIN/archcanary"
     install -m 755 "$REPO_DIR/archcanary-gui.sh" "$USER_BIN/archcanary-gui"
+    sed -i "s/@VERSION@/$_ver/" "$USER_BIN/archcanary"
     echo "  installed: $USER_BIN/archcanary"
     echo "  installed: $USER_BIN/archcanary-gui"
     _removed_system=false
@@ -184,7 +186,6 @@ else
     done
     MAN_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/man/man1"
     mkdir -p "$MAN_DIR"
-    _ver=$(cat "$REPO_DIR/version.txt" 2>/dev/null || echo "unknown")
     sed "s/@VERSION@/$_ver/" "$REPO_DIR/man/archcanary.1" > "$MAN_DIR/archcanary.1"
     chmod 644 "$MAN_DIR/archcanary.1"
     echo "  installed: $MAN_DIR/archcanary.1"
@@ -225,6 +226,7 @@ if $SYSTEM; then
     SYSTEM_LIB="/usr/lib/archcanary"
     sudo install -d -m 755 "$SYSTEM_LIB"
     sudo cp "$REPO_DIR/archcanary.sh" "$SYSTEM_LIB/archcanary.sh"
+    sudo sed -i "s/@VERSION@/$_ver/" "$SYSTEM_LIB/archcanary.sh"
     sudo chmod 755 "$SYSTEM_LIB/archcanary.sh"
     sudo cp "$REPO_DIR/lib/archcanary-root-helper" "$SYSTEM_LIB/root-helper"
     sudo chown root:root "$SYSTEM_LIB/root-helper"


### PR DESCRIPTION
## Summary
- `archcanary.sh` carried its own hardcoded `SCRIPT_VERSION`, separate from `version.txt`; the v0.1.12 bump (`c0fe4e6`) only touched `version.txt`, so `-V`/`--version` and the GUI About dialog kept reporting v0.1.11 even after a clean uninstall/reinstall from latest git.
- `install.sh` now stamps the real version from `version.txt` into every installed copy of `archcanary.sh` (user bin, system bin, and `/usr/lib/archcanary`), making `version.txt` the actual single source of truth. Running the script unstamped straight from a git checkout falls back to reading the sibling `version.txt`.
- GUI About dialog now calls `archcanary --version` instead of grepping the script source for `SCRIPT_VERSION=`.

## Test plan
- [x] `bash archcanary.sh -V` from an unstamped checkout → falls back to `version.txt`, reports `v0.1.12`
- [x] Simulated stamped copy (`sed s/@VERSION@/9.9.9-teststamp/`) → `-V` reports the stamped value, not `unknown` (caught and fixed a sentinel-collision bug where the install-time `sed` was also rewriting the comparison line)
- [x] Real `./install.sh <scratch-dir>` (user install) → installed binary has `SCRIPT_VERSION="0.1.12"` stamped in, `-V` reports correctly
- [x] `bash -n` syntax check on all three changed shell scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)