### PR TITLE
fix: root system scan can't find bundled threat lists

### DIFF
--- a/archcanary.sh
+++ b/archcanary.sh
@@ -786,9 +786,24 @@ if [[ -r "$_auto_cfg" ]]; then    # skip if missing/unreadable (don't abort unde
 fi
 unset _auto_cfg _al
 
+# Resolves a bundled data file next to the running script. Checks the flat
+# layout first (/usr/lib/archcanary/<file> — how install.sh --system and the
+# AUR package deploy it, since root's $HOME isn't seeded) and falls back to
+# the lists/ subdir layout (repo checkout, ./archcanary.sh run in place).
+_bundled_list_path() {
+    local _dir _f
+    _dir="$(dirname "$(realpath "$0")")"
+    for _f in "$_dir/$1" "$_dir/lists/$1"; do
+        if [[ -f "$_f" ]]; then
+            printf '%s' "$_f"
+            return 0
+        fi
+    done
+    return 1
+}
+
 if [[ ! -f "$MALICIOUS_NPM_LIST" ]]; then
-    _bundled="$(dirname "$(realpath "$0")")/lists/malicious_npm_packages.txt"
-    if [[ -f "$_bundled" ]]; then
+    if _bundled="$(_bundled_list_path malicious_npm_packages.txt)"; then
         cp "$_bundled" "$MALICIOUS_NPM_LIST"
     else
         echo >&2 "ERROR: Malicious npm package list not found: $MALICIOUS_NPM_LIST"
@@ -798,13 +813,11 @@ if [[ ! -f "$MALICIOUS_NPM_LIST" ]]; then
 fi
 
 if [[ ! -f "$CHAOS_RAT_LIST" ]]; then
-    _bundled="$(dirname "$(realpath "$0")")/lists/chaos_rat_packages.txt"
-    [[ -f "$_bundled" ]] && cp "$_bundled" "$CHAOS_RAT_LIST"
+    _bundled="$(_bundled_list_path chaos_rat_packages.txt)" && cp "$_bundled" "$CHAOS_RAT_LIST"
 fi
 
 if [[ ! -f "$RUSSIAN_SPAM_LIST" ]]; then
-    _bundled="$(dirname "$(realpath "$0")")/lists/malicious_russian_spam_packages.txt"
-    [[ -f "$_bundled" ]] && cp "$_bundled" "$RUSSIAN_SPAM_LIST"
+    _bundled="$(_bundled_list_path malicious_russian_spam_packages.txt)" && cp "$_bundled" "$RUSSIAN_SPAM_LIST"
 fi
 
 if [[ ! -f "$EXTRA_LISTS_CONF" ]]; then
@@ -889,8 +902,7 @@ load_packages() {
     fi
 
     if [[ ! -f "$PACKAGE_LIST_FILE" ]]; then
-        _bundled="$(dirname "$(realpath "$0")")/lists/package_list.txt"
-        if [[ -f "$_bundled" ]]; then
+        if _bundled="$(_bundled_list_path package_list.txt)"; then
             cp "$_bundled" "$PACKAGE_LIST_FILE"
         else
             echo >&2 "ERROR: Package list not found: $PACKAGE_LIST_FILE"


### PR DESCRIPTION
## Summary
- `archcanary.service` (root system scan, triggered by `archcanary.timer` ~5min after boot) failed on every fresh `--system`/AUR install with `ERROR: Malicious npm package list not found`.
- Root cause: the repo-layout reorg (#40) updated `archcanary.sh`'s bundled-list fallback to expect a `lists/` subdir, but `install.sh --system` and the AUR `PKGBUILD` both deploy the lists flat into `/usr/lib/archcanary/`, alongside the script. Root's `$HOME` is deliberately never seeded, so there was no working fallback.
- `_bundled_list_path()` now checks the flat layout (actual installed location) first, then falls back to `lists/<file>` (repo checkout).

## Test plan
- [x] Sandboxed both layouts (flat + `lists/` subdir) locally, confirmed `--check-npm-cache` resolves cleanly in both
- [x] `tests/run_matching_tests.sh` — 33/33 PASS
- [x] Installed on a Garuda VM from this branch, rebooted, confirmed `archcanary.service` now runs successfully via the boot timer (previously failed every time)
- [x] `/ultrareview` — clean, no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)