### PR TITLE
chore: restore packaging/ to the repo

### DIFF
--- a/packaging/.SRCINFO
+++ b/packaging/.SRCINFO
@@ -1,0 +1,21 @@
+pkgbase = archcanary
+	pkgdesc = Layered security detection stack for Arch Linux — malicious AUR packages, systemd/eBPF persistence, npm/bun cache poisoning, kernel module tampering
+	pkgver = 0.1.14
+	pkgrel = 1
+	url = https://github.com/musqz/archcanary
+	install = archcanary.install
+	arch = any
+	license = MIT
+	depends = bash
+	depends = pacman
+	optdepends = yad: GTK GUI frontend (archcanary-gui)
+	optdepends = libnotify: desktop alerts on infected scan result
+	optdepends = polkit: GUI privilege escalation for root checks
+	optdepends = bpf: bpftool for eBPF rootkit detection
+	optdepends = yay: AUR helper with Lua hook support
+	optdepends = aurscan: LLM-based PKGBUILD scanner (pre-install gate)
+	backup = etc/archcanary/dkms_allowlist.conf
+	source = archcanary-0.1.14.tar.gz::https://github.com/musqz/archcanary/archive/v0.1.14.tar.gz
+	sha256sums = ca35d9680f184cc6e337fcd5ecd4634bd877d56f9a7650c257681a8375a32459
+
+pkgname = archcanary

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -1,0 +1,76 @@
+# Maintainer: musqz <gummy-fang-deputy@duck.com>
+pkgname=archcanary
+pkgver=0.1.14
+pkgrel=1
+pkgdesc="Layered security detection stack for Arch Linux — malicious AUR packages, systemd/eBPF persistence, npm/bun cache poisoning, kernel module tampering"
+arch=('any')
+url="https://github.com/musqz/archcanary"
+license=('MIT')
+depends=('bash' 'pacman')
+optdepends=(
+  'yad: GTK GUI frontend (archcanary-gui)'
+  'libnotify: desktop alerts on infected scan result'
+  'polkit: GUI privilege escalation for root checks'
+  'bpf: bpftool for eBPF rootkit detection'
+  'yay: AUR helper with Lua hook support'
+  'aurscan: LLM-based PKGBUILD scanner (pre-install gate)'
+)
+backup=('etc/archcanary/dkms_allowlist.conf')
+install=archcanary.install
+source=("$pkgname-$pkgver.tar.gz::https://github.com/musqz/$pkgname/archive/v$pkgver.tar.gz")
+sha256sums=('ca35d9680f184cc6e337fcd5ecd4634bd877d56f9a7650c257681a8375a32459')
+
+package() {
+  cd "$srcdir/$pkgname-$pkgver"
+
+  # Main user-facing binaries
+  install -Dm755 archcanary.sh    "$pkgdir/usr/bin/archcanary"
+  install -Dm755 archcanary-gui.sh "$pkgdir/usr/bin/archcanary-gui"
+
+  # System lib: scanner + root helper + threat lists (used by the root scan)
+  install -dm755 "$pkgdir/usr/lib/archcanary"
+  install -m755  archcanary.sh         "$pkgdir/usr/lib/archcanary/archcanary.sh"
+  install -m755  lib/archcanary-root-helper "$pkgdir/usr/lib/archcanary/root-helper"
+  for _list in package_list.txt malicious_npm_packages.txt \
+               chaos_rat_packages.txt malicious_russian_spam_packages.txt; do
+    install -Dm644 "lists/$_list" "$pkgdir/usr/lib/archcanary/$_list"
+  done
+
+  # Polkit policy (authorises root-helper via pkexec)
+  install -Dm644 configs/org.archcanary.policy \
+    "$pkgdir/usr/share/polkit-1/actions/org.archcanary.policy"
+
+  # Desktop entry
+  install -Dm644 configs/archcanary.desktop \
+    "$pkgdir/usr/share/applications/archcanary.desktop"
+
+  # Systemd system units (root scan: weekly timer + pacman-triggered path)
+  for _unit in systemd/system/archcanary.service \
+               systemd/system/archcanary.timer \
+               systemd/system/archcanary.path \
+               systemd/system/archcanary-onchange.service; do
+    install -Dm644 "$_unit" "$pkgdir/usr/lib/systemd/system/$(basename "$_unit")"
+  done
+
+  # Systemd user units (user-scope scan + result notifier)
+  for _unit in systemd/user/archcanary-user.service \
+               systemd/user/archcanary-user.timer \
+               systemd/user/archcanary-notify.path \
+               systemd/user/archcanary-notify.service; do
+    install -Dm644 "$_unit" "$pkgdir/usr/lib/systemd/user/$(basename "$_unit")"
+  done
+
+  # DKMS allowlist — seeded as a commented template; users edit in place
+  install -dm755 "$pkgdir/etc/archcanary"
+  cat > "$pkgdir/etc/archcanary/dkms_allowlist.conf" << 'EOF'
+# DKMS modules to skip during --check-kmod (system-wide allowlist).
+# One module name per line. Everything after # is a comment.
+# Add modules that are known-good but not tracked by pacman.
+#
+# Common examples (uncomment as needed):
+# tuxedo-drivers  # TUXEDO Computers hardware driver
+# v4l2loopback    # virtual camera (OBS, video conferencing)
+# vboxdrv         # VirtualBox host kernel module
+# vmmon           # VMware Workstation
+EOF
+}

--- a/packaging/archcanary.install
+++ b/packaging/archcanary.install
@@ -1,0 +1,21 @@
+post_install() {
+  echo ""
+  echo "==> archcanary installed."
+  echo ""
+  echo "  Enable the automated system scan (runs as root — weekly + on boot + after pacman):"
+  echo "    sudo systemctl enable --now archcanary.timer archcanary.path"
+  echo ""
+  echo "  Enable the user-scope scan and result notifier (run as your user):"
+  echo "    systemctl --user enable --now archcanary-user.timer archcanary-notify.path"
+  echo ""
+  echo "  Run a manual full scan:"
+  echo "    archcanary --refresh --full --all-time"
+  echo ""
+  echo "  Optional add-ons: aurscan (LLM PKGBUILD scanner), yay (Lua hooks)."
+  echo "  See: https://github.com/musqz/archcanary"
+  echo ""
+}
+
+post_upgrade() {
+  post_install
+}


### PR DESCRIPTION
## Summary
- Restores `packaging/PKGBUILD`, `packaging/archcanary.install`, `packaging/.SRCINFO` (removed in 935538d during the beta period) so a `git pull` on a test VM is enough to `makepkg -si` — no more manually copying files in from the separate local `~/AUR/archcanary` staging folder.
- `packaging/` becomes the working copy for local makepkg testing going forward. Publishing to aur.archlinux.org is still explicitly out of scope for now.
- Build artifacts (`src/`, `pkg/`, `*.pkg.tar.zst`, `*.tar.gz`) stay gitignored as before — only the 3 source files are tracked.

## Test plan
- [x] `makepkg -f` from `packaging/` in this checkout — builds cleanly, sha256 validated
- [x] Package contents inspected — v0.1.14 fix (`_bundled_list_path`) present in the built `archcanary.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)