### PR TITLE
fix: PKGBUILD didn't stamp SCRIPT_VERSION, About/-V showed "unknown"

### DIFF
--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -23,6 +23,12 @@ sha256sums=('ca35d9680f184cc6e337fcd5ecd4634bd877d56f9a7650c257681a8375a32459')
 package() {
   cd "$srcdir/$pkgname-$pkgver"
 
+  # Stamp the real version into the placeholder install.sh normally sed's at
+  # install time — package() bypasses install.sh entirely, so without this
+  # every installed copy keeps the literal "@VERSION@" and -V/About show
+  # "unknown" (archcanary-gui's About dialog runs `archcanary --version`).
+  sed -i "s/@VERSION@/$pkgver/" archcanary.sh
+
   # Main user-facing binaries
   install -Dm755 archcanary.sh    "$pkgdir/usr/bin/archcanary"
   install -Dm755 archcanary-gui.sh "$pkgdir/usr/bin/archcanary-gui"


### PR DESCRIPTION
## Summary
- `install.sh` stamps the real version into `archcanary.sh`'s `@VERSION@` placeholder at install time (PR #75), but `packaging/PKGBUILD`'s `package()` bypasses `install.sh` and copies `archcanary.sh` straight from the tarball — so pacman-installed copies kept the literal placeholder, and `archcanary --version` / the GUI About dialog showed "unknown".
- `sed -i "s/@VERSION@/$pkgver/" archcanary.sh` added to `package()`, before it's copied to `/usr/bin/archcanary` and `/usr/lib/archcanary/archcanary.sh`.

## Test plan
- [x] `makepkg -f` from `packaging/`, extracted the built package, confirmed `SCRIPT_VERSION="0.1.14"` and `archcanary --version` → `Archcanary v0.1.14`

🤖 Generated with [Claude Code](https://claude.com/claude-code)