### PR TITLE
fix: doctor missed /usr/bin as a system-installed path

### DIFF
--- a/archcanary.sh
+++ b/archcanary.sh
@@ -265,7 +265,7 @@ run_doctor() {
     user_bin="$real_home/.local/bin"
     user_sd="${XDG_CONFIG_HOME:-$real_home/.config}/systemd/user"
     local system_installed=false
-    [[ -f /usr/local/bin/archcanary ]] && system_installed=true
+    [[ -f /usr/local/bin/archcanary || -f /usr/bin/archcanary ]] && system_installed=true
 
     # The repo-relative fix sources only exist when run from a clone; degrade
     # gracefully to a hint when run from an installed copy.


### PR DESCRIPTION
## Summary
- `run_doctor()`'s `system_installed` check only looked at `/usr/local/bin/archcanary` (the manual `install.sh --system` path), never `/usr/bin/archcanary` (where PKGBUILD actually installs it for pacman/AUR).
- Result: every pacman/AUR install of archcanary showed red `[MISS]` for `~/.local/bin/archcanary` and `~/.local/bin/archcanary-gui` in the "User install" section, even though those per-user copies were never expected to exist alongside a system-wide package — alarming but not an actual problem.

## Test plan
- [ ] On a pacman-installed archcanary (e.g. the Garuda VM), run `archcanary --doctor` and confirm the "User install" section no longer reports `[MISS]` for the two `~/.local/bin` entries.
- [ ] On a manual `install.sh --system` checkout, confirm behavior is unchanged (still `system_installed=true` via `/usr/local/bin/archcanary`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)