### PR TITLE
chore: set sha256sum for v0.1.15 release tarball

### DIFF
--- a/packaging/.SRCINFO
+++ b/packaging/.SRCINFO
@@ -16,6 +16,6 @@ pkgbase = archcanary
 	optdepends = aurscan: LLM-based PKGBUILD scanner (pre-install gate)
 	backup = etc/archcanary/dkms_allowlist.conf
 	source = archcanary-0.1.15.tar.gz::https://github.com/musqz/archcanary/archive/v0.1.15.tar.gz
-	sha256sums = SKIP
+	sha256sums = f4e38716f4a0129bd3293c4d519eb2f07deaaf756193f83f3b92f1ce8d29bc7e
 
 pkgname = archcanary

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -18,7 +18,7 @@ optdepends=(
 backup=('etc/archcanary/dkms_allowlist.conf')
 install=archcanary.install
 source=("$pkgname-$pkgver.tar.gz::https://github.com/musqz/$pkgname/archive/v$pkgver.tar.gz")
-sha256sums=('SKIP')
+sha256sums=('f4e38716f4a0129bd3293c4d519eb2f07deaaf756193f83f3b92f1ce8d29bc7e')
 
 package() {
   cd "$srcdir/$pkgname-$pkgver"


### PR DESCRIPTION
## Summary
- Final step of the v0.1.15 release: fills in the real sha256sum for the `v0.1.15` tarball (tag already pushed), replacing the `SKIP` placeholder from #80.
- `.SRCINFO` regenerated to match.

Per the release checklist, the tag itself is not moved — only PKGBUILD/.SRCINFO are updated post-tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)