### PR TITLE
docs: document manual timer activation for package installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,11 +166,25 @@ Every scan prints a per-check summary before the final verdict:
 ./install.sh uninstall --system
 ```
 
-`--system` sets up:
+`--system` sets up and **enables**:
 - Root system timer: weekly + on boot + after each pacman transaction
 - User notifier: watches `/var/lib/archcanary/last-scan.log`, fires a desktop alert on `INFECTED`
 - pkexec root helper for GUI-triggered root checks (eBPF, bpftool, kmod, Lynis)
 - auditd ruleset at `/etc/audit/rules.d/30-archcanary.rules` when auditd is installed (seeded from template, editable via GUI)
+
+### Package install (pacman / AUR)
+
+Installing the built package (`makepkg -si`, or via an AUR helper) drops all the same files, but — per Arch packaging convention — **never auto-enables services**. You must enable the timers yourself after install:
+
+```bash
+# Root system timer (weekly + on boot + after each pacman transaction)
+sudo systemctl enable --now archcanary.timer archcanary.path
+
+# User-scope scan and desktop notifier
+systemctl --user enable --now archcanary-user.timer archcanary-notify.path
+```
+
+Until you run these, `archcanary --doctor` will correctly show `[WARN]` for all four automation entries — that's expected, not a bug. Re-run `--doctor` after enabling to confirm they flip to `[ OK ]`.
 
 See [docs/systemd.md](docs/systemd.md) for unit file details and [docs/my-setup.md](docs/my-setup.md) for the full personal stack and reinstall steps.
 


### PR DESCRIPTION
## Summary
- The Installation section only documented `install.sh --system`, which *auto-enables* the systemd timers (`sudo systemctl enable --now ...` runs inside `install.sh`, line 382).
- The pacman/AUR package path never auto-enables services (Arch packaging convention — `archcanary.install`'s `post_install()` only prints the commands), which wasn't documented anywhere.
- Without this, seeing `[WARN]` on all four automation entries in `archcanary --doctor` right after a fresh package install (as hit during Garuda VM testing, see #79) reads as broken rather than an expected one-time manual step.
- Added a "Package install (pacman / AUR)" subsection with the exact enable commands and an explicit note that the `[WARN]` state is expected until they're run.

## Test plan
- [ ] Read through the new README section for accuracy against `archcanary.install`'s printed instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)