### PR TITLE
chore: set sha256sum for v0.1.16 release tarball

### DIFF
--- a/packaging/.SRCINFO
+++ b/packaging/.SRCINFO
@@ -16,6 +16,6 @@ pkgbase = archcanary
 	optdepends = aurscan: LLM-based PKGBUILD scanner (pre-install gate)
 	backup = etc/archcanary/dkms_allowlist.conf
 	source = archcanary-0.1.16.tar.gz::https://github.com/musqz/archcanary/archive/v0.1.16.tar.gz
-	sha256sums = SKIP
+	sha256sums = f8dbb7087c65f58aa757b83e5d4d96f1824a1ed2fc36fabdd5c934e97ff9dc39
 
 pkgname = archcanary

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -18,7 +18,7 @@ optdepends=(
 backup=('etc/archcanary/dkms_allowlist.conf')
 install=archcanary.install
 source=("$pkgname-$pkgver.tar.gz::https://github.com/musqz/$pkgname/archive/v$pkgver.tar.gz")
-sha256sums=('SKIP')
+sha256sums=('f8dbb7087c65f58aa757b83e5d4d96f1824a1ed2fc36fabdd5c934e97ff9dc39')
 
 package() {
   cd "$srcdir/$pkgname-$pkgver"


### PR DESCRIPTION
## Summary
- Final step of the v0.1.16 release: fills in the real sha256sum for the `v0.1.16` tarball (tag already pushed), replacing the `SKIP` placeholder from #84.
- `.SRCINFO` regenerated to match.

Per the release checklist, the tag itself is not moved — only PKGBUILD/.SRCINFO are updated post-tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)