### PR TITLE
chore: set sha256sum for v0.1.17 release tarball

### DIFF
--- a/packaging/.SRCINFO
+++ b/packaging/.SRCINFO
@@ -19,6 +19,6 @@ pkgbase = archcanary
 	backup = etc/archcanary/bpftool_allowlist.conf
 	backup = etc/archcanary/autostart_allowlist.conf
 	source = archcanary-0.1.17.tar.gz::https://github.com/musqz/archcanary/archive/v0.1.17.tar.gz
-	sha256sums = SKIP
+	sha256sums = ca6bb410b213af4403e1cd9f77e7c914c1595f85fe55db869710f231e50eb763
 
 pkgname = archcanary

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -21,7 +21,7 @@ backup=('etc/archcanary/dkms_allowlist.conf'
         'etc/archcanary/autostart_allowlist.conf')
 install=archcanary.install
 source=("$pkgname-$pkgver.tar.gz::https://github.com/musqz/$pkgname/archive/v$pkgver.tar.gz")
-sha256sums=('SKIP')
+sha256sums=('ca6bb410b213af4403e1cd9f77e7c914c1595f85fe55db869710f231e50eb763')
 
 package() {
   cd "$srcdir/$pkgname-$pkgver"


### PR DESCRIPTION
Tag v0.1.17 is pushed and untouched. Computed sha256 of the actual GitHub release tarball and verified it extracts cleanly with version.txt = 0.1.17 before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)