### PR TITLE
fix: bundled list resolution failed for the packaged /usr/bin/archcanary

### DIFF
--- a/archcanary.sh
+++ b/archcanary.sh
@@ -812,14 +812,20 @@ if [[ -r "$_auto_cfg" ]]; then    # skip if missing/unreadable (don't abort unde
 fi
 unset _auto_cfg _al
 
-# Resolves a bundled data file next to the running script. Checks the flat
-# layout first (/usr/lib/archcanary/<file> — how install.sh --system and the
-# AUR package deploy it, since root's $HOME isn't seeded) and falls back to
-# the lists/ subdir layout (repo checkout, ./archcanary.sh run in place).
+# Resolves a bundled data file. Checks two locations relative to the running
+# script first (flat layout — $0 is /usr/lib/archcanary/archcanary.sh, the
+# root-scan copy; then the lists/ subdir layout — repo checkout,
+# ./archcanary.sh run in place), then falls back to the fixed system path
+# /usr/lib/archcanary/<file>. That last fallback is required when $0 is
+# /usr/bin/archcanary (the plain user-facing binary both install.sh and the
+# AUR PKGBUILD install) — it has no data files next to it; only
+# /usr/lib/archcanary/ does, since root's $HOME isn't seeded and needs its own
+# copy regardless of which entry point the user actually runs.
+# ARCHCANARY_SYSTEM_LIB overrides the fixed path for testing.
 _bundled_list_path() {
     local _dir _f
     _dir="$(dirname "$(realpath "$0")")"
-    for _f in "$_dir/$1" "$_dir/lists/$1"; do
+    for _f in "$_dir/$1" "$_dir/lists/$1" "${ARCHCANARY_SYSTEM_LIB:-/usr/lib/archcanary}/$1"; do
         if [[ -f "$_f" ]]; then
             printf '%s' "$_f"
             return 0

--- a/tests/run_matching_tests.sh
+++ b/tests/run_matching_tests.sh
@@ -725,6 +725,38 @@ SCRIPT
 }
 
 # ---------------------------------------------------------------------------
+# Test 15: _bundled_list_path falls back to the system-lib dir when the
+#          running script has no bundled data files next to it (the
+#          /usr/bin/archcanary packaged layout — only /usr/lib/archcanary/
+#          carries the bundled lists, not /usr/bin/).
+# ---------------------------------------------------------------------------
+test_bundled_list_path_usr_bin_layout() {
+    local isolated_bin sys_lib fake_home
+    isolated_bin=$(mktemp -d)
+    sys_lib=$(mktemp -d)
+    fake_home=$(mktemp -d)
+
+    cp "$REPO_DIR/archcanary.sh" "$isolated_bin/archcanary.sh"
+    chmod +x "$isolated_bin/archcanary.sh"
+    cp "$SCRIPT_DIR/fake_npm_lists/malicious_npm.txt" "$sys_lib/malicious_npm_packages.txt"
+
+    local out rc=0
+    out=$(HOME="$fake_home" XDG_CONFIG_HOME="$fake_home/.config" \
+        ARCHCANARY_SYSTEM_LIB="$sys_lib" \
+        "$isolated_bin/archcanary.sh" \
+        --package-list="$SCRIPT_DIR/fake_package_lists/simple.txt" \
+        --no-notify 2>&1) || rc=$?
+
+    if [[ "$out" == *"Packages checked:"* && "$out" != *"Malicious npm package list not found"* ]]; then
+        pass "bundled_list_path: /usr/bin-style layout resolves npm list via system-lib fallback"
+    else
+        fail "bundled_list_path: expected fallback resolution to succeed, got: $out"
+    fi
+
+    rm -rf "$isolated_bin" "$sys_lib" "$fake_home"
+}
+
+# ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
 echo "=== Matching Tests ==="
@@ -772,6 +804,9 @@ test_check_kmod
 
 $VERBOSE && msg "--- Test 14: check_bpftool allowlist ---"
 test_check_bpftool_allowlist
+
+$VERBOSE && msg "--- Test 15: bundled_list_path /usr/bin layout ---"
+test_bundled_list_path_usr_bin_layout
 
 echo "=== Results: $PASS_COUNT PASS, $FAIL_COUNT FAIL ==="
 [[ $FAIL_COUNT -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary
Reproduced on a fresh CachyOS boot (new machine, plain AUR/pacman install, nothing seeded yet): `archcanary --refresh` fails immediately with `ERROR: Malicious npm package list not found`.

`_bundled_list_path()` resolves the bundled data files relative to `$0`'s own directory. That works for `/usr/lib/archcanary/archcanary.sh` (the root-scan copy — data files sit right next to it) and a repo checkout (`lists/` subdir), but **not** for `/usr/bin/archcanary` — the plain user-facing binary both `install.sh` and the AUR `PKGBUILD` install — which has no data files next to it at all. Every fresh package-only install hits this on the very first invocation, before `~/.config/archcanary` has ever been seeded.

## Fix
Added `/usr/lib/archcanary/<file>` as an explicit third fallback candidate, with an `ARCHCANARY_SYSTEM_LIB` env override (matches the existing `LSMOD_CMD`/`DKMS_CMD`/`BPFTOOL_CMD` testability pattern) so this can be exercised in tests without touching the real system path.

## Test plan
- [x] New regression test (`test_bundled_list_path_usr_bin_layout`) reproduces the exact real-world error message when run against the pre-fix code (confirmed red via `git stash`), passes against the fix
- [x] Full suite: 34/34 pass
- [x] Manual repro of the exact scenario (isolated bin dir mimicking `/usr/bin`, fresh `$HOME`, fake system-lib dir) — now resolves and scans cleanly instead of erroring

🤖 Generated with [Claude Code](https://claude.com/claude-code)