### PR TITLE
fix: sync threat-intel lists with upstream lenucksi/aur-malware-check

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Three waves:
 
 ### Russian Spam Campaign (June 14, 2026)
 
-A separate campaign ([reported by Sid Karunaratne](https://lists.archlinux.org/archives/list/aur-general@lists.archlinux.org/message/2YQSHTC27MOKDDKHZTH2BJGTEN2CYC7W/)) in which 73 AUR package PKGBUILDs were modified to inject Russian-language spam `echo` statements into `~/.bashrc`, `~/.zshrc`, and other shell configs at install time. No credential theft or persistence — nuisance/propaganda payload. Reported to Arch DevOps; cleanup was in progress as of 2026-06-14.
+A separate campaign ([reported by Sid Karunaratne](https://lists.archlinux.org/archives/list/aur-general@lists.archlinux.org/message/2YQSHTC27MOKDDKHZTH2BJGTEN2CYC7W/)) in which 75 AUR package PKGBUILDs were modified to inject Russian-language spam `echo` statements into `~/.bashrc`, `~/.zshrc`, and other shell configs at install time. No credential theft or persistence — nuisance/propaganda payload. Reported to Arch DevOps; cleanup was in progress as of 2026-06-14.
 
 archcanary detects these via `malicious_russian_spam_packages.txt` (shown in the scan header alongside the JS campaign count).
 

--- a/SOURCES.md
+++ b/SOURCES.md
@@ -25,7 +25,7 @@ Numbered and structured references for the atomic-lockfile / js-digest supply-ch
 ## 2. Technical Analysis
 
 ### 2.1 ioctl.fail — Preliminary Analysis
-- **URL:** https://ioctl.fail/preliminary-analysis-of-archcanary/
+- **URL:** https://ioctl.fail/preliminary-analysis-of-aur-malware/
 - **Date:** 2026-06-11
 - **Content:** Detailed technical analysis. IOCs, eBPF rootkit details (CAP_BPF, hides processes/files/socket inodes), C2 extraction via Tor onion service, systemd persistence, credential theft targeting Discord/GitHub/npm/Slack/SSH/Vault.
 - **Relevant for:** Malware capabilities, IoCs, persistence mechanisms.

--- a/lists/at_risk_accounts.json
+++ b/lists/at_risk_accounts.json
@@ -90,6 +90,70 @@
         "16 adopted orphaned packages (details unknown)"
       ],
       "notes": "Account 3 days old, adopted 16 orphaned packages. No malicious commits found yet — under observation."
+    },
+    "meryemplath": {
+      "first_reported": "2026-06-13T00:00:00+00:00",
+      "source": "https://lists.archlinux.org/archives/list/aur-general@lists.archlinux.org/message/NHRO2RT3VRXHQ7O4WQCPTNGNIOQQQAWX/",
+      "reported_by": "aur-general mailing list",
+      "status": "confirmed",
+      "packages": [
+        "pypiserver",
+        "anythingllm-cli-bin",
+        "python-dbapi-compliance"
+      ],
+      "notes": "Took over multiple orphaned packages and injected malicious code."
+    },
+    "laurentbavaud": {
+      "first_reported": "2026-06-13T00:00:00+00:00",
+      "source": "https://lists.archlinux.org/archives/list/aur-general@lists.archlinux.org/message/NHRO2RT3VRXHQ7O4WQCPTNGNIOQQQAWX/",
+      "reported_by": "aur-general mailing list",
+      "status": "confirmed",
+      "packages": [
+        "zathura-gruvbox-git",
+        "python2-mutagen",
+        "fastoggenc"
+      ],
+      "notes": "Banned. Associated with malicious commits in multiple packages."
+    },
+    "vitoriapires": {
+      "first_reported": "2026-06-11T17:31:00+00:00",
+      "source": "https://lists.archlinux.org/archives/list/aur-general@lists.archlinux.org/message/LVYB62N3FPAWUHNJ5Z5GXG6OIR7S5P3F/",
+      "reported_by": "Fabio Loli",
+      "status": "confirmed",
+      "packages": [
+        "Multiple AUR packages (npm shenanigans)"
+      ],
+      "notes": "Confirmed malicious by Fabio Loli via update notification checks."
+    },
+    "catringiess": {
+      "first_reported": "2026-06-11T17:31:00+00:00",
+      "source": "https://lists.archlinux.org/archives/list/aur-general@lists.archlinux.org/message/LVYB62N3FPAWUHNJ5Z5GXG6OIR7S5P3F/",
+      "reported_by": "Fabio Loli",
+      "status": "confirmed",
+      "packages": [
+        "Multiple AUR packages (npm shenanigans)"
+      ],
+      "notes": "Confirmed malicious by Fabio Loli via update notification checks."
+    },
+    "dominikgross": {
+      "first_reported": "2026-06-11T17:31:00+00:00",
+      "source": "https://lists.archlinux.org/archives/list/aur-general@lists.archlinux.org/message/LVYB62N3FPAWUHNJ5Z5GXG6OIR7S5P3F/",
+      "reported_by": "Fabio Loli",
+      "status": "confirmed",
+      "packages": [
+        "Multiple AUR packages (npm shenanigans)"
+      ],
+      "notes": "Confirmed malicious by Fabio Loli via update notification checks."
+    },
+    "skarbricat": {
+      "first_reported": "2026-06-13T00:00:00+00:00",
+      "source": "https://lists.archlinux.org/archives/list/aur-general@lists.archlinux.org/message/NHRO2RT3VRXHQ7O4WQCPTNGNIOQQQAWX/",
+      "reported_by": "Jason Marinaro",
+      "status": "confirmed",
+      "packages": [
+        "All PKGBUILDs contained malicious code"
+      ],
+      "notes": "All packages under this account confirmed malicious by Jason Marinaro."
     }
   }
 }

--- a/lists/iocs.txt
+++ b/lists/iocs.txt
@@ -1,6 +1,7 @@
 # Indicators of Compromise (IOCs) - AUR Malware Campaign June 2026
-# Sources: https://ioctl.fail/preliminary-analysis-of-archcanary/
+# Sources: https://ioctl.fail/preliminary-analysis-of-aur-malware/
 #          https://gist.github.com/Kidev/59bf9f5fb53ab5eee99f19a6a2fc3992
+#          https://github.com/lenucksi/aur-malware-check/issues/24
 
 ## File Hashes
 ELF Payload (deps - atomic-lockfile variant):
@@ -37,6 +38,14 @@ Additional sample (cryptominer - atomic-lockfile variant):
   Payload:    embedded ELF (same SHA256 as atomic-lockfile variant)
   Publisher:  herbsobering (same NPM account)
   Source:     Sonatype blog post
+
+### ansi-colors (bun companion — NOT in automated scan list)
+  Name:       ansi-colors
+  Installer:  bun add ansi-colors (injected via obfuscated .install hooks alongside nextfile-js)
+  Note:       Shares name with legitimate popular npm package (~500M downloads).
+              Used as cover alongside nextfile-js in htbrowser-bin attack.
+              Excluded from malicious_npm_packages.txt to avoid false positives.
+  Source:     https://lists.archlinux.org/archives/list/aur-general@lists.archlinux.org/message/TND7HA2KBQ46OHHUMMIAHKGXZE4WALM6/  (Nicolas Boichat, 2026-06-14)
 
 ## Network Indicators (C2)
   Onion:  olrh4mibs62l6kkuvvjyc5lrercqg5tz543r4lsw3o6mh5qb7g7sneid.onion
@@ -75,6 +84,16 @@ Additional sample (cryptominer - atomic-lockfile variant):
   /usr/bin/monero-wallet-gui (potential cryptominer)
   ~/.npm/_cacache/ (npm cache of malicious npm packages — see malicious_npm_packages.txt)
   ~/.bun/install/cache/ (bun cache — bun variant of the attack)
+  ~/.local/bin/sudo (sudo password grabber)
+  /tmp/.cache (captured sudo passwords)
+
+## Artifact Details
+### sudo password grabber
+  Path:     ~/.local/bin/sudo
+  SHA256:   fd4852334ce1c2d7c9bf0e1c91dbf274a1247989b4827d4f7758cbf3bf42ebfe
+  Source:   https://github.com/lenucksi/aur-malware-check/issues/24
+  Behavior: Intercepts sudo calls, captures password to /tmp/.cache, then
+            removes itself after successful authentication.
 
 ## Attacker Accounts
   AUR:  krisztinavarga (malicious maintainer for alvr)
@@ -83,6 +102,16 @@ Additional sample (cryptominer - atomic-lockfile variant):
   Git:  PLYSHKA (commit author name used for impersonation)
   NPM:  herbsobering
   GH:   fardewoak (container registry: herbsobering430)
+  AUR:  meryemplath (took over pypiserver, anythingllm-cli-bin, python-dbapi-compliance)
+  AUR:  laurentbavaud (banned — zathura-gruvbox-git, python2-mutagen, fastoggenc)
+  AUR:  vitoriapires (confirmed malicious by Fabio Loli)
+  AUR:  catringiess (confirmed malicious by Fabio Loli)
+  AUR:  dominikgross (confirmed malicious by Fabio Loli)
+  AUR:  skarbricat (all PKGBUILDs contained malicious code — Jason Marinaro)
+
+## Malicious Git Commits
+  htbrowser-bin: 462c21877fe6d2f563ed6620ef227e06ac8c51c8 (obfuscated bun payload)
+  Attacker email: annikkitikkanen@gmail.com
 
 ## Impersonated Accounts
   AUR:  arojas (legitimate Arch Linux maintainer — identity forged by attacker via git commit forgery; see Impersonation Clarification in README)

--- a/lists/malicious_russian_spam_packages.txt
+++ b/lists/malicious_russian_spam_packages.txt
@@ -41,10 +41,13 @@ nikto-git
 nodejs-serverless
 nodejs-uglifycss
 nullfs-dkms-git
+# Issue #20: pingwin840 packages (Remco R., 2026-06-14)
+obd-auto-doctor
 onivim2-git
 onvifviewer
 pcb
 pcmanx-gtk2-git
+peksystray
 perl-xml-filter-domfilter-libxml
 pfqueue
 pgdbf


### PR DESCRIPTION
## Summary
- archcanary's threat-intel data (`lists/`) was frozen at the point of the `aur-malware-check` rename and never resynced against `lenucksi/aur-malware-check` (verified byte-identical to `musqz/aur-malware-check`, 0 commits diverged either direction)
- Adds 6 wave-2 attacker accounts (`meryemplath`, `laurentbavaud`, `vitoriapires`, `catringiess`, `dominikgross`, `skarbricat`) to `at_risk_accounts.json` and `iocs.txt`
- Adds 2 missing russian-spam packages (`obd-auto-doctor`, `peksystray`) to `malicious_russian_spam_packages.txt`; README count updated 73 → 75
- Adds the sudo-password-grabber IOC, the `ansi-colors` companion-package note, and a "Malicious Git Commits" section to `iocs.txt`
- Fixes the ioctl.fail source URL in `iocs.txt`/`SOURCES.md`, which pointed at a nonexistent `-of-archcanary/` slug instead of the real `-of-aur-malware/` article
- Main AUR package list, npm list, and chaos-rat list were already fully in sync — no changes there

## Test plan
- [x] `tests/run_matching_tests.sh` — 34/34 PASS
- [x] `python3 -c "json.load(...)"` validated `at_risk_accounts.json`
- [x] `diff` confirmed `iocs.txt` now byte-identical to upstream's `aur-infected/iocs.txt`
- [x] Reviewed via `/ultrareview` (one nit found and fixed: stale URL in `SOURCES.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)