### PR TITLE
chore: set real sha256 for v0.1.18 release tarball

### DIFF
--- a/packaging/.SRCINFO
+++ b/packaging/.SRCINFO
@@ -19,6 +19,6 @@ pkgbase = archcanary
 	backup = etc/archcanary/bpftool_allowlist.conf
 	backup = etc/archcanary/autostart_allowlist.conf
 	source = archcanary-0.1.18.tar.gz::https://github.com/musqz/archcanary/archive/v0.1.18.tar.gz
-	sha256sums = SKIP
+	sha256sums = ca80adb6d317187d7e4be09190445bb641c0e19981d3e31ed2c50f756f9a96a9
 
 pkgname = archcanary

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -21,7 +21,7 @@ backup=('etc/archcanary/dkms_allowlist.conf'
         'etc/archcanary/autostart_allowlist.conf')
 install=archcanary.install
 source=("$pkgname-$pkgver.tar.gz::https://github.com/musqz/$pkgname/archive/v$pkgver.tar.gz")
-sha256sums=('SKIP')
+sha256sums=('ca80adb6d317187d7e4be09190445bb641c0e19981d3e31ed2c50f756f9a96a9')
 
 package() {
   cd "$srcdir/$pkgname-$pkgver"


### PR DESCRIPTION
Verified by extracting version.txt (0.1.18) and lists/iocs.txt from the tagged tarball before trusting the hash. Tag v0.1.18 is not moved.