### PR TITLE
chore: set real sha256 for v0.1.19 release tarball

### DIFF
--- a/packaging/.SRCINFO
+++ b/packaging/.SRCINFO
@@ -20,6 +20,6 @@ pkgbase = archcanary
 	backup = etc/archcanary/bpftool_allowlist.conf
 	backup = etc/archcanary/autostart_allowlist.conf
 	source = archcanary-0.1.19.tar.gz::https://github.com/musqz/archcanary/archive/v0.1.19.tar.gz
-	sha256sums = SKIP
+	sha256sums = c0abfc722b7c0fd25a02e4b01c54815f28b02b5cb9013501b49dd53813313e00
 
 pkgname = archcanary

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -22,7 +22,7 @@ backup=('etc/archcanary/dkms_allowlist.conf'
         'etc/archcanary/autostart_allowlist.conf')
 install=archcanary.install
 source=("$pkgname-$pkgver.tar.gz::https://github.com/musqz/$pkgname/archive/v$pkgver.tar.gz")
-sha256sums=('SKIP')
+sha256sums=('c0abfc722b7c0fd25a02e4b01c54815f28b02b5cb9013501b49dd53813313e00')
 
 package() {
   cd "$srcdir/$pkgname-$pkgver"


### PR DESCRIPTION
## Summary
- Real sha256 for the `v0.1.19` tag tarball, verified by extracting `version.txt` (0.1.19) and confirming `archcanary.sh`'s corrected `--doctor` hint before trusting the hash
- Does not move the `v0.1.19` tag

## Test plan
- [x] Downloaded tarball, extracted, verified `version.txt` and `archcanary.sh` contents match the tag
- [ ] Merge