### PR TITLE
Integrate aur-audit.wtako.net black/red feed + bash completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Added: `--refresh` now also syncs the black/red package lists from the third-party [aur-audit.wtako.net](https://wtako.net/services/aur-audit) service (continuous community AUR scan feed, free/unauthenticated API). Hits merge into the existing infected-package check, annotated `[aur-audit: black]`/`[aur-audit: red]`. Yellow (qualitative/minor) findings are not synced. Purely additive — no new dependency, no network call outside `--refresh`, no CLI overrides.
+
 ## v0.1.19 (2026-07-25)
 
 - Fix: the AUR package `aurscan-manticore-git` no longer exists — upstream split it into `aurscan-manticore-release-git` (source build) and `aurscan-manticore-bin-release-git` (prebuilt binary). Updated every install command/optdepend pointing at the old name, including the `PKGBUILD`'s own `optdepends="aurscan: ..."`, which never matched anyway since no AUR package is literally named `aurscan`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Added: `--refresh` now also syncs the black/red package lists from the third-party [aur-audit.wtako.net](https://wtako.net/services/aur-audit) service (continuous community AUR scan feed, free/unauthenticated API). Hits merge into the existing infected-package check, annotated `[aur-audit: black]`/`[aur-audit: red]`. Yellow (qualitative/minor) findings are not synced. Purely additive — no new dependency, no network call outside `--refresh`, no CLI overrides.
+- Added: new `AURPreInstall` yay hook in `configs/yay-init.lua` checks the about-to-build package against the synced aur-audit black/red lists — aborts on black, warns on red. Gives pre-build protection against known-bad AUR packages without requiring aurscan/an LLM. No new systemd unit: the existing weekly/on-boot `archcanary.timer` already keeps the lists fresh via `--refresh`.
 
 ## v0.1.19 (2026-07-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added: `--refresh` now also syncs the black/red package lists from the third-party [aur-audit.wtako.net](https://wtako.net/services/aur-audit) service (continuous community AUR scan feed, free/unauthenticated API). Hits merge into the existing infected-package check, annotated `[aur-audit: black]`/`[aur-audit: red]`. Yellow (qualitative/minor) findings are not synced. Purely additive — no new dependency, no network call outside `--refresh`, no CLI overrides.
 - Added: new `AURPreInstall` yay hook in `configs/yay-init.lua` checks the about-to-build package against the synced aur-audit black/red lists — aborts on black, warns on red. Gives pre-build protection against known-bad AUR packages without requiring aurscan/an LLM. No new systemd unit: the existing weekly/on-boot `archcanary.timer` already keeps the lists fresh via `--refresh`.
+- Added: bash tab-completion (`configs/archcanary-completion.bash`), installed by both `install.sh` and the AUR package into the standard `bash-completion` completions directory — no `.bashrc` edits needed. Also registers a `canary` completion alongside it (as a symlink) for anyone who adds their own `alias canary=archcanary`.
 
 ## v0.1.19 (2026-07-25)
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Every scan prints a per-check summary before the final verdict:
 | `--run-lynis` | Run `lynis audit system`, stream output | Yes |
 | `--check-pkginteg` | Verify installed file checksums via `pacman -Qkk`. Reports SHA256 mismatches on non-backup, non-factory files. Backup files (pacman-managed configs expected to diverge) and `/factory/` paths are filtered out. Prioritise hits in `/usr/bin/`, `/usr/lib/`, `/usr/sbin/`. | Yes |
 | `--full` | All of the above | Partial |
-| `--refresh` | Fetch the live package list from the Arch Linux HedgeDoc | — |
+| `--refresh` | Fetch the live package list from the Arch Linux HedgeDoc, plus the supplementary npm/CHAOS RAT/Russian Spam lists and the aur-audit black/red feed | — |
 | `--package-list=PATH` | Override the infected AUR package list | — |
 | `--extra-list=PATH_OR_URL` | Load an additional package list (file or `https://` URL); repeatable | — |
 | `--doctor` | Health check: binary deps, systemd units, install paths | — |
@@ -259,6 +259,10 @@ Three waves:
 A separate campaign ([reported by Sid Karunaratne](https://lists.archlinux.org/archives/list/aur-general@lists.archlinux.org/message/2YQSHTC27MOKDDKHZTH2BJGTEN2CYC7W/)) in which 75 AUR package PKGBUILDs were modified to inject Russian-language spam `echo` statements into `~/.bashrc`, `~/.zshrc`, and other shell configs at install time. No credential theft or persistence — nuisance/propaganda payload. Reported to Arch DevOps; cleanup was in progress as of 2026-06-14.
 
 archcanary detects these via `malicious_russian_spam_packages.txt` (shown in the scan header alongside the JS campaign count).
+
+### aur-audit.wtako.net feed
+
+`--refresh` also syncs the black/red package lists published by the third-party [aur-audit.wtako.net](https://wtako.net/services/aur-audit) service, which continuously scans all of AUR and publishes verdicts via a free, unauthenticated API. Black (confirmed malicious) and red (high-risk) hits are merged into the same infected-package check as the lists above, annotated `[aur-audit: black]` / `[aur-audit: red]` so you can tell the source of a hit. Yellow (minor/qualitative findings) is intentionally not synced — too noisy for an automated check. This is a best-effort, third-party feed, not a guarantee — same caveat as any heuristic scanner.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ Every scan prints a per-check summary before the final verdict:
 | `--extra-list=PATH_OR_URL` | Load an additional package list (file or `https://` URL); repeatable | — |
 | `--doctor` | Health check: binary deps, systemd units, install paths | — |
 
+Both `install.sh` and the AUR package install bash tab-completion for every flag above (`archcanary --<TAB>`), loaded automatically via the `bash-completion` package — no `.bashrc` edits needed. If you'd rather type `canary`, add `alias canary=archcanary` to your `.bashrc`/`.zshrc`; the completion is already registered for that name too, so it works immediately.
+
 ### Lynis on a desktop system
 
 Lynis was originally built for server hardening, so a chunk of its

--- a/README.md
+++ b/README.md
@@ -264,6 +264,8 @@ archcanary detects these via `malicious_russian_spam_packages.txt` (shown in the
 
 `--refresh` also syncs the black/red package lists published by the third-party [aur-audit.wtako.net](https://wtako.net/services/aur-audit) service, which continuously scans all of AUR and publishes verdicts via a free, unauthenticated API. Black (confirmed malicious) and red (high-risk) hits are merged into the same infected-package check as the lists above, annotated `[aur-audit: black]` / `[aur-audit: red]` so you can tell the source of a hit. Yellow (minor/qualitative findings) is intentionally not synced — too noisy for an automated check. This is a best-effort, third-party feed, not a guarantee — same caveat as any heuristic scanner.
 
+The same synced lists also gate installs directly: the `AURPreInstall` yay hook (see [yay 13.0 integration](docs/my-setup.md#yay-130-integration)) aborts a build on a black hit and warns on a red hit — a pre-build check that doesn't need aurscan or an LLM.
+
 ---
 
 ## What to Do If Infected

--- a/SOURCES.md
+++ b/SOURCES.md
@@ -261,3 +261,15 @@ All threads on https://lists.archlinux.org/archives/list/aur-general@lists.archl
 - **Detection method:** `git grep --files-with-matches 'NoServices'` across all AUR remote refs.
 - **Status:** Reported to Arch DevOps, cleanup in progress.
 - **Relevant for:** Independent threat vector requiring separate detection patterns (shell config injection ≠ JS package manager detection).
+
+---
+
+## 9. aur-audit.wtako.net Feed
+
+- **URL:** https://wtako.net/services/aur-audit
+- **API docs:** https://wtako.net/services/aur-audit/docs
+- **Author:** wtako.net (third-party, independent of archcanary)
+- **Content:** Free, unauthenticated JSON API publishing continuous automated scan verdicts for AUR packages, categorized black (confirmed malicious), red (high-risk), and yellow (minor/qualitative). Paginated via `GET /packages?filter=black|red&before=&limit=`.
+- **Detection method:** `--refresh` pages through the `black` and `red` filters and stores the package names in `aur_audit_black.txt`/`aur_audit_red.txt`. Yellow is intentionally not synced — too noisy for an automated check without incident history to justify it.
+- **Status:** Live, continuously updated by the upstream service — not a static snapshot.
+- **Relevant for:** Community-scale, continuously-updated denylist supplementing archcanary's own hand-curated lists. Best-effort third-party data, not a guarantee — same caveat as any heuristic scanner.

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -156,7 +156,7 @@ for arg in "$@"; do
             echo "  --check-pkginteg   Verify installed file checksums against pacman database (SHA256 mismatch)"
             echo "  --run-lynis        Run a full Lynis audit (lynis audit system) and exit — not included in --full"
             echo "  --full             Enable all checks"
-            echo "  --refresh          Download the latest package list before scanning"
+            echo "  --refresh          Download the latest package list before scanning (incl. aur-audit black/red feed)"
             echo "  --verbose, -v, --debug    Verbose output (--debug also enables set -x)"
             echo "  --log-file=PATH           Write full detail log to PATH (auto: ~/.cache/archcanary/aur-check-<date>.log)"
             echo "  --package-list=PATH       Custom infected AUR package list (default: ./package_list.txt)"
@@ -738,6 +738,12 @@ CHAOS_RAT_PKGS=()
 RUSSIAN_SPAM_LIST="${RUSSIAN_SPAM_LIST:-$AUR_CONFIG_DIR/malicious_russian_spam_packages.txt}"
 RUSSIAN_SPAM_PKGS=()
 
+AUR_AUDIT_BLACK_LIST="${AUR_AUDIT_BLACK_LIST:-$AUR_CONFIG_DIR/aur_audit_black.txt}"
+AUR_AUDIT_BLACK_PKGS=()
+
+AUR_AUDIT_RED_LIST="${AUR_AUDIT_RED_LIST:-$AUR_CONFIG_DIR/aur_audit_red.txt}"
+AUR_AUDIT_RED_PKGS=()
+
 EXTRA_LISTS_CONF="${EXTRA_LISTS_CONF:-$AUR_CONFIG_DIR/extra_lists.conf}"
 EXTRA_PKGS=()
 
@@ -933,6 +939,38 @@ load_packages() {
         _refresh_list "$CHAOS_RAT_LIST_URL"       "$CHAOS_RAT_LIST"      "CHAOS RAT list"       "$CHAOS_RAT_LIST_OPT"
         _refresh_list "$RUSSIAN_SPAM_LIST_URL"    "$RUSSIAN_SPAM_LIST"   "Russian spam list"    "$RUSSIAN_SPAM_LIST_OPT"
         unset -f _refresh_list
+
+        # aur-audit.wtako.net — community/third-party continuous AUR scan feed.
+        # Paginated JSON API (no auth, no jq dependency: grep -oP field pull).
+        # Fails soft per filter, like the supplementary lists above.
+        _refresh_aur_audit() {
+            local filter="$1" dest="$2" label="$3"
+            local base="https://aur-audit.wtako.net/packages"
+            local cursor="" page page_names all=() n pages=0
+            echo "Fetching aur-audit $label list..."
+            while :; do
+                page=$(curl -fsSL "${base}?filter=${filter}&limit=500${cursor:+&before=$cursor}" 2>/dev/null) || {
+                    echo >&2 "WARNING: failed to fetch aur-audit $label list — keeping existing."
+                    return
+                }
+                mapfile -t page_names < <(grep -oP '"packageName":"\K[^"]*' <<<"$page")
+                all+=("${page_names[@]}")
+                cursor=$(grep -oP '"nextCursor":\K[0-9]+' <<<"$page" || true)
+                pages=$((pages + 1))
+                [[ -n "$cursor" && $pages -lt 200 ]] || break
+            done
+            n=${#all[@]}
+            if [[ $n -eq 0 ]]; then
+                echo >&2 "WARNING: aur-audit $label fetch returned 0 entries — keeping existing."
+                return
+            fi
+            printf '%s\n' "${all[@]}" | sort -u > "$dest"
+            _chown_to_invoker "$dest"
+            echo "Updated $dest ($(grep -c '^[^#[:space:]]' "$dest") entries)"
+        }
+        _refresh_aur_audit black "$AUR_AUDIT_BLACK_LIST" "black"
+        _refresh_aur_audit red   "$AUR_AUDIT_RED_LIST"   "red"
+        unset -f _refresh_aur_audit
     fi
 
     if [[ ! -f "$PACKAGE_LIST_FILE" ]]; then
@@ -968,6 +1006,23 @@ load_packages() {
             [[ "$line" =~ ^#.*$ || -z "$line" ]] && continue
             RUSSIAN_SPAM_PKGS+=("$line")
         done <"$RUSSIAN_SPAM_LIST"
+    fi
+
+    # aur-audit.wtako.net black/red lists (optional — only exist after --refresh)
+    AUR_AUDIT_BLACK_PKGS=()
+    if [[ -f "$AUR_AUDIT_BLACK_LIST" ]]; then
+        while IFS= read -r line; do
+            [[ "$line" =~ ^#.*$ || -z "$line" ]] && continue
+            AUR_AUDIT_BLACK_PKGS+=("$line")
+        done <"$AUR_AUDIT_BLACK_LIST"
+    fi
+
+    AUR_AUDIT_RED_PKGS=()
+    if [[ -f "$AUR_AUDIT_RED_LIST" ]]; then
+        while IFS= read -r line; do
+            [[ "$line" =~ ^#.*$ || -z "$line" ]] && continue
+            AUR_AUDIT_RED_PKGS+=("$line")
+        done <"$AUR_AUDIT_RED_LIST"
     fi
 
     # Extra lists — from extra_lists.conf and --extra-list= flags
@@ -1065,6 +1120,10 @@ check_current() {
         fi
         if [[ -v CHAOS_LOOKUP["$pkg"] ]]; then
             found+=("$pkg (installed: $install_date) [CHAOS RAT campaign, 2025-07]")
+        elif [[ -v AUR_AUDIT_BLACK_LOOKUP["$pkg"] ]]; then
+            found+=("$pkg (installed: $install_date) [aur-audit: black]")
+        elif [[ -v AUR_AUDIT_RED_LOOKUP["$pkg"] ]]; then
+            found+=("$pkg (installed: $install_date) [aur-audit: red]")
         else
             found+=("$pkg (installed: $install_date)")
         fi
@@ -1132,6 +1191,10 @@ check_logs() {
 
             if [[ -v CHAOS_LOOKUP[$pkg] ]]; then
                 echo "LOG_HIT: $pkg ($action on $datetime_str) [CHAOS RAT campaign, 2025-07]"
+            elif [[ -v AUR_AUDIT_BLACK_LOOKUP[$pkg] ]]; then
+                echo "LOG_HIT: $pkg ($action on $datetime_str) [aur-audit: black]"
+            elif [[ -v AUR_AUDIT_RED_LOOKUP[$pkg] ]]; then
+                echo "LOG_HIT: $pkg ($action on $datetime_str) [aur-audit: red]"
             else
                 echo "LOG_HIT: $pkg ($action on $datetime_str)"
             fi
@@ -2261,6 +2324,20 @@ for p in "${RUSSIAN_SPAM_PKGS[@]}"; do
     INFECTED_PKGS+=("$p")
 done
 
+# aur-audit.wtako.net black/red — built before merging, same reason as
+# CHAOS_LOOKUP above (source-specific annotation in check_current/check_logs).
+declare -A AUR_AUDIT_BLACK_LOOKUP
+for p in "${AUR_AUDIT_BLACK_PKGS[@]}"; do
+    AUR_AUDIT_BLACK_LOOKUP["$p"]=1
+    INFECTED_PKGS+=("$p")
+done
+
+declare -A AUR_AUDIT_RED_LOOKUP
+for p in "${AUR_AUDIT_RED_PKGS[@]}"; do
+    AUR_AUDIT_RED_LOOKUP["$p"]=1
+    INFECTED_PKGS+=("$p")
+done
+
 # Extra lists — merged last so they appear in INFECTED_LOOKUP
 for p in "${EXTRA_PKGS[@]}"; do
     INFECTED_PKGS+=("$p")
@@ -2285,6 +2362,12 @@ if ! $FOCUSED_MODE; then
     fi
     if [[ ${#RUSSIAN_SPAM_PKGS[@]} -gt 0 ]]; then
         printf "   + Russian Spam%7s pkgs\n" "${#RUSSIAN_SPAM_PKGS[@]}"
+    fi
+    if [[ ${#AUR_AUDIT_BLACK_PKGS[@]} -gt 0 ]]; then
+        printf "   + aur-audit black%4s pkgs\n" "${#AUR_AUDIT_BLACK_PKGS[@]}"
+    fi
+    if [[ ${#AUR_AUDIT_RED_PKGS[@]} -gt 0 ]]; then
+        printf "   + aur-audit red%6s pkgs\n" "${#AUR_AUDIT_RED_PKGS[@]}"
     fi
     if [[ ${#EXTRA_PKGS[@]} -gt 0 ]]; then
         printf "   + extra lists%8s pkgs  (extra_lists.conf / --extra-list)\n" "${#EXTRA_PKGS[@]}"

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -566,7 +566,7 @@ run_doctor() {
                 "path: /usr/share/libalpm/hooks/traur.hook"
         fi
         _opt_dep "lynis (system hardening auditor)" lynis lynis "post-install hardening audit"
-        _opt_item "yay init.lua (archcanary's hooks: upgrade-age warning, pattern block, install log)" "$(_marker "$_ARCHCANARY_LUA_MARKER" "$yay_init_lua")" "" "path: $yay_init_lua"
+        _opt_item "yay init.lua (archcanary's hooks: upgrade-age warning, pattern block, aur-audit black/red check, install log)" "$(_marker "$_ARCHCANARY_LUA_MARKER" "$yay_init_lua")" "" "path: $yay_init_lua"
         printf '\n'
     fi
 

--- a/configs/archcanary-completion.bash
+++ b/configs/archcanary-completion.bash
@@ -1,0 +1,44 @@
+# bash completion for archcanary / canary
+# Installed by install.sh / the AUR package into a bash-completion
+# completions/ directory (system or user) where it loads automatically.
+
+_archcanary() {
+    local cur prev words cword split
+    if declare -F _init_completion >/dev/null; then
+        _init_completion -s || return
+    else
+        cur="${COMP_WORDS[COMP_CWORD]}"
+        prev="${COMP_WORDS[COMP_CWORD-1]:-}"
+        split=false
+    fi
+
+    case "$prev" in
+        --doctor)
+            COMPREPLY=($(compgen -W "platform deps user system systemd external all" -- "$cur"))
+            return 0
+            ;;
+        --color)
+            COMPREPLY=($(compgen -W "auto always never" -- "$cur"))
+            return 0
+            ;;
+        --package-list|--malicious-npm-list|--chaos-rat-list|--russian-spam-list|--extra-list|--log-file)
+            _filedir
+            return 0
+            ;;
+    esac
+    $split && return 0   # e.g. --start-date=, --end-date= — no value completion
+
+    local flags="
+        --check-systemd --check-ebpf --check-npm-cache --check-bun-cache
+        --check-yarn-cache --check-pnpm-cache --check-pkgbuild --check-bpftool
+        --check-ldso --check-autostart --check-kmod --check-lynis
+        --check-pkginteg --full --refresh --verbose -v --debug
+        --no-notify --no-summary --run-lynis --doctor --version -V --help -h
+        --log-file= --package-list= --malicious-npm-list= --chaos-rat-list=
+        --russian-spam-list= --extra-list= --start-date= --end-date=
+        --color= --doctor=
+    "
+    COMPREPLY=($(compgen -W "$flags" -- "$cur"))
+    return 0
+}
+complete -F _archcanary archcanary canary

--- a/configs/yay-init.lua
+++ b/configs/yay-init.lua
@@ -55,6 +55,43 @@ yay.create_autocmd("AURPreInstall", {
   end,
 })
 
+local function _archcanary_config_dir()
+  local xdg = os.getenv("XDG_CONFIG_HOME")
+  if xdg and xdg ~= "" then return xdg .. "/archcanary" end
+  return os.getenv("HOME") .. "/.config/archcanary"
+end
+
+local function _archcanary_load_pkg_set(path)
+  local set = {}
+  local f = io.open(path, "r")
+  if not f then return set end
+  for line in f:lines() do
+    if not line:match("^#") and line:match("%S") then
+      set[line] = true
+    end
+  end
+  f:close()
+  return set
+end
+
+-- aur-audit.wtako.net black/red check (complements the pattern block above;
+-- lists are synced by `archcanary --refresh`, already run weekly by
+-- archcanary.timer — see docs/my-setup.md)
+yay.create_autocmd("AURPreInstall", {
+  desc = "aur-audit.wtako.net black/red check",
+  callback = function(event)
+    local dir = _archcanary_config_dir()
+    local black = _archcanary_load_pkg_set(dir .. "/aur_audit_black.txt")
+    local red   = _archcanary_load_pkg_set(dir .. "/aur_audit_red.txt")
+
+    if black[event.match] then
+      yay.abort(event.match .. ": aur-audit flagged BLACK (confirmed malicious) — https://aur-audit.wtako.net")
+    elseif red[event.match] then
+      yay.log.warn(event.match .. ": aur-audit flagged RED (high-risk, unconfirmed) — review before continuing")
+    end
+  end,
+})
+
 -- Log AUR installs
 yay.create_autocmd("PostInstall", {
   desc = "log AUR installs",

--- a/docs/my-setup.md
+++ b/docs/my-setup.md
@@ -228,12 +228,13 @@ exec env -u EDITOR -u VISUAL aurscan-edit "$@"
 
 — that runs aurscan's edit-hook (`aurscan-edit`) with `EDITOR`/`VISUAL` cleared, so a CLEAN scan proceeds without dropping you into a manual editor and a non-CLEAN verdict exits non-zero, aborting the build. Because yay only invokes the editor for actual builds, non-build operations (`yay -Syu` with nothing to build, `-Ss`, `-Q`, `--version`) are untouched — this is why the old `syay` wrapper alias was dropped.
 
-**2. The yay 13.0 Lua hooks** (`~/.config/yay/init.lua`) — seeded by `install.sh` if not already present (source: [`configs/yay-init.lua`](../configs/yay-init.lua)). An offline backstop that runs alongside the editor-gate:
+**2. The yay 13.0 Lua hooks** (`~/.config/yay/init.lua`) — seeded by `install.sh` **only if the file doesn't already exist** (source: [`configs/yay-init.lua`](../configs/yay-init.lua)). If you already have an `init.lua` from before a hook was added here, `install.sh` won't retrofit it — re-copy `configs/yay-init.lua` by hand (merging in any of your own customizations) to pick up new hooks. An offline backstop that runs alongside the editor-gate:
 
 | Hook | Event | What it does |
 |------|-------|--------------|
 | Upgrade-age warning | `UpgradeSelect` | Warns for any AUR upgrade whose PKGBUILD was modified < 3 days ago (prints hours since change) — a freshly rewritten PKGBUILD is the classic compromise signal |
 | Pattern block | `AURPreInstall` | Aborts the build if the PKGBUILD matches a known-malicious pattern: `npm install atomic-lockfile` (Atomic Arch wave 1), `bun install js-digest` (wave 2), or `curl`/`wget` piped to `bash`/`sh` |
+| aur-audit check | `AURPreInstall` | Aborts on a black (confirmed malicious) hit, warns on red (high-risk, unconfirmed) from the [aur-audit.wtako.net](https://wtako.net/services/aur-audit) feed synced by `--refresh` — the only protection against a malicious AUR package that doesn't require aurscan/an LLM |
 | Install log | `PostInstall` | Logs every installed AUR package (name + version) via `yay.log.info` |
 
 Options set in `init.lua`: `diff_menu = true`, `clean_menu = true`, `sort_by = "votes"`, and **`edit_menu = true`** — `editmenu`/`edit_menu` being on is **required** for the editor-gate: it forces yay to invoke its editor (`aurscan-gate`) on each PKGBUILD, which is the interception point for the scan. `config.json` mirrors the rest of the options and sets `editor=aurscan-gate`.

--- a/docs/my-setup.md
+++ b/docs/my-setup.md
@@ -151,6 +151,8 @@ triggers (timer + `.path` units) are in [systemd.md](systemd.md).
     ├── malicious_npm_packages.txt         # static lists, auto-seeded on first run
     ├── chaos_rat_packages.txt
     ├── malicious_russian_spam_packages.txt
+    ├── aur_audit_black.txt                # synced via --refresh only (no bundled fallback —
+    ├── aur_audit_red.txt                  #   third-party live feed, not ours to snapshot)
     └── extra_lists.conf                   # optional extra list subscriptions (paths/URLs)
 
 ~/.config/yay/

--- a/docs/my-setup.md
+++ b/docs/my-setup.md
@@ -241,6 +241,12 @@ Options set in `init.lua`: `diff_menu = true`, `clean_menu = true`, `sort_by = "
 
 > The two layers are complementary: the editor-gate (aurscan/Claude) catches novel or obfuscated payloads; the Lua hooks are a fast offline backstop for known campaign signatures and stale-rewrite upgrades, and run even if the LLM call is unavailable.
 
+## Shell completion and the `canary` alias
+
+Both install paths (`install.sh` and the AUR package) drop a bash-completion script into `/usr/share/bash-completion/completions/archcanary` (system) or `~/.local/share/bash-completion/completions/archcanary` (user), plus a `canary` symlink alongside it — both load automatically via the `bash-completion` package, no `.bashrc` edits required. `archcanary --<TAB>` lists every flag; `--doctor=<TAB>`, `--color=<TAB>`, and the `--*-list=<TAB>`/`--log-file=<TAB>` flags complete their values (section names, `auto|always|never`, and file paths respectively).
+
+The `canary` completion works standalone, but `canary` itself is only a *name* until you actually alias it — add `alias canary=archcanary` to `.bashrc`/`.zshrc` yourself if you want the shorter command; `install.sh` deliberately doesn't inject this (same "never touch the user's shell rc" rule as everything else here).
+
 ## Known false positives
 
 See [false-positives.md](false-positives.md) for documented signals that fire on benign packages and how to verify them.

--- a/install.sh
+++ b/install.sh
@@ -80,9 +80,15 @@ if $UNINSTALL; then
     if $SYSTEM; then
         sudo rm -f /usr/share/man/man1/archcanary.1
         echo "  removed: /usr/share/man/man1/archcanary.1"
+        sudo rm -f /usr/share/bash-completion/completions/archcanary \
+                   /usr/share/bash-completion/completions/canary
+        echo "  removed: /usr/share/bash-completion/completions/{archcanary,canary}"
     else
         rm -f "${XDG_DATA_HOME:-$HOME/.local/share}/man/man1/archcanary.1"
         echo "  removed: ${XDG_DATA_HOME:-$HOME/.local/share}/man/man1/archcanary.1"
+        rm -f "${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion/completions/archcanary" \
+              "${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion/completions/canary"
+        echo "  removed: ${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion/completions/{archcanary,canary}"
     fi
 
     desktop_dst="${XDG_DATA_HOME:-$HOME/.local/share}/applications/archcanary.desktop"
@@ -169,6 +175,11 @@ if $SYSTEM; then
         | sudo tee /usr/share/man/man1/archcanary.1 >/dev/null
     sudo chmod 644 /usr/share/man/man1/archcanary.1
     echo "  installed: /usr/share/man/man1/archcanary.1"
+    sudo install -d -m 755 /usr/share/bash-completion/completions
+    sudo install -m 644 "$REPO_DIR/configs/archcanary-completion.bash" \
+        /usr/share/bash-completion/completions/archcanary
+    sudo ln -sf archcanary /usr/share/bash-completion/completions/canary
+    echo "  installed: /usr/share/bash-completion/completions/{archcanary,canary}"
 else
     mkdir -p "$USER_BIN"
     install -m 755 "$REPO_DIR/archcanary.sh"    "$USER_BIN/archcanary"
@@ -189,6 +200,11 @@ else
     sed "s/@VERSION@/$_ver/" "$REPO_DIR/man/archcanary.1" > "$MAN_DIR/archcanary.1"
     chmod 644 "$MAN_DIR/archcanary.1"
     echo "  installed: $MAN_DIR/archcanary.1"
+    COMPLETION_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion/completions"
+    mkdir -p "$COMPLETION_DIR"
+    install -m 644 "$REPO_DIR/configs/archcanary-completion.bash" "$COMPLETION_DIR/archcanary"
+    ln -sf archcanary "$COMPLETION_DIR/canary"
+    echo "  installed: $COMPLETION_DIR/{archcanary,canary}"
 fi
 
 # Install desktop entry

--- a/man/archcanary.1
+++ b/man/archcanary.1
@@ -109,6 +109,13 @@ Enable all of the above checks.
 .TP
 .B \-\-refresh
 Download the latest package list from the Arch Linux HedgeDoc before scanning.
+Also refreshes the supplementary npm/CHAOS RAT/Russian Spam lists and syncs
+the black/red package feed from the third-party
+.I aur-audit.wtako.net
+service (continuous community AUR scan; free, unauthenticated API). Hits from
+that feed are merged into the same infected-package check and annotated
+.IR "[aur-audit: black]" " / " "[aur-audit: red]" .
+Yellow (minor/qualitative) findings are not synced.
 .TP
 \fB\-\-package-list\fR=\fIPATH\fR
 Override the infected AUR package list (default:

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -13,6 +13,7 @@ optdepends=(
   'polkit: GUI privilege escalation for root checks'
   'bpf: bpftool for eBPF rootkit detection'
   'yay: AUR helper with Lua hook support'
+  'bash-completion: tab-completion for archcanary/canary flags'
   'aurscan-manticore-release-git: LLM-based PKGBUILD scanner (pre-install gate), builds from source'
   'aurscan-manticore-bin-release-git: LLM-based PKGBUILD scanner (pre-install gate), pre-built binary'
 )
@@ -40,6 +41,11 @@ package() {
 
   # Man page
   install -Dm644 man/archcanary.1 "$pkgdir/usr/share/man/man1/archcanary.1"
+
+  # Bash completion (archcanary + canary alias)
+  install -Dm644 configs/archcanary-completion.bash \
+    "$pkgdir/usr/share/bash-completion/completions/archcanary"
+  ln -sf archcanary "$pkgdir/usr/share/bash-completion/completions/canary"
 
   # System lib: scanner + root helper + threat lists (used by the root scan)
   install -dm755 "$pkgdir/usr/lib/archcanary"

--- a/tests/run_matching_tests.sh
+++ b/tests/run_matching_tests.sh
@@ -195,10 +195,14 @@ test_cli_flag() {
     log_file=$(mktemp)
 
     # Run via env var (existing path)
-    # Pin chaos-rat/russian-spam lists to an empty fixture so the count isn't
-    # inflated by real lists cached under this machine's ~/.config/archcanary.
+    # Pin chaos-rat/russian-spam/aur-audit lists to an empty fixture so the
+    # count isn't inflated by real lists cached under this machine's
+    # ~/.config/archcanary (aur-audit has no CLI override flag by design —
+    # env var is the only pin point, same as PACKAGE_LIST_FILE below).
     local result=0
     PACKAGE_LIST_FILE="$SCRIPT_DIR/fake_package_lists/simple.txt" \
+    AUR_AUDIT_BLACK_LIST="$SCRIPT_DIR/fake_package_lists/empty.txt" \
+    AUR_AUDIT_RED_LIST="$SCRIPT_DIR/fake_package_lists/empty.txt" \
     "$REPO_DIR/archcanary.sh" \
         --chaos-rat-list="$SCRIPT_DIR/fake_package_lists/empty.txt" \
         --russian-spam-list="$SCRIPT_DIR/fake_package_lists/empty.txt" \
@@ -210,6 +214,8 @@ test_cli_flag() {
     else
         # Try with direct --package-list flag
         result=0
+        AUR_AUDIT_BLACK_LIST="$SCRIPT_DIR/fake_package_lists/empty.txt" \
+        AUR_AUDIT_RED_LIST="$SCRIPT_DIR/fake_package_lists/empty.txt" \
         "$REPO_DIR/archcanary.sh" \
             --package-list="$SCRIPT_DIR/fake_package_lists/simple.txt" \
             --chaos-rat-list="$SCRIPT_DIR/fake_package_lists/empty.txt" \


### PR DESCRIPTION
## Summary
- `--refresh` now also syncs the black/red package lists from the third-party [aur-audit.wtako.net](https://wtako.net/services/aur-audit) service (continuous community AUR scan, free/unauthenticated API, paginated). Hits merge into the existing infected-package check, annotated `[aur-audit: black]`/`[aur-audit: red]`. Yellow findings are intentionally not synced. No new dependency, no CLI overrides, no network call outside `--refresh`.
- New `AURPreInstall` yay hook (`configs/yay-init.lua`) checks the about-to-build package against those same synced lists — aborts on black, warns (non-blocking) on red. Gives pre-build protection to anyone who doesn't run aurscan/an LLM. No new systemd unit needed: the existing weekly/on-boot `archcanary.timer` already runs `--refresh`.
- Bash tab-completion (`configs/archcanary-completion.bash`), installed by both `install.sh` and the AUR package into the standard `bash-completion` completions directory. Also registers a `canary` completion (via symlink) for anyone who adds their own `alias canary=archcanary` — no `.bashrc` edits made automatically.
- Fixed a test isolation gap in `tests/run_matching_tests.sh` (`test_cli_flag`) that the aur-audit list sync exposed: its exact package-count assertion wasn't pinning the new `AUR_AUDIT_BLACK_LIST`/`AUR_AUDIT_RED_LIST` env vars, so it would silently inflate on any machine with real synced lists.

## Test plan
- [x] `tests/run_matching_tests.sh` — 34/34 passing
- [x] Live `--refresh` dry run against the real aur-audit API — correct pagination, banner counts, offline reload on subsequent scans
- [x] Manual injection of a known-installed package into the synced black list — confirms `[aur-audit: black]` annotation and exit code fire correctly
- [x] `configs/yay-init.lua` loaded under a stubbed `yay` Lua API (`lua5.1`) — confirms abort/warn/pass-through/missing-file behavior on the real edited file
- [x] Bash completion sourced against the real installed `bash-completion` package — confirms flag/value completion for both `archcanary` and `canary`, and `complete -p` shows both registered
- [ ] Manual `./install.sh --system` + real `yay -S`/tab-completion smoke test on a live shell (not run by Claude — requires sudo / live shell config, left for you)

🤖 Generated with [Claude Code](https://claude.com/claude-code)