### PR TITLE
Show +/- delta on Lists loaded banner

### DIFF
--- a/archcanary.sh
+++ b/archcanary.sh
@@ -2311,6 +2311,10 @@ _print_summary() {
 
 load_packages
 
+# Captured before the merge loops below append the supplementary lists, so
+# it reflects package_list.txt alone (used by the "Lists loaded" banner).
+BASE_PKG_COUNT=${#INFECTED_PKGS[@]}
+
 # Build CHAOS_LOOKUP before merging into INFECTED_PKGS so checks can apply
 # the CHAOS RAT date window separately from the main campaign window.
 declare -A CHAOS_LOOKUP
@@ -2351,26 +2355,47 @@ for p in "${INFECTED_PKGS[@]}"; do
 done
 
 if ! $FOCUSED_MODE; then
+    # Per-list pkg counts from the previous run, so the banner below can show
+    # a "(+N)"/"(-N)" delta and flag when a threat-intel feed grew or shrank.
+    LIST_COUNTS_FILE="$AUR_CONFIG_DIR/.list_counts"
+    declare -A _PREV_LIST_COUNTS
+    if [[ -f "$LIST_COUNTS_FILE" ]]; then
+        while IFS='=' read -r _k _v; do
+            [[ -z "$_k" ]] && continue
+            _PREV_LIST_COUNTS["$_k"]="$_v"
+        done < "$LIST_COUNTS_FILE"
+    fi
+
+    # Prints " (+N)" / " (-N)" against last run's count for key $1, or nothing
+    # if unchanged / not tracked yet (first run, or a newly-populated list).
+    _count_diff() {
+        local prev="${_PREV_LIST_COUNTS[$1]:-}" delta
+        [[ -z "$prev" ]] && return
+        delta=$(( $2 - prev ))
+        [[ $delta -ne 0 ]] && printf ' (%+d)' "$delta"
+    }
+
     echo "============================================================"
     echo " Archcanary v${SCRIPT_VERSION}"
     echo " Scanned: $(date '+%Y-%m-%d %H:%M')"
     echo
     echo " Lists loaded"
-    echo "   $(basename "$PACKAGE_LIST_FILE")  infostealer + eBPF rootkit"
+    printf "   %s  infostealer + eBPF rootkit  %s pkgs%s\n" \
+        "$(basename "$PACKAGE_LIST_FILE")" "$BASE_PKG_COUNT" "$(_count_diff package_list "$BASE_PKG_COUNT")"
     if [[ ${#CHAOS_RAT_PKGS[@]} -gt 0 ]]; then
-        printf "   + CHAOS RAT%10s pkgs\n" "${#CHAOS_RAT_PKGS[@]}"
+        printf "   + CHAOS RAT%10s pkgs%s\n" "${#CHAOS_RAT_PKGS[@]}" "$(_count_diff chaos_rat "${#CHAOS_RAT_PKGS[@]}")"
     fi
     if [[ ${#RUSSIAN_SPAM_PKGS[@]} -gt 0 ]]; then
-        printf "   + Russian Spam%7s pkgs\n" "${#RUSSIAN_SPAM_PKGS[@]}"
+        printf "   + Russian Spam%7s pkgs%s\n" "${#RUSSIAN_SPAM_PKGS[@]}" "$(_count_diff russian_spam "${#RUSSIAN_SPAM_PKGS[@]}")"
     fi
     if [[ ${#AUR_AUDIT_BLACK_PKGS[@]} -gt 0 ]]; then
-        printf "   + aur-audit black%4s pkgs\n" "${#AUR_AUDIT_BLACK_PKGS[@]}"
+        printf "   + aur-audit black%4s pkgs%s\n" "${#AUR_AUDIT_BLACK_PKGS[@]}" "$(_count_diff aur_audit_black "${#AUR_AUDIT_BLACK_PKGS[@]}")"
     fi
     if [[ ${#AUR_AUDIT_RED_PKGS[@]} -gt 0 ]]; then
-        printf "   + aur-audit red%6s pkgs\n" "${#AUR_AUDIT_RED_PKGS[@]}"
+        printf "   + aur-audit red%6s pkgs%s\n" "${#AUR_AUDIT_RED_PKGS[@]}" "$(_count_diff aur_audit_red "${#AUR_AUDIT_RED_PKGS[@]}")"
     fi
     if [[ ${#EXTRA_PKGS[@]} -gt 0 ]]; then
-        printf "   + extra lists%8s pkgs  (extra_lists.conf / --extra-list)\n" "${#EXTRA_PKGS[@]}"
+        printf "   + extra lists%8s pkgs%s  (extra_lists.conf / --extra-list)\n" "${#EXTRA_PKGS[@]}" "$(_count_diff extra "${#EXTRA_PKGS[@]}")"
     fi
     echo
     echo " Packages checked: ${#INFECTED_PKGS[@]}"
@@ -2379,6 +2404,18 @@ if ! $FOCUSED_MODE; then
     fi
     echo "============================================================"
     echo
+
+    # Persist this run's counts as the baseline for the next comparison.
+    {
+        printf 'package_list=%s\n' "$BASE_PKG_COUNT"
+        printf 'chaos_rat=%s\n' "${#CHAOS_RAT_PKGS[@]}"
+        printf 'russian_spam=%s\n' "${#RUSSIAN_SPAM_PKGS[@]}"
+        printf 'aur_audit_black=%s\n' "${#AUR_AUDIT_BLACK_PKGS[@]}"
+        printf 'aur_audit_red=%s\n' "${#AUR_AUDIT_RED_PKGS[@]}"
+        printf 'extra=%s\n' "${#EXTRA_PKGS[@]}"
+    } > "$LIST_COUNTS_FILE"
+    _chown_to_invoker "$LIST_COUNTS_FILE"
+    unset -f _count_diff
 
     log_info "Loaded ${#INFECTED_PKGS[@]} packages from $PACKAGE_LIST_FILE"
 

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -2357,10 +2357,13 @@ done
 if ! $FOCUSED_MODE; then
     # Per-list pkg counts from the previous run, so the banner below can show
     # a "(+N)"/"(-N)" delta and flag when a threat-intel feed grew or shrank.
+    # Keyed by each list's own file path (not a fixed label) so a one-off run
+    # against a different --package-list / test fixture can't clobber the
+    # baseline used by normal scans of the real list.
     LIST_COUNTS_FILE="$AUR_CONFIG_DIR/.list_counts"
     declare -A _PREV_LIST_COUNTS
     if [[ -f "$LIST_COUNTS_FILE" ]]; then
-        while IFS='=' read -r _k _v; do
+        while IFS=$'\t' read -r _k _v; do
             [[ -z "$_k" ]] && continue
             _PREV_LIST_COUNTS["$_k"]="$_v"
         done < "$LIST_COUNTS_FILE"
@@ -2381,21 +2384,21 @@ if ! $FOCUSED_MODE; then
     echo
     echo " Lists loaded"
     printf "   %s  infostealer + eBPF rootkit  %s pkgs%s\n" \
-        "$(basename "$PACKAGE_LIST_FILE")" "$BASE_PKG_COUNT" "$(_count_diff package_list "$BASE_PKG_COUNT")"
+        "$(basename "$PACKAGE_LIST_FILE")" "$BASE_PKG_COUNT" "$(_count_diff "$PACKAGE_LIST_FILE" "$BASE_PKG_COUNT")"
     if [[ ${#CHAOS_RAT_PKGS[@]} -gt 0 ]]; then
-        printf "   + CHAOS RAT%10s pkgs%s\n" "${#CHAOS_RAT_PKGS[@]}" "$(_count_diff chaos_rat "${#CHAOS_RAT_PKGS[@]}")"
+        printf "   + CHAOS RAT%10s pkgs%s\n" "${#CHAOS_RAT_PKGS[@]}" "$(_count_diff "$CHAOS_RAT_LIST" "${#CHAOS_RAT_PKGS[@]}")"
     fi
     if [[ ${#RUSSIAN_SPAM_PKGS[@]} -gt 0 ]]; then
-        printf "   + Russian Spam%7s pkgs%s\n" "${#RUSSIAN_SPAM_PKGS[@]}" "$(_count_diff russian_spam "${#RUSSIAN_SPAM_PKGS[@]}")"
+        printf "   + Russian Spam%7s pkgs%s\n" "${#RUSSIAN_SPAM_PKGS[@]}" "$(_count_diff "$RUSSIAN_SPAM_LIST" "${#RUSSIAN_SPAM_PKGS[@]}")"
     fi
     if [[ ${#AUR_AUDIT_BLACK_PKGS[@]} -gt 0 ]]; then
-        printf "   + aur-audit black%4s pkgs%s\n" "${#AUR_AUDIT_BLACK_PKGS[@]}" "$(_count_diff aur_audit_black "${#AUR_AUDIT_BLACK_PKGS[@]}")"
+        printf "   + aur-audit black%4s pkgs%s\n" "${#AUR_AUDIT_BLACK_PKGS[@]}" "$(_count_diff "$AUR_AUDIT_BLACK_LIST" "${#AUR_AUDIT_BLACK_PKGS[@]}")"
     fi
     if [[ ${#AUR_AUDIT_RED_PKGS[@]} -gt 0 ]]; then
-        printf "   + aur-audit red%6s pkgs%s\n" "${#AUR_AUDIT_RED_PKGS[@]}" "$(_count_diff aur_audit_red "${#AUR_AUDIT_RED_PKGS[@]}")"
+        printf "   + aur-audit red%6s pkgs%s\n" "${#AUR_AUDIT_RED_PKGS[@]}" "$(_count_diff "$AUR_AUDIT_RED_LIST" "${#AUR_AUDIT_RED_PKGS[@]}")"
     fi
     if [[ ${#EXTRA_PKGS[@]} -gt 0 ]]; then
-        printf "   + extra lists%8s pkgs%s  (extra_lists.conf / --extra-list)\n" "${#EXTRA_PKGS[@]}" "$(_count_diff extra "${#EXTRA_PKGS[@]}")"
+        printf "   + extra lists%8s pkgs%s  (extra_lists.conf / --extra-list)\n" "${#EXTRA_PKGS[@]}" "$(_count_diff "$EXTRA_LISTS_CONF" "${#EXTRA_PKGS[@]}")"
     fi
     echo
     echo " Packages checked: ${#INFECTED_PKGS[@]}"
@@ -2405,14 +2408,19 @@ if ! $FOCUSED_MODE; then
     echo "============================================================"
     echo
 
-    # Persist this run's counts as the baseline for the next comparison.
+    # Merge this run's counts into the previously loaded map (rather than
+    # overwriting the file outright) so a one-off run against a different set
+    # of list paths doesn't erase the baseline recorded for the usual ones.
+    _PREV_LIST_COUNTS["$PACKAGE_LIST_FILE"]="$BASE_PKG_COUNT"
+    _PREV_LIST_COUNTS["$CHAOS_RAT_LIST"]="${#CHAOS_RAT_PKGS[@]}"
+    _PREV_LIST_COUNTS["$RUSSIAN_SPAM_LIST"]="${#RUSSIAN_SPAM_PKGS[@]}"
+    _PREV_LIST_COUNTS["$AUR_AUDIT_BLACK_LIST"]="${#AUR_AUDIT_BLACK_PKGS[@]}"
+    _PREV_LIST_COUNTS["$AUR_AUDIT_RED_LIST"]="${#AUR_AUDIT_RED_PKGS[@]}"
+    _PREV_LIST_COUNTS["$EXTRA_LISTS_CONF"]="${#EXTRA_PKGS[@]}"
     {
-        printf 'package_list=%s\n' "$BASE_PKG_COUNT"
-        printf 'chaos_rat=%s\n' "${#CHAOS_RAT_PKGS[@]}"
-        printf 'russian_spam=%s\n' "${#RUSSIAN_SPAM_PKGS[@]}"
-        printf 'aur_audit_black=%s\n' "${#AUR_AUDIT_BLACK_PKGS[@]}"
-        printf 'aur_audit_red=%s\n' "${#AUR_AUDIT_RED_PKGS[@]}"
-        printf 'extra=%s\n' "${#EXTRA_PKGS[@]}"
+        for _k in "${!_PREV_LIST_COUNTS[@]}"; do
+            printf '%s\t%s\n' "$_k" "${_PREV_LIST_COUNTS[$_k]}"
+        done
     } > "$LIST_COUNTS_FILE"
     _chown_to_invoker "$LIST_COUNTS_FILE"
     unset -f _count_diff


### PR DESCRIPTION
## Summary
- Persists each run's per-list package counts to `~/.config/archcanary/.list_counts` and diffs against them on the next run, so the "Lists loaded" banner shows `(+N)`/`(-N)` when a threat-intel feed (aur-audit black/red, CHAOS RAT, Russian Spam, package_list.txt, extra lists) grew or shrank since the last scan.
- Entries are keyed by each list's resolved file path (not a fixed label) and merged into the existing state rather than overwritten, so a one-off run against a different `--package-list` (or the test suite's fixtures) can't clobber the baseline used for the real lists.

## Test plan
- [x] `./tests/run_matching_tests.sh` — 34/34 pass
- [x] Manual run confirms first run shows no diff (no prior baseline), a synthetic prior-count file renders both `(+N)` and `(-N)` correctly, and unchanged lists show nothing
- [x] Confirmed real baseline (`package_list.txt`, `aur_audit_red.txt`, etc.) survives running the test suite afterward — no cross-contamination between real config and test fixtures

```                                              
============================================================
 Archcanary v0.1.19
 Scanned: 2026-07-31 12:42

 Lists loaded
  package_list.txt  infostealer + eBPF rootkit  1936 pkgs                 
     + CHAOS RAT         7 pkgs                                              
     + Russian Spam     75 pkgs                                              
     + aur-audit black  58 pkgs                                              
     + aur-audit red   226 pkgs (-1)

 Packages checked: 2302
============================================================
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)