### PR TITLE
feat: add checkbox/flag to disable the aur-audit.wtako.net feed

### DIFF
--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -339,6 +339,7 @@ edit_config() {
     $HAS_AUDITD && choices+=("Audit rules")
     $HAS_LYNIS  && choices+=("Lynis config")
     choices+=("Extra malware lists")
+    choices+=("Network feeds")
 
     local choice
     choice=$(yad --list \
@@ -355,6 +356,7 @@ edit_config() {
         "Audit rules")        edit_audit_rules ;;
         "Lynis config")       edit_lynis_config ;;
         "Extra malware lists") extra_lists_manager ;;
+        "Network feeds")      edit_network_feeds ;;
     esac
 }
 
@@ -650,6 +652,41 @@ CONF
             --button="OK:0" 2>/dev/null || true
     fi
     rm -f "$tmpout"
+}
+
+# Persisted true/false settings for archcanary.sh itself, written to
+# ~/.config/archcanary/env (sourced by archcanary.sh at startup).
+edit_network_feeds() {
+    local cfg_dir="${XDG_CONFIG_HOME:-$HOME/.config}/archcanary"
+    local env_file="$cfg_dir/env"
+    mkdir -p "$cfg_dir"
+
+    local cur="TRUE"
+    grep -qE '^AUR_AUDIT_ENABLE=false' "$env_file" 2>/dev/null && cur="FALSE"
+
+    local result
+    result=$(yad --form \
+        --title="Network Feeds — Archcanary" \
+        --window-icon=security-high --center \
+        --width=480 \
+        --field="Fetch aur-audit.wtako.net black/red feed on --refresh:CHK" "$cur" \
+        --button="Save:0" --button="Cancel:1" \
+        2>/dev/null) || return 0
+
+    local enable="true"
+    [[ "$result" == FALSE* ]] && enable="false"
+
+    {
+        printf '# archcanary settings — managed by archcanary-gui\n'
+        printf 'AUR_AUDIT_ENABLE=%s\n' "$enable"
+    } > "$env_file"
+
+    yad --image=dialog-information \
+        --title="Archcanary" \
+        --window-icon=security-high --center \
+        --text="Saved to\n<tt>$env_file</tt>" \
+        --width=380 \
+        --button="OK:0" 2>/dev/null || true
 }
 
 run_action() {

--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -655,14 +655,18 @@ CONF
 }
 
 # Persisted true/false settings for archcanary.sh itself, written to
-# ~/.config/archcanary/env (sourced by archcanary.sh at startup).
+# ~/.config/archcanary/env. archcanary.sh reads this file as plain data
+# (grep) — it is NEVER sourced as shell, since the pkexec-elevated root
+# scan resolves this same path under the invoking user's own $HOME (see
+# lib/archcanary-root-helper), and sourcing a user-writable file as root
+# would be a local privilege escalation.
 edit_network_feeds() {
     local cfg_dir="${XDG_CONFIG_HOME:-$HOME/.config}/archcanary"
     local env_file="$cfg_dir/env"
     mkdir -p "$cfg_dir"
 
     local cur="TRUE"
-    grep -qE '^AUR_AUDIT_ENABLE=false' "$env_file" 2>/dev/null && cur="FALSE"
+    grep -qiE '^AUR_AUDIT_ENABLE=false' "$env_file" 2>/dev/null && cur="FALSE"
 
     local result
     result=$(yad --form \
@@ -673,12 +677,9 @@ edit_network_feeds() {
         --button="Save:0" --button="Cancel:1" \
         2>/dev/null) || return 0
 
-    local enable="true"
-    [[ "$result" == FALSE* ]] && enable="false"
-
     {
         printf '# archcanary settings — managed by archcanary-gui\n'
-        printf 'AUR_AUDIT_ENABLE=%s\n' "$enable"
+        [[ "$result" == FALSE* ]] && printf 'AUR_AUDIT_ENABLE=false\n'
     } > "$env_file"
 
     yad --image=dialog-information \

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -128,6 +128,7 @@ for arg in "$@"; do
         --extra-list=*)          EXTRA_LIST_OPTS+=("${arg#*=}") ;;
         --start-date=*)          START_DATE_OPT="${arg#*=}" ;;
         --end-date=*)            END_DATE_OPT="${arg#*=}" ;;
+        --no-aur-audit)          AUR_AUDIT_ENABLE=false ;;
         --no-notify)             NO_NOTIFY=true ;;
         --no-summary)            NO_SUMMARY=true ;;
         --color=*)               _COLOR_ARG="${arg#*=}" ;;
@@ -157,6 +158,7 @@ for arg in "$@"; do
             echo "  --run-lynis        Run a full Lynis audit (lynis audit system) and exit — not included in --full"
             echo "  --full             Enable all checks"
             echo "  --refresh          Download the latest package list before scanning (incl. aur-audit black/red feed)"
+            echo "  --no-aur-audit     Skip the aur-audit.wtako.net feed on --refresh (env: AUR_AUDIT_ENABLE=false)"
             echo "  --verbose, -v, --debug    Verbose output (--debug also enables set -x)"
             echo "  --log-file=PATH           Write full detail log to PATH (auto: ~/.cache/archcanary/aur-check-<date>.log)"
             echo "  --package-list=PATH       Custom infected AUR package list (default: ./package_list.txt)"
@@ -729,6 +731,21 @@ exec > >(tee "$LOG_FILE") 2>&1
 AUR_CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/archcanary"
 mkdir -p "$AUR_CONFIG_DIR"
 
+# Persisted settings written by archcanary-gui's "Edit config" > "Network
+# feeds" dialog. Read as plain data (grep), never `source`d as shell — this
+# file resolves into the invoking user's $HOME even during the pkexec-elevated
+# root scan (see lib/archcanary-root-helper), so sourcing it would let any
+# local user run arbitrary code as root.
+ARCHCANARY_ENV_FILE="${ARCHCANARY_ENV_FILE:-$AUR_CONFIG_DIR/env}"
+# || true twice: grep exits non-zero on no match / missing file, and under
+# `pipefail` that would propagate through tail/cut; under `set -e` a bare
+# `return` would then inherit that non-zero status and kill the whole script
+# (same failure class as the picker bug documented for archcanary-gui.sh).
+_archcanary_env_get() {
+    [[ -f "$ARCHCANARY_ENV_FILE" ]] || return 0
+    grep -E "^$1=" "$ARCHCANARY_ENV_FILE" 2>/dev/null | tail -1 | cut -d= -f2- || true
+}
+
 PACKAGE_LIST_FILE="${PACKAGE_LIST_FILE:-$AUR_CONFIG_DIR/package_list.txt}"
 INFECTED_PKGS=()
 
@@ -743,6 +760,12 @@ AUR_AUDIT_BLACK_PKGS=()
 
 AUR_AUDIT_RED_LIST="${AUR_AUDIT_RED_LIST:-$AUR_CONFIG_DIR/aur_audit_red.txt}"
 AUR_AUDIT_RED_PKGS=()
+
+# Fetch the aur-audit.wtako.net black/red feed on --refresh. Disable via
+# AUR_AUDIT_ENABLE=false (env), --no-aur-audit (one-off), or the GUI checkbox.
+AUR_AUDIT_ENABLE="${AUR_AUDIT_ENABLE:-$(_archcanary_env_get AUR_AUDIT_ENABLE)}"
+AUR_AUDIT_ENABLE="${AUR_AUDIT_ENABLE:-true}"
+unset -f _archcanary_env_get
 
 EXTRA_LISTS_CONF="${EXTRA_LISTS_CONF:-$AUR_CONFIG_DIR/extra_lists.conf}"
 EXTRA_PKGS=()
@@ -968,8 +991,12 @@ load_packages() {
             _chown_to_invoker "$dest"
             echo "Updated $dest ($(grep -c '^[^#[:space:]]' "$dest") entries)"
         }
-        _refresh_aur_audit black "$AUR_AUDIT_BLACK_LIST" "black"
-        _refresh_aur_audit red   "$AUR_AUDIT_RED_LIST"   "red"
+        if [[ "$AUR_AUDIT_ENABLE" == true ]]; then
+            _refresh_aur_audit black "$AUR_AUDIT_BLACK_LIST" "black"
+            _refresh_aur_audit red   "$AUR_AUDIT_RED_LIST"   "red"
+        else
+            echo "Skipping aur-audit.wtako.net fetch (disabled)."
+        fi
         unset -f _refresh_aur_audit
     fi
 

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -763,8 +763,12 @@ AUR_AUDIT_RED_PKGS=()
 
 # Fetch the aur-audit.wtako.net black/red feed on --refresh. Disable via
 # AUR_AUDIT_ENABLE=false (env), --no-aur-audit (one-off), or the GUI checkbox.
+# Lowercased so a hand-edited env file (TRUE/False/etc.) still matches the
+# exact-string gate below, and so it agrees with the GUI's own case-insensitive
+# grep for the checkbox's current state.
 AUR_AUDIT_ENABLE="${AUR_AUDIT_ENABLE:-$(_archcanary_env_get AUR_AUDIT_ENABLE)}"
 AUR_AUDIT_ENABLE="${AUR_AUDIT_ENABLE:-true}"
+AUR_AUDIT_ENABLE="${AUR_AUDIT_ENABLE,,}"
 unset -f _archcanary_env_get
 
 EXTRA_LISTS_CONF="${EXTRA_LISTS_CONF:-$AUR_CONFIG_DIR/extra_lists.conf}"

--- a/configs/archcanary-completion.bash
+++ b/configs/archcanary-completion.bash
@@ -32,7 +32,7 @@ _archcanary() {
         --check-systemd --check-ebpf --check-npm-cache --check-bun-cache
         --check-yarn-cache --check-pnpm-cache --check-pkgbuild --check-bpftool
         --check-ldso --check-autostart --check-kmod --check-lynis
-        --check-pkginteg --full --refresh --verbose -v --debug
+        --check-pkginteg --full --refresh --no-aur-audit --verbose -v --debug
         --no-notify --no-summary --run-lynis --doctor --version -V --help -h
         --log-file= --package-list= --malicious-npm-list= --chaos-rat-list=
         --russian-spam-list= --extra-list= --start-date= --end-date=

--- a/lib/archcanary-root-helper
+++ b/lib/archcanary-root-helper
@@ -22,7 +22,7 @@ if [[ -n "${PKEXEC_UID:-}" ]]; then
     fi
 fi
 
-ALLOWED_FLAGS=(--full --refresh --check-kmod --check-bpftool --check-ebpf --check-lynis --check-pkginteg --run-lynis --no-notify --no-summary)
+ALLOWED_FLAGS=(--full --refresh --no-aur-audit --check-kmod --check-bpftool --check-ebpf --check-lynis --check-pkginteg --run-lynis --no-notify --no-summary)
 
 for _arg in "$@"; do
     _ok=false

--- a/man/archcanary.1
+++ b/man/archcanary.1
@@ -117,6 +117,19 @@ that feed are merged into the same infected-package check and annotated
 .IR "[aur-audit: black]" " / " "[aur-audit: red]" .
 Yellow (minor/qualitative) findings are not synced.
 .TP
+.B \-\-no-aur-audit
+Skip the
+.I aur-audit.wtako.net
+feed on
+.BR \-\-refresh ,
+leaving any previously fetched black/red lists on disk untouched. Persists
+across runs via
+.I AUR_AUDIT_ENABLE=false
+in
+.I ~/.config/archcanary/env
+(also toggleable from
+.BR archcanary-gui "'s Edit config " "Network feeds" " dialog)."
+.TP
 \fB\-\-package-list\fR=\fIPATH\fR
 Override the infected AUR package list (default:
 .IR ~/.config/archcanary/package_list.txt ).


### PR DESCRIPTION
## Summary
- Adds `--no-aur-audit` (one-off CLI flag) and `AUR_AUDIT_ENABLE=false` (env var) to skip the aur-audit.wtako.net black/red feed fetch on `--refresh`, scoped to just that feed (the main package list and npm/CHAOS-RAT/spam list fetches are unaffected).
- Adds a persisted GUI checkbox: `archcanary-gui` → Edit config → Network feeds, writing `AUR_AUDIT_ENABLE` to `~/.config/archcanary/env`.
- That env file is read as plain data (grep) and deliberately never `source`d — `lib/archcanary-root-helper` rebinds `$HOME` to the invoking user's home during the pkexec-elevated root scan, so sourcing a user-writable file there would be a local privilege escalation. Caught and fixed pre-commit.
- `/code-review high` follow-up fixes: stale comment contradicting the no-source security rationale, `--no-aur-audit` added to root-helper's flag allowlist, case-insensitive matching so the GUI checkbox can't desync from actual scan behavior on a hand-edited env file, and the GUI now omits the key entirely when left at its default.

## Test plan
- [x] `tests/run_matching_tests.sh` — 34/34 pass
- [x] Manual: default run fetches the feed; `--no-aur-audit` skips it; env-file `AUR_AUDIT_ENABLE=false` skips it; env-var override wins over the file; hand-edited `TRUE`/`FALSE` casing matches on both the GUI and scan side
- [x] Verified a crafted env file cannot execute code (confirms the no-`source` fix holds)
- [x] `man/archcanary.1` renders clean (`man -l`, no warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)