### PR TITLE
chore: set real sha256 for v0.1.20 release tarball

### DIFF
--- a/packaging/.SRCINFO
+++ b/packaging/.SRCINFO
@@ -21,6 +21,6 @@ pkgbase = archcanary
 	backup = etc/archcanary/bpftool_allowlist.conf
 	backup = etc/archcanary/autostart_allowlist.conf
 	source = archcanary-0.1.20.tar.gz::https://github.com/musqz/archcanary/archive/v0.1.20.tar.gz
-	sha256sums = SKIP
+	sha256sums = 422ff4208bbe713b458441a1e77d8ac3dd19a8a683835b12320645c2939d909b
 
 pkgname = archcanary

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -23,7 +23,7 @@ backup=('etc/archcanary/dkms_allowlist.conf'
         'etc/archcanary/autostart_allowlist.conf')
 install=archcanary.install
 source=("$pkgname-$pkgver.tar.gz::https://github.com/musqz/$pkgname/archive/v$pkgver.tar.gz")
-sha256sums=('SKIP')
+sha256sums=('422ff4208bbe713b458441a1e77d8ac3dd19a8a683835b12320645c2939d909b')
 
 package() {
   cd "$srcdir/$pkgname-$pkgver"


### PR DESCRIPTION
## Summary
- Real sha256 for the tagged `v0.1.20` release tarball, replacing the `SKIP` placeholder from #106/#107.
- `packaging/.SRCINFO` regenerated to match.
- Does not move the `v0.1.20` tag.

## Test plan
- [x] Extracted `version.txt` from the downloaded tarball — reads `0.1.20`
- [x] Spot-checked `archcanary-gui.sh` inside the tarball for the "Scan settings" feature (from #104) — present
- [x] `makepkg --verifysource` locally — sha256 passes against the live download

🤖 Generated with [Claude Code](https://claude.com/claude-code)