### PR TITLE
feat: add --check-list-overlap to flag duplicate package names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Added: `--check-list-overlap` flags package names duplicated across loaded lists. A custom list (`extra_lists.conf`/`--extra-list`) entry already covered by an official list (`package_list.txt`, CHAOS RAT, Russian Spam, aur-audit black/red) is reported as safe to remove, since the official list is authoritative. Duplicates *between* official lists are also reported, informational only. Advisory-only — never affects the exit status, and not included in `--full`.
+
 ## v0.1.20 (2026-08-01)
 
 - Added: `--refresh` now also syncs the black/red package lists from the third-party [aur-audit.wtako.net](https://wtako.net/services/aur-audit) service (continuous community AUR scan feed, free/unauthenticated API). Hits merge into the existing infected-package check, annotated `[aur-audit: black]`/`[aur-audit: red]`. Yellow (qualitative/minor) findings are not synced. Purely additive — no new dependency, no network call outside `--refresh`, no CLI overrides.

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -77,6 +77,7 @@ CHECK_AUTOSTART=false
 CHECK_KMOD=false
 CHECK_LYNIS=false
 CHECK_PKGINTEG=false
+CHECK_LIST_OVERLAP=false
 CHECK_FULL=false
 REFRESH_PACKAGE_LIST=false
 VERBOSE=false
@@ -116,6 +117,7 @@ for arg in "$@"; do
         --check-kmod)       CHECK_KMOD=true ;;
         --check-lynis)      CHECK_LYNIS=true ;;
         --check-pkginteg)   CHECK_PKGINTEG=true ;;
+        --check-list-overlap) CHECK_LIST_OVERLAP=true ;;
         --full)          CHECK_SYSTEMD=true; CHECK_EBPF=true; CHECK_NPM_CACHE=true; CHECK_BUN_CACHE=true; CHECK_YARN_CACHE=true; CHECK_PNPM_CACHE=true; CHECK_PKGBUILD=true; CHECK_BPFTOOL=true; CHECK_LDSO=true; CHECK_AUTOSTART=true; CHECK_KMOD=true; CHECK_LYNIS=true; CHECK_PKGINTEG=true; CHECK_FULL=true ;;
         --refresh)               REFRESH_PACKAGE_LIST=true ;;
         --verbose|-v)            VERBOSE=true ;;
@@ -155,6 +157,8 @@ for arg in "$@"; do
             echo "  --check-kmod       Audit loaded kernel modules against pacman-tracked files (needs root)"
             echo "  --check-lynis      Parse Lynis hardening report (/var/log/lynis-report.dat)"
             echo "  --check-pkginteg   Verify installed file checksums against pacman database (SHA256 mismatch)"
+            echo "  --check-list-overlap  Flag package names duplicated across lists (custom vs. official, and"
+            echo "                        across official lists) — advisory only, not included in --full"
             echo "  --run-lynis        Run a full Lynis audit (lynis audit system) and exit — not included in --full"
             echo "  --full             Enable all checks"
             echo "  --refresh          Download the latest package list before scanning (incl. aur-audit black/red feed)"
@@ -2235,6 +2239,71 @@ check_pkginteg() {
 }
 
 # ---------------------------------------------------------------------------
+# Check 14: Duplicate package names across loaded lists
+# Advisory only — never affects EXIT_CODE. A custom list (extra_lists.conf /
+# --extra-list) that duplicates an official list's entry is redundant; the
+# official list is authoritative, so the custom entry is flagged as safe to
+# remove. Also reports duplicates BETWEEN official lists (informational —
+# maintainer's call, not something a user should "fix" locally).
+# ---------------------------------------------------------------------------
+check_list_overlap() {
+    local -A owner=()   # pkgname -> comma-joined official list labels
+    local pkg
+
+    # INFECTED_PKGS is package_list.txt merged with every other list further
+    # down (for the unified detection lookup) — BASE_PKG_COUNT was captured
+    # right before that merge, so slice back to just the package_list.txt
+    # portion rather than re-reading the file.
+    local -a _base_pkgs=("${INFECTED_PKGS[@]:0:$BASE_PKG_COUNT}")
+    for pkg in "${_base_pkgs[@]}";        do owner["$pkg"]="${owner[$pkg]:+${owner[$pkg]}, }package_list.txt"; done
+    for pkg in "${CHAOS_RAT_PKGS[@]}";     do owner["$pkg"]="${owner[$pkg]:+${owner[$pkg]}, }CHAOS RAT";       done
+    for pkg in "${RUSSIAN_SPAM_PKGS[@]}";  do owner["$pkg"]="${owner[$pkg]:+${owner[$pkg]}, }Russian Spam";    done
+    for pkg in "${AUR_AUDIT_BLACK_PKGS[@]}"; do owner["$pkg"]="${owner[$pkg]:+${owner[$pkg]}, }aur-audit black"; done
+    for pkg in "${AUR_AUDIT_RED_PKGS[@]}";   do owner["$pkg"]="${owner[$pkg]:+${owner[$pkg]}, }aur-audit red";   done
+
+    local -a official_dupes=()
+    for pkg in "${!owner[@]}"; do
+        [[ "${owner[$pkg]}" == *,* ]] && official_dupes+=("$pkg  (${owner[$pkg]})")
+    done
+
+    # Custom lists aren't kept as per-source arrays after loading (only the
+    # combined EXTRA_PKGS), so re-resolve each source's own file here — same
+    # cache-path logic _load_extra uses for a URL source.
+    local -a custom_dupes=()
+    local i orig path line
+    for i in "${!EXTRA_LIST_KEYS[@]}"; do
+        orig="${EXTRA_LIST_KEYS[$i]}"
+        if [[ "$orig" =~ ^https?:// ]]; then
+            path="$AUR_CONFIG_DIR/extra_$(printf '%s' "$orig" | md5sum | cut -c1-8).txt"
+        else
+            path="$orig"
+        fi
+        [[ -f "$path" ]] || continue
+        while IFS= read -r line; do
+            [[ "$line" =~ ^#.*$ || -z "$line" ]] && continue
+            [[ -n "${owner[$line]:-}" ]] && custom_dupes+=("$line  —  ${EXTRA_LIST_NAMES[$i]}  (also in: ${owner[$line]})")
+        done < "$path"
+    done
+
+    if [[ ${#custom_dupes[@]} -eq 0 && ${#official_dupes[@]} -eq 0 ]]; then
+        echo "  No duplicate package names found across any loaded list."
+        return 0
+    fi
+
+    if [[ ${#custom_dupes[@]} -gt 0 ]]; then
+        printf '  %d custom-list entr%s already covered by an official list (safe to remove):\n' \
+            "${#custom_dupes[@]}" "$([[ ${#custom_dupes[@]} -eq 1 ]] && echo y || echo ies)"
+        printf '    - %s\n' "${custom_dupes[@]}"
+        echo
+    fi
+    if [[ ${#official_dupes[@]} -gt 0 ]]; then
+        printf '  %d duplicate(s) across official lists (informational only):\n' "${#official_dupes[@]}"
+        printf '    - %s\n' "${official_dupes[@]}"
+    fi
+    return 0
+}
+
+# ---------------------------------------------------------------------------
 # Check 12: Lynis hardening report
 # Parses /var/log/lynis-report.dat (written by: sudo lynis audit system).
 # Reports the hardening index and warnings from the last Lynis run.
@@ -2600,6 +2669,13 @@ if $CHECK_PKGINTEG; then
     check_pkginteg && ret=$? || ret=$?
     _apply_ret "$ret" pkginteg
     _rec "Package integrity" "$ret"
+    echo
+fi
+
+if $CHECK_LIST_OVERLAP; then
+    echo "--- [14] Duplicate package names across lists ---"
+    check_list_overlap
+    _rec "List overlap check" 0
     echo
 fi
 

--- a/configs/archcanary-completion.bash
+++ b/configs/archcanary-completion.bash
@@ -32,7 +32,7 @@ _archcanary() {
         --check-systemd --check-ebpf --check-npm-cache --check-bun-cache
         --check-yarn-cache --check-pnpm-cache --check-pkgbuild --check-bpftool
         --check-ldso --check-autostart --check-kmod --check-lynis
-        --check-pkginteg --full --refresh --no-aur-audit --verbose -v --debug
+        --check-pkginteg --check-list-overlap --full --refresh --no-aur-audit --verbose -v --debug
         --no-notify --no-summary --run-lynis --doctor --version -V --help -h
         --log-file= --package-list= --malicious-npm-list= --chaos-rat-list=
         --russian-spam-list= --extra-list= --start-date= --end-date=

--- a/man/archcanary.1
+++ b/man/archcanary.1
@@ -103,6 +103,18 @@ Running as root gives complete coverage; as a regular user
 silently skips files it cannot read.
 Requires root.
 .TP
+.B \-\-check-list-overlap
+Flag package names that appear in more than one loaded list. A custom list
+.RI ( extra_lists.conf " or " \-\-extra\-list )
+entry already covered by an official list
+.RI ( package_list.txt ", CHAOS RAT, Russian Spam, or aur-audit black/red)"
+is reported as safe to remove — the official list is authoritative.
+Duplicates
+.I between
+official lists are also reported, informational only.
+Advisory only: never affects the exit status, and not included in
+.BR \-\-full .
+.TP
 .B \-\-full
 Enable all of the above checks.
 .SS List management


### PR DESCRIPTION
## Summary
- New `--check-list-overlap` flag: cross-references every loaded list (`package_list.txt`, CHAOS RAT, Russian Spam, aur-audit black/red, and any custom `extra_lists.conf`/`--extra-list` source) for duplicate package names.
- A custom-list entry already covered by an official list is reported as safe to remove (official list wins). Duplicates *between* official lists are reported separately, informational only.
- Advisory only: always returns 0, never affects the scan's exit code. Not included in `--full` — it's a list-hygiene report, not a security check.

## Test plan
- [x] `tests/run_matching_tests.sh` — 33/34 pass (1 pre-existing unrelated failure, same as master)
- [x] Synthetic fixture test: confirmed correct output for custom-vs-official overlap, official-vs-official overlap, entries unique to only one list (no false positive), and the fully-clean case
- [x] Ran against real local data — surfaced 27 genuine overlaps between a real custom list and the official feeds (including one against `package_list.txt` itself) and 101 real aur-audit black/red overlaps
- [x] Caught + fixed a real bug during testing: `INFECTED_PKGS` has every other list merged into it later in the script (for the unified detection lookup), so it had to be sliced back to `BASE_PKG_COUNT` rather than read directly — first test run produced false positives before this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)