### PR TITLE
feat: surface --check-list-overlap in the GUI, show exact file to fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Added: `--check-list-overlap` flags package names duplicated across loaded lists. A custom list (`extra_lists.conf`/`--extra-list`) entry already covered by an official list (`package_list.txt`, CHAOS RAT, Russian Spam, aur-audit black/red) is reported as safe to remove, along with the exact file path to remove it from, since the official list is authoritative. Duplicates *between* official lists are also reported, informational only (no path, since those aren't meant to be hand-edited). Advisory-only — never affects the exit status, and not included in `--full`. Also reachable from the GUI: `archcanary-gui` → Edit config → List overlap check, which runs it and shows just its own report (with a live duplicate count in the window title) rather than a full scan.
+- Changed: the check summary row for `--check-list-overlap` now shows a warning glyph (not always "clean") when custom-list duplicates are found, and a clear wrap-up prints right after the final RESULT banner — total duplicate count plus a "remove N entries from: PATH" line per affected file — instead of requiring a scroll back up to the section's raw output to figure out what to actually do. Shown in the GUI report too.
 
 ## v0.1.20 (2026-08-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Added: `--check-list-overlap` flags package names duplicated across loaded lists. A custom list (`extra_lists.conf`/`--extra-list`) entry already covered by an official list (`package_list.txt`, CHAOS RAT, Russian Spam, aur-audit black/red) is reported as safe to remove, since the official list is authoritative. Duplicates *between* official lists are also reported, informational only. Advisory-only — never affects the exit status, and not included in `--full`.
+- Added: `--check-list-overlap` flags package names duplicated across loaded lists. A custom list (`extra_lists.conf`/`--extra-list`) entry already covered by an official list (`package_list.txt`, CHAOS RAT, Russian Spam, aur-audit black/red) is reported as safe to remove, along with the exact file path to remove it from, since the official list is authoritative. Duplicates *between* official lists are also reported, informational only (no path, since those aren't meant to be hand-edited). Advisory-only — never affects the exit status, and not included in `--full`. Also reachable from the GUI: `archcanary-gui` → Edit config → List overlap check, which runs it and shows just its own report (with a live duplicate count in the window title) rather than a full scan.
 
 ## v0.1.20 (2026-08-01)
 

--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -709,14 +709,21 @@ scan_settings() {
 # rest of a default scan) in a read-only window. Fast/local (no network), so
 # run synchronously rather than through show_output()'s live-tail machinery.
 list_overlap_check() {
-    local raw body count
+    local raw body hint count
     raw="$("$MAIN_SCRIPT" --check-list-overlap --no-notify --no-summary 2>&1)"
     body="$(awk '/^--- \[14\] /{f=1; next} /^--- \[/{f=0} /^===/{f=0} f' <<< "$raw")"
+    # The "quick fix" wrap-up (which file to remove which entries from) is
+    # printed near the very end of the scan, after the RESULT banner — outside
+    # the section [14] body captured above — so pull it in separately.
+    hint="$(awk '/^ LIST OVERLAP:/{f=1} f && !/^===/' <<< "$raw")"
     count="$(grep -c '^    - ' <<< "$body" || true)"
 
     local tmpout
     tmpout="$(mktemp /tmp/archcanary-XXXXXX.txt)"
-    printf '%s\n' "$body" > "$tmpout"
+    {
+        printf '%s\n' "$body"
+        [[ -n "$hint" ]] && printf '\n%s\n' "$hint"
+    } > "$tmpout"
 
     yad --text-info \
         --title="List Overlap Check (${count} found) — Archcanary" \

--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -351,6 +351,7 @@ edit_config() {
     $HAS_AUDITD && choices+=("Audit rules")
     $HAS_LYNIS  && choices+=("Lynis config")
     choices+=("Extra malware lists")
+    choices+=("List overlap check")
 
     local choice
     choice=$(yad --list \
@@ -367,6 +368,7 @@ edit_config() {
         "Audit rules")        edit_audit_rules ;;
         "Lynis config")       edit_lynis_config ;;
         "Extra malware lists") extra_lists_manager ;;
+        "List overlap check") list_overlap_check ;;
     esac
 }
 
@@ -701,6 +703,30 @@ scan_settings() {
         --text="Saved to\n<tt>$env_file</tt>" \
         --width=380 \
         --button="OK:0" 2>/dev/null || true
+}
+
+# Runs --check-list-overlap and shows just its own report section (not the
+# rest of a default scan) in a read-only window. Fast/local (no network), so
+# run synchronously rather than through show_output()'s live-tail machinery.
+list_overlap_check() {
+    local raw body count
+    raw="$("$MAIN_SCRIPT" --check-list-overlap --no-notify --no-summary 2>&1)"
+    body="$(awk '/^--- \[14\] /{f=1; next} /^--- \[/{f=0} /^===/{f=0} f' <<< "$raw")"
+    count="$(grep -c '^    - ' <<< "$body" || true)"
+
+    local tmpout
+    tmpout="$(mktemp /tmp/archcanary-XXXXXX.txt)"
+    printf '%s\n' "$body" > "$tmpout"
+
+    yad --text-info \
+        --title="List Overlap Check (${count} found) — Archcanary" \
+        --window-icon=security-high --center \
+        --width=760 --height=460 \
+        --fontname="Monospace 10" \
+        --wrap \
+        --filename="$tmpout" \
+        --button="Close:0" 2>/dev/null || true
+    rm -f "$tmpout"
 }
 
 run_action() {

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -2281,7 +2281,7 @@ check_list_overlap() {
         [[ -f "$path" ]] || continue
         while IFS= read -r line; do
             [[ "$line" =~ ^#.*$ || -z "$line" ]] && continue
-            [[ -n "${owner[$line]:-}" ]] && custom_dupes+=("$line  —  ${EXTRA_LIST_NAMES[$i]}  (also in: ${owner[$line]})")
+            [[ -n "${owner[$line]:-}" ]] && custom_dupes+=("$line  —  also in: ${owner[$line]}  →  remove from: $path")
         done < "$path"
     done
 

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -2269,8 +2269,15 @@ check_list_overlap() {
     # Custom lists aren't kept as per-source arrays after loading (only the
     # combined EXTRA_PKGS), so re-resolve each source's own file here — same
     # cache-path logic _load_extra uses for a URL source.
+    #
+    # LIST_OVERLAP_CUSTOM_TOTAL / LIST_OVERLAP_FILE_COUNTS are globals (no
+    # `local`/declared with -g) — read by the caller after this function
+    # returns, to print a "what to actually do" wrap-up hint at the very end
+    # of the scan instead of leaving it buried in this section's own output.
     local -a custom_dupes=()
     local i orig path line
+    LIST_OVERLAP_CUSTOM_TOTAL=0
+    declare -gA LIST_OVERLAP_FILE_COUNTS=()
     for i in "${!EXTRA_LIST_KEYS[@]}"; do
         orig="${EXTRA_LIST_KEYS[$i]}"
         if [[ "$orig" =~ ^https?:// ]]; then
@@ -2281,7 +2288,11 @@ check_list_overlap() {
         [[ -f "$path" ]] || continue
         while IFS= read -r line; do
             [[ "$line" =~ ^#.*$ || -z "$line" ]] && continue
-            [[ -n "${owner[$line]:-}" ]] && custom_dupes+=("$line  —  also in: ${owner[$line]}  →  remove from: $path")
+            if [[ -n "${owner[$line]:-}" ]]; then
+                custom_dupes+=("$line  —  also in: ${owner[$line]}  →  remove from: $path")
+                LIST_OVERLAP_CUSTOM_TOTAL=$(( LIST_OVERLAP_CUSTOM_TOTAL + 1 ))
+                LIST_OVERLAP_FILE_COUNTS["$path"]=$(( ${LIST_OVERLAP_FILE_COUNTS["$path"]:-0} + 1 ))
+            fi
         done < "$path"
     done
 
@@ -2675,7 +2686,14 @@ fi
 if $CHECK_LIST_OVERLAP; then
     echo "--- [14] Duplicate package names across lists ---"
     check_list_overlap
-    _rec "List overlap check" 0
+    # Warn (not clean) in the summary iff there's something actually
+    # actionable — official-vs-official overlap is expected/informational,
+    # not something the user needs to go fix.
+    if [[ "${LIST_OVERLAP_CUSTOM_TOTAL:-0}" -gt 0 ]]; then
+        _rec "List overlap check" 1
+    else
+        _rec "List overlap check" 0
+    fi
     echo
 fi
 
@@ -2704,6 +2722,16 @@ if [[ ${#SKIPPED_ROOT[@]} -gt 0 ]]; then
 fi
 if [[ ${#SKIPPED_MISSING[@]} -gt 0 ]]; then
     printf ' INCOMPLETE: %d optional check(s) skipped (tool not installed): %s\n' "${#SKIPPED_MISSING[@]}" "${SKIPPED_MISSING[*]}"
+fi
+if [[ "${LIST_OVERLAP_CUSTOM_TOTAL:-0}" -gt 0 ]]; then
+    printf ' %sLIST OVERLAP: %d duplicate(s) in your custom list(s) — already covered by an official list.%s\n' \
+        "$_CY" "$LIST_OVERLAP_CUSTOM_TOTAL" "$_CN"
+    for _f in "${!LIST_OVERLAP_FILE_COUNTS[@]}"; do
+        printf ' → Remove %d entr%s from: %s\n' \
+            "${LIST_OVERLAP_FILE_COUNTS[$_f]}" \
+            "$([[ ${LIST_OVERLAP_FILE_COUNTS[$_f]} -eq 1 ]] && echo y || echo ies)" \
+            "$_f"
+    done
 fi
 printf '%s============================================================%s\n' "$_CB" "$_CN"
 


### PR DESCRIPTION
## Summary
- `archcanary-gui`: new "List overlap check" choice under **Edit config**. Runs `--check-list-overlap` synchronously and shows just its own report section (not a full scan's worth of output) in a read-only window titled with the live duplicate count, e.g. "List Overlap Check (128 found)".
- `archcanary.sh`: custom-list duplicates now report the entry's actual resolved file path (e.g. `/home/user/.config/archcanary/my-list.txt`) instead of just the list's basename — directly actionable, no need to cross-reference `extra_lists.conf` to find which file to edit. Official-vs-official duplicates deliberately stay path-free (those files are managed by `--refresh`, not meant to be hand-edited).

## Test plan
- [x] `tests/run_matching_tests.sh` — 33/34 pass (1 pre-existing unrelated failure, same as master)
- [x] CLI: verified file paths appear correctly for custom-list dupes, and are absent for official-vs-official dupes
- [x] GUI: launched the real app, navigated Edit config → List overlap check, confirmed the window title shows the correct live count and the body shows only the relevant report section (not the rest of a default scan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)