### PR TITLE
feat: give a ready-to-run removal command for list-overlap dupes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Added: `--check-list-overlap` notes custom list (`extra_lists.conf`/`--extra-list`) entries already covered by an official list (`package_list.txt`, CHAOS RAT, Russian Spam, aur-audit black/red) — grouped by file, safe to remove, since the official list is authoritative. A note, not a warning: always shows "clean" in the check summary and never affects the exit status, and not included in `--full`. The same note prints twice — once in its own section, once again right after the final RESULT banner — so it's visible without scrolling back up. Also reachable from the GUI: `archcanary-gui` → Edit config → List overlap check, which runs it and shows just its own report (with the live count in the window title) rather than a full scan.
+- Added: `--check-list-overlap` notes custom list (`extra_lists.conf`/`--extra-list`) entries already covered by an official list (`package_list.txt`, CHAOS RAT, Russian Spam, aur-audit black/red) — grouped by file, each with a ready-to-run `sed` command to remove exactly those entries, since the official list is authoritative. A note, not a warning: always shows "clean" in the check summary and never affects the exit status, and not included in `--full`. The same note prints twice — once in its own section, once again right after the final RESULT banner — so it's visible without scrolling back up. Also reachable from the GUI: `archcanary-gui` → Edit config → List overlap check, which runs it and shows just its own report (with the live count in the window title) rather than a full scan.
 
 ## v0.1.20 (2026-08-01)
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Every scan prints a per-check summary before the final verdict:
 | `--check-lynis` | Read last Lynis report — hardening index, warnings, scan date | Yes |
 | `--run-lynis` | Run `lynis audit system`, stream output | Yes |
 | `--check-pkginteg` | Verify installed file checksums via `pacman -Qkk`. Reports SHA256 mismatches on non-backup, non-factory files. Backup files (pacman-managed configs expected to diverge) and `/factory/` paths are filtered out. Prioritise hits in `/usr/bin/`, `/usr/lib/`, `/usr/sbin/`. | Yes |
-| `--check-list-overlap` | A note, not a warning: custom (`--extra-list`) entries already covered by an official list, grouped by file — safe to remove, since the official list is authoritative. Never affects the exit code or the check summary, and not included in `--full`. Also reachable from the GUI: Edit config → List overlap check. | No |
+| `--check-list-overlap` | A note, not a warning: custom (`--extra-list`) entries already covered by an official list are grouped by file, with a ready-to-run `sed` command to remove them — safe to remove, since the official list is authoritative. Never affects the exit code or the check summary, and not included in `--full`. Also reachable from the GUI: Edit config → List overlap check. | No |
 | `--full` | All of the above except `--check-list-overlap` | Partial |
 | `--refresh` | Fetch the live package list from the Arch Linux HedgeDoc, plus the supplementary npm/CHAOS RAT/Russian Spam lists and the aur-audit black/red feed | — |
 | `--no-aur-audit` | Skip the aur-audit.wtako.net feed on `--refresh`. Persists via `AUR_AUDIT_ENABLE=false` in `~/.config/archcanary/env`, also toggleable from the GUI's Scan settings menu row | — |

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -2266,10 +2266,10 @@ check_list_overlap() {
     # combined EXTRA_PKGS), so re-resolve each source's own file here — same
     # cache-path logic _load_extra uses for a URL source.
     #
-    # LIST_OVERLAP_CUSTOM_TOTAL / LIST_OVERLAP_FILE_PKGS are globals (no
-    # `local`/declared with -g) — read by the caller after this function
-    # returns, to print the same note again at the very end of the scan
-    # instead of leaving it buried in this section's own output.
+    # LIST_OVERLAP_CUSTOM_TOTAL / LIST_OVERLAP_FILE_PKGS / LIST_OVERLAP_FILE_CMD
+    # are globals (no `local`/declared with -g) — read by the caller after
+    # this function returns, to print the same note again at the very end of
+    # the scan instead of leaving it buried in this section's own output.
     local i orig path line
     LIST_OVERLAP_CUSTOM_TOTAL=0
     declare -gA LIST_OVERLAP_FILE_PKGS=()
@@ -2295,10 +2295,25 @@ check_list_overlap() {
         return 0
     fi
 
-    printf '  NOTE: %d package(s) below are already covered by an official list — safe to remove:\n' \
-        "$LIST_OVERLAP_CUSTOM_TOTAL"
+    # Build a ready-to-run removal command per file — an ERE alternation of
+    # the exact duplicate names, anchored per line. Package names can only
+    # contain [a-z0-9@._+-] (pacman naming rules); of those, only . and +
+    # are ERE metacharacters, so those are the only two that need escaping.
+    local pattern
+    declare -gA LIST_OVERLAP_FILE_CMD=()
     for path in "${!LIST_OVERLAP_FILE_PKGS[@]}"; do
-        printf '    %s: %s\n' "$path" "${LIST_OVERLAP_FILE_PKGS[$path]}"
+        pattern="${LIST_OVERLAP_FILE_PKGS[$path]//, /|}"
+        pattern="${pattern//./\\.}"
+        pattern="${pattern//+/\\+}"
+        LIST_OVERLAP_FILE_CMD["$path"]="sed -i -E '/^(${pattern})\$/d' '$path'"
+    done
+
+    printf '  NOTE: %d package(s) below are already covered by an official list — safe to remove.\n' \
+        "$LIST_OVERLAP_CUSTOM_TOTAL"
+    printf '  Run the command shown for each file to remove them:\n\n'
+    for path in "${!LIST_OVERLAP_FILE_PKGS[@]}"; do
+        printf '    %s\n' "$path"
+        printf '      %s\n\n' "${LIST_OVERLAP_FILE_CMD[$path]}"
     done
     return 0
 }
@@ -2711,7 +2726,8 @@ if [[ "${LIST_OVERLAP_CUSTOM_TOTAL:-0}" -gt 0 ]]; then
     printf ' %sNOTE: %d package(s) in your custom list(s) are already covered by an official list — safe to remove.%s\n' \
         "$_CC" "$LIST_OVERLAP_CUSTOM_TOTAL" "$_CN"
     for _f in "${!LIST_OVERLAP_FILE_PKGS[@]}"; do
-        printf '   %s: %s\n' "$_f" "${LIST_OVERLAP_FILE_PKGS[$_f]}"
+        printf '   %s\n' "$_f"
+        printf '     %s\n' "${LIST_OVERLAP_FILE_CMD[$_f]}"
     done
 fi
 printf '%s============================================================%s\n' "$_CB" "$_CN"

--- a/man/archcanary.1
+++ b/man/archcanary.1
@@ -108,9 +108,11 @@ Note custom list
 .RI ( extra_lists.conf " or " \-\-extra\-list )
 entries already covered by an official list
 .RI ( package_list.txt ", CHAOS RAT, Russian Spam, or aur-audit black/red)"
-— safe to remove, since the official list is authoritative. A note, not a
-warning: never affects the exit status, never warns in the check summary,
-and not included in
+— safe to remove, since the official list is authoritative. Prints a
+ready-to-run
+.B sed
+command per affected file. A note, not a warning: never affects the exit
+status, never warns in the check summary, and not included in
 .BR \-\-full .
 .TP
 .B \-\-full


### PR DESCRIPTION
## Summary
Real-world feedback after running `--check-list-overlap` on 27 actual duplicates: the flat "file: pkg1, pkg2, pkg3, ..." dump wasn't friendly, and what's actually needed is the command to fix it, not just the list of names.

For each affected file, the note now includes a ready-to-run command:
```
/home/user/.config/archcanary/archlinux-list.txt
  sed -i -E '/^(pkg1|pkg2|pkg3)$/d' '/home/user/.config/archcanary/archlinux-list.txt'
```

Package names only ever contain `[a-z0-9@._+-]` per pacman naming rules — of those, only `.` and `+` are ERE metacharacters, so those are the only two escaped when building the alternation pattern.

## Test plan
- [x] `tests/run_matching_tests.sh` — 33/34 pass (1 pre-existing unrelated failure, same as master)
- [x] Verified the generated `sed` command against a real fixture file containing a package name with both `.` and `+` (`node.js+extra`) — removed exactly the 3 intended duplicate lines, left an unrelated unique entry untouched
- [x] Re-ran the check after applying the generated commands — confirmed clean
- [x] GUI extraction/count logic re-verified against the new output format
- [x] `man -l` renders clean, no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)