### PR TITLE
fix: GUI crash in List overlap check when there are no duplicates

### DIFF
--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -712,7 +712,10 @@ list_overlap_check() {
     local raw body count
     raw="$("$MAIN_SCRIPT" --check-list-overlap --no-notify --no-summary 2>&1)"
     body="$(awk '/^--- \[14\] /{f=1; next} /^--- \[/{f=0} /^===/{f=0} f' <<< "$raw")"
-    count="$(grep -oP '(?<=NOTE: )[0-9]+' <<< "$body" | head -1)"
+    # || true: grep exits non-zero when there are no duplicates (no "NOTE:"
+    # line to match) — under set -e + pipefail that would otherwise kill the
+    # whole GUI instead of just showing "nothing found".
+    count="$(grep -oP '(?<=NOTE: )[0-9]+' <<< "$body" | head -1 || true)"
     count="${count:-0}"
 
     local tmpout


### PR DESCRIPTION
## Summary
When there are no duplicates left, `check_list_overlap` prints "No custom-list entries duplicate an official list." with no "NOTE:" line. The GUI's count-extraction grep then matches nothing and exits non-zero — under `set -euo pipefail`, that silently killed the whole GUI instead of showing "0 found" and returning to the main menu.

Fix: `|| true` on the grep, matching the identical guard `_extract_infected_pkgs()` already uses for the same grep-after-awk pattern elsewhere in this file.

## Test plan
- [x] Reproduced the crash in isolation: a bare `set -euo pipefail` script with the same grep pipeline against a no-match string exits 1 silently before reaching later commands
- [x] Confirmed the `|| true` fix resolves it
- [x] Extracted the real function from the file post-fix and ran it end-to-end against a clean fixture (no duplicates) — no crash, correctly reports "(0 found)"
- [x] `tests/run_matching_tests.sh` — 33/34 pass (1 pre-existing unrelated failure, same as master)
- [x] Checked every other `grep`/`awk` call in `archcanary-gui.sh` for the same unguarded pattern — all others are either inside `if`/`&&` conditions (exempt from `set -e`) or already guarded

🤖 Generated with [Claude Code](https://claude.com/claude-code)