### PR TITLE
chore: set real sha256 for v0.1.21 release tarball

### DIFF
--- a/packaging/.SRCINFO
+++ b/packaging/.SRCINFO
@@ -21,6 +21,6 @@ pkgbase = archcanary
 	backup = etc/archcanary/bpftool_allowlist.conf
 	backup = etc/archcanary/autostart_allowlist.conf
 	source = archcanary-0.1.21.tar.gz::https://github.com/musqz/archcanary/archive/v0.1.21.tar.gz
-	sha256sums = SKIP
+	sha256sums = 1e3c0bf5e2443c1b726dc4f365e9df827932f81345b2504d29180009fabb64cf
 
 pkgname = archcanary

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -23,7 +23,7 @@ backup=('etc/archcanary/dkms_allowlist.conf'
         'etc/archcanary/autostart_allowlist.conf')
 install=archcanary.install
 source=("$pkgname-$pkgver.tar.gz::https://github.com/musqz/$pkgname/archive/v$pkgver.tar.gz")
-sha256sums=('SKIP')
+sha256sums=('1e3c0bf5e2443c1b726dc4f365e9df827932f81345b2504d29180009fabb64cf')
 
 package() {
   cd "$srcdir/$pkgname-$pkgver"


### PR DESCRIPTION
## Summary
- Real sha256 for the tagged `v0.1.21` release tarball, replacing the `SKIP` placeholder from #116.
- `packaging/.SRCINFO` regenerated to match.
- Does not move the `v0.1.21` tag.

## Test plan
- [x] Extracted `version.txt` from the downloaded tarball — reads `0.1.21`
- [x] Confirmed `lists/community_reports.txt` has all 42 entries and the trailing-newline fix is present in `archcanary.sh`
- [x] `makepkg --verifysource` locally — sha256 passes against the live download

🤖 Generated with [Claude Code](https://claude.com/claude-code)