### PR TITLE
docs: add contribution flow for reporting AUR packages

### DIFF
--- a/.github/ISSUE_TEMPLATE/report-package.yml
+++ b/.github/ISSUE_TEMPLATE/report-package.yml
@@ -1,0 +1,56 @@
+name: Report a malicious/suspicious AUR package
+description: Report an AUR package for archcanary's community-reported list
+title: "[package report]: "
+labels: ["community-report"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping keep `lists/community_reports.txt` up to date.
+        A merged report ships to every archcanary user automatically on
+        their next `--refresh`, annotated `[community report]`.
+
+        Before submitting, please check the package isn't already covered:
+        `grep -rF 'package-name' lists/` in the repo, or just search
+        `lists/` on GitHub.
+
+  - type: input
+    id: package-name
+    attributes:
+      label: Package name
+      description: Exact AUR package name (as it appears in the AUR web UI or `pacman -Qm` output).
+      placeholder: e.g. some-malicious-pkg-git
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: >
+        Link(s) to what makes this package suspicious/malicious — an AUR
+        comment, a mailing-list post, a PKGBUILD diff, a writeup. A package
+        name alone without evidence can't be verified or acted on.
+      placeholder: |
+        https://aur.archlinux.org/packages/...
+        https://lists.archlinux.org/archives/list/aur-general@lists.archlinux.org/message/...
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What does it do?
+      description: Brief description of the malicious/suspicious behavior (credential theft, backdoor, spam injection, etc.) if known.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I checked this package isn't already in `package_list.txt`, `chaos_rat_packages.txt`, `malicious_russian_spam_packages.txt`, or `community_reports.txt` in this repo.
+          required: true
+        - label: I have a concrete link or evidence, not just suspicion.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Summary
+
+<!-- What does this PR do? For a community_reports.txt addition, the
+     package name(s) plus the checklist below is enough. -->
+
+## If this adds to `lists/community_reports.txt`
+
+- [ ] Package name is exact (matches the AUR package name / `pacman -Qm` output)
+- [ ] Evidence is linked below — an AUR comment, mailing-list post, PKGBUILD diff, or writeup, not just suspicion
+- [ ] Checked it isn't already in `package_list.txt`, `chaos_rat_packages.txt`, `malicious_russian_spam_packages.txt`, or `community_reports.txt`
+
+**Evidence:** <!-- link(s) here -->
+
+## For code changes
+
+- [ ] Ran `bash tests/run_matching_tests.sh` (for `archcanary.sh` changes)
+- [ ] Updated `--help`/man page/README if user-facing behavior changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Added: `CONTRIBUTING.md`, a GitHub issue form (`.github/ISSUE_TEMPLATE/report-package.yml`), and a PR template (`.github/PULL_REQUEST_TEMPLATE.md`) for reporting a malicious/suspicious AUR package into `lists/community_reports.txt` — either via a low-friction form (no git needed) or a direct PR, both asking for the same evidence link so reports can be reviewed without back-and-forth.
+
 ## v0.1.21 (2026-08-01)
 
 - Added: `--check-list-overlap` notes custom list (`extra_lists.conf`/`--extra-list`) entries already covered by an official list (`package_list.txt`, CHAOS RAT, Russian Spam, Community Reports, aur-audit black/red) — grouped by file, each with a ready-to-run `sed` command to remove exactly those entries, since the official list is authoritative. A note, not a warning: always shows "clean" in the check summary and never affects the exit status, and not included in `--full`. The same note prints twice — once in its own section, once again right after the final RESULT banner — so it's visible without scrolling back up. Also reachable from the GUI: `archcanary-gui` → Edit config → List overlap check, which runs it and shows just its own report (with the live count in the window title) rather than a full scan.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,72 @@
+# Contributing
+
+## Reporting a malicious/suspicious AUR package
+
+This is the most common and most useful contribution: archcanary maintains a
+community-sourced list of individually-reported packages
+(`lists/community_reports.txt`) that don't (yet) belong to a documented
+campaign like CHAOS RAT or the Russian Spam Campaign. A merged report ships
+to every archcanary user automatically on their next `--refresh`, annotated
+`[community report]` in the scan output.
+
+**Two ways to report, pick whichever is easier for you:**
+
+### 1. Open an issue (no git knowledge needed)
+
+Use the [Report a package](https://github.com/musqz/archcanary/issues/new?template=report-package.yml)
+form. Fill in the package name and a link to whatever makes you believe
+it's malicious or suspicious. That's it — someone will verify it and add it
+to the list if it checks out.
+
+### 2. Open a pull request directly
+
+If you're comfortable with git, add the package name as a new line at the
+end of `lists/community_reports.txt` and open a PR. Please use the PR
+template — it asks for the same evidence link as the issue form, so the
+PR can be reviewed without back-and-forth.
+
+### What counts as evidence
+
+A package name on its own can't be verified or acted on. Link to *something*
+concrete:
+
+- An AUR comment describing the malicious behavior
+- A mailing-list post (e.g. `aur-general@lists.archlinux.org`)
+- A PKGBUILD diff or analysis showing the obfuscated/malicious part
+- A writeup, blog post, or forum thread
+
+### Before submitting
+
+Check the package isn't already covered — a duplicate report just adds
+review overhead for no benefit:
+
+```bash
+grep -rF 'package-name-here' lists/
+```
+
+(This is the same check `archcanary --check-list-overlap` runs for your own
+custom lists — see the README's "Checks" table.)
+
+### What happens after that
+
+Reports are reviewed by hand, not auto-merged — expect this to take a
+while, not real-time. This is intentionally the slower, human-vetted path:
+see the [aur-audit.wtako.net feed](README.md#aur-auditwtakonet-feed) if you
+want a continuously-updated, best-effort automated signal instead — they're
+complementary, not alternatives.
+
+---
+
+## Other contributions
+
+Bug reports, feature ideas, and code PRs are welcome too — open an
+[issue](https://github.com/musqz/archcanary/issues) or
+[discussion](https://github.com/musqz/archcanary/discussions) first for
+anything non-trivial, so we can agree on the approach before you put work
+into it.
+For code changes: run `bash tests/run_matching_tests.sh` before opening a
+PR, and update `--help`/the man page/README if you changed user-facing
+behavior.
+
+archcanary is read-only by design — it detects and reports, it never
+remediates. Keep that in mind if you're proposing a new check or flag.

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ archcanary detects these via `malicious_russian_spam_packages.txt` (shown in the
 
 ### Community Reports
 
-A hand-curated list (`community_reports.txt`), sourced from AUR malware reports shared by the community — refreshed the same way as the lists above, no separate opt-in needed. Unlike the campaign-specific lists, this one has no fixed scope or end date; it's an ongoing collection point for individually-reported packages that don't (yet) belong to a documented campaign. Hits are annotated `[community report]` so you can tell the source. Maintained directly in this repo — see [SOURCES.md](SOURCES.md) for how entries get added.
+A hand-curated list (`community_reports.txt`), sourced from AUR malware reports shared by the community — refreshed the same way as the lists above, no separate opt-in needed. Unlike the campaign-specific lists, this one has no fixed scope or end date; it's an ongoing collection point for individually-reported packages that don't (yet) belong to a documented campaign. Hits are annotated `[community report]` so you can tell the source. Maintained directly in this repo — see [CONTRIBUTING.md](CONTRIBUTING.md) to report a package, or [SOURCES.md](SOURCES.md) for the trust basis.
 
 ### aur-audit.wtako.net feed
 
@@ -299,6 +299,7 @@ The same synced lists also gate installs directly: the `AURPreInstall` yay hook 
 - [docs/systemd.md](docs/systemd.md) — systemd unit files and automated scan setup
 - [docs/my-setup.md](docs/my-setup.md) — full personal stack, component connections, reinstall steps
 - [docs/false-positives.md](docs/false-positives.md) — documented benign signals and how to verify
+- [CONTRIBUTING.md](CONTRIBUTING.md) — how to report a malicious/suspicious AUR package
 - [SOURCES.md](SOURCES.md) — full numbered source references
 
 ---


### PR DESCRIPTION
## Summary
The Community Reports list (`community_reports.txt`) already ships to every archcanary user via `--refresh`, but there was no documented way for anyone besides the maintainer to actually add to it. Adds the standard three-piece GitHub contribution setup:

- **`CONTRIBUTING.md`** — how to report a package (issue form or direct PR), what counts as evidence, how to check for existing coverage first (`grep -rF`), and realistic expectations (human-reviewed, not real-time — the wtako feed is the automated/continuous complement, not a competitor).
- **`.github/ISSUE_TEMPLATE/report-package.yml`** — a GitHub Issue Form (structured fields, not free text) for reporters who don't know git: package name, evidence link, and a checkbox confirming they checked for existing coverage.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — same evidence requirements for direct-PR contributors, plus a separate checklist for ordinary code PRs.

Also linked from README's Documentation section and the Community Reports subsection.

## Test plan
- [x] Validated the issue form YAML parses correctly and matches GitHub's Issue Forms schema
- [x] Confirmed GitHub Issues and Discussions are both enabled on this repo (linked from `CONTRIBUTING.md`)
- [x] `tests/run_matching_tests.sh` — 33/34 pass (1 pre-existing unrelated failure, same as master; this PR doesn't touch `archcanary.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)