### PR TITLE
docs: show the --refresh Lists-loaded banner in Quick Start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added: `CONTRIBUTING.md`, a GitHub issue form (`.github/ISSUE_TEMPLATE/report-package.yml`), and a PR template (`.github/PULL_REQUEST_TEMPLATE.md`) for reporting a malicious/suspicious AUR package into `lists/community_reports.txt` — either via a low-friction form (no git needed) or a direct PR, both asking for the same evidence link so reports can be reviewed without back-and-forth.
 - Changed: reordered README.md so Quick Start comes right after the intro instead of after a 10-row dependency table and an architecture explainer — the simple "just run archcanary" path now comes before the deeper-dive material (Projects Used, Detection Layers), which moved down. The full `--check-*` flag reference table is now collapsed behind a `<details>` toggle, with a one-line summary staying visible. No content removed, only reordered/collapsed.
+- Added: a Quick Start example showing `archcanary --refresh`'s "Lists loaded" banner (per-list counts plus the `+N`/`-N` delta since the last run), alongside the existing plain-scan check-summary example.
 
 ## v0.1.21 (2026-08-01)
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,27 @@ Every scan prints a per-check summary before the final verdict:
 ============================================================
 ```
 
+With `archcanary --refresh`, the banner also shows each list's count and how
+much it changed since the last run — handy for noticing a threat-intel feed
+just grew:
+
+```
+============================================================
+ Archcanary v0.1.20
+ Scanned: 2026-08-01 16:14
+
+ Lists loaded
+   package_list.txt  infostealer + eBPF rootkit  1936 pkgs
+   + CHAOS RAT         7 pkgs
+   + Russian Spam     75 pkgs
+   + aur-audit black 101 pkgs (+17)
+   + aur-audit red   306 pkgs (+27)
+   + extra: archlinux-list.txt    68 pkgs
+
+ Packages checked: 2493
+============================================================
+```
+
 ---
 
 ## Screenshots


### PR DESCRIPTION
## Summary
The Quick Start example only showed a plain scan's check summary — never demonstrated what `--refresh` actually adds (per-list counts, the `+N`/`-N` delta since the last run), even though `archcanary --refresh --full` is one of the Quick Start commands right above it.

Added a second example output block showing the "Lists loaded" banner produced by `--refresh`.

## Test plan
- [x] Confirmed all 12 top-level README sections still present exactly once (pure addition, nothing reordered/removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)