### PR TITLE
chore: set real sha256 for v0.1.22 release tarball

### DIFF
--- a/packaging/.SRCINFO
+++ b/packaging/.SRCINFO
@@ -19,6 +19,6 @@ pkgbase = archcanary
 	backup = etc/archcanary/bpftool_allowlist.conf
 	backup = etc/archcanary/autostart_allowlist.conf
 	source = archcanary-0.1.22.tar.gz::https://github.com/musqz/archcanary/archive/v0.1.22.tar.gz
-	sha256sums = SKIP
+	sha256sums = c64a4783c6cdf318a80326460dadc9a155a9d159e21bfd088deba501c90eb618
 
 pkgname = archcanary

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -21,7 +21,7 @@ backup=('etc/archcanary/dkms_allowlist.conf'
         'etc/archcanary/autostart_allowlist.conf')
 install=archcanary.install
 source=("$pkgname-$pkgver.tar.gz::https://github.com/musqz/$pkgname/archive/v$pkgver.tar.gz")
-sha256sums=('SKIP')
+sha256sums=('c64a4783c6cdf318a80326460dadc9a155a9d159e21bfd088deba501c90eb618')
 
 package() {
   cd "$srcdir/$pkgname-$pkgver"


### PR DESCRIPTION
## Summary
Second PR of the standard two-PR release flow for v0.1.22. Tag `v0.1.22` is already created and pushed (pointing at the version-bump merge commit `a4fd747`) — this just fills in the real sha256, does not move the tag.

- Downloaded the tagged tarball, verified its `version.txt` reads `0.1.22` before trusting the hash.
- `sha256sums` set to the real value: `c64a4783c6cdf318a80326460dadc9a155a9d159e21bfd088deba501c90eb618`.
- `.SRCINFO` regenerated to match.
- `makepkg --verifysource` passes.

No AUR remote to update afterward (per this project's own convention — beta-only, local `makepkg` distribution, no `aur.archlinux.org` listing).

## Test plan
- [x] `makepkg --verifysource` — sha256 validates.
- [x] Extracted `version.txt` from the tarball, confirmed it matches the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)