### PR TITLE
fix: strip quotes from .desktop Exec= before matching/display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix: `check_autostart`'s `.desktop` `Exec=` parsing didn't strip surrounding literal double quotes (allowed by the Desktop Entry Spec, and used by some installers — e.g. pCloud's — even when the path has no spaces to quote). Left quoted, the value was misclassified as an unresolvable bare name instead of an absolute path, and worse, was un-allowlistable: a real shell strips the quotes when the user types the exact suggested `--allowlist-add` command, so the stored (unquoted) value could never match the raw, still-quoted one compared at scan time. Reported live — the user could never get the suggested allowlist command to actually work. Quotes are now stripped before classification, display, and allowlist matching.
+
 ## v0.1.22 (2026-08-02)
 
 - Fix: `packaging/PKGBUILD`'s embedded `autostart_allowlist.conf` template had drifted from `install.sh`'s — a pure package install (`makepkg -si`/AUR helper) seeded the old template (missing the full-path unowned-ExecStart-binary documentation and example added below) instead of the current one. Same recurring drift class as the `configs/audit-rules.conf` fix earlier this file — synced.

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -2373,6 +2373,19 @@ check_autostart() {
                 local exec_val="${line#Exec=}"
                 exec_val=$(printf '%s' "$exec_val" | sed 's/[[:space:]]*%[a-zA-Z]//g' | awk '{print $1}')
                 [[ -z "$exec_val" ]] && continue
+                # Desktop Entry Spec allows (and some installers, e.g. pCloud's,
+                # use) a quoted Exec= value even with no spaces to quote — awk
+                # has no concept of quoting, so a wrapped "/path/to/bin" comes
+                # out with the literal quote characters still attached. Left
+                # alone, that (a) misclassifies an absolute path as an
+                # unresolvable bare name (starts with '"', not '/') and (b)
+                # makes the value un-allowlistable: a normal shell strips the
+                # quotes when the user types the suggested --allowlist-add
+                # command, so the stored value could never match this raw one.
+                if [[ "$exec_val" == \"*\" && ${#exec_val} -gt 1 ]]; then
+                    exec_val="${exec_val#\"}"
+                    exec_val="${exec_val%\"}"
+                fi
 
                 # $home_dir/bin and $home_dir/.local/bin are standard, common
                 # places for a user's own scripts (e.g. a DE-generated

--- a/tests/run_matching_tests.sh
+++ b/tests/run_matching_tests.sh
@@ -727,6 +727,47 @@ DESK
         fail "check_autostart: Flatpak libdir-fallback regression, rc=$rc, out: $out"
     fi
     rm -rf "$tmpdir11"
+
+    # Sub-test S: a quoted Exec= value (e.g. pCloud's installer wraps its
+    # launcher path in literal double quotes even with no spaces to quote)
+    # must have the quotes stripped before classification/display/allowlist
+    # matching — otherwise it's misclassified as an unresolvable bare name
+    # (starts with '"' not '/'), and the value is un-allowlistable: a real
+    # shell strips the quotes when the user types the suggested
+    # --allowlist-add command, so the stored value could never match the
+    # raw, still-quoted one used for comparison. Reported live.
+    local tmpdir12
+    tmpdir12=$(mktemp -d)
+    mkdir -p "$tmpdir12/.config/autostart"
+    cat > "$tmpdir12/.config/autostart/pcloud.desktop" << DESK
+[Desktop Entry]
+Type=Application
+Name=pCloud
+Exec="$tmpdir12/pcloud-launcher.sh"
+DESK
+    rc=0
+    out=$(AUTOSTART_HOME="$tmpdir12" \
+        "$REPO_DIR/archcanary.sh" "${base_args[@]}" --no-color 2>&1) || rc=$?
+    if [[ $rc -eq 2 && "$out" == *"Exec=$tmpdir12/pcloud-launcher.sh (outside"* && \
+          "$out" == *"--allowlist-add=autostart:$tmpdir12/pcloud-launcher.sh"* ]]; then
+        pass "check_autostart: quoted Exec= value has quotes stripped in WARNING/hint text"
+    else
+        fail "check_autostart: quoted Exec= should show unquoted value, rc=$rc, out: $out"
+    fi
+
+    local allow_file5
+    allow_file5=$(mktemp)
+    printf '%s\n' "$tmpdir12/pcloud-launcher.sh" > "$allow_file5"
+    rc=0
+    out=$(AUTOSTART_HOME="$tmpdir12" AUTOSTART_ALLOWLIST_FILE="$allow_file5" \
+        "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
+    if [[ $rc -eq 0 && "$out" == *"Clean"* && "$out" != *"WARNING"* ]]; then
+        pass "check_autostart: quoted Exec= value allowlisted with unquoted path matches"
+    else
+        fail "check_autostart: allowlisting the unquoted path should match quoted Exec=, rc=$rc, out: $out"
+    fi
+    rm -rf "$tmpdir12"
+    rm -f "$allow_file5"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Reported live: the user followed the *exact* suggested `--allowlist-add=autostart:"..."` command for a flagged pCloud autostart entry, and it never actually worked ("pcloud won't be added").

Root cause: pCloud's installer wraps its launcher path in literal double quotes (`Exec="/home/wombat/.config/pcloud/pcloud-launcher.sh"`) even though there's nothing that needs quoting — valid per the Desktop Entry Spec, but `awk '{print $1}'` has no concept of quoting, so the parsed value kept the literal quote characters. That caused two problems:

1. Misclassified as an unresolvable bare name instead of an absolute path (starts with `"`, not `/`).
2. Permanently un-allowlistable: a real shell strips the quotes when the user types the suggested command, so the *unquoted* value that actually gets stored can never match the *quoted* raw value compared at scan time. The user wasn't doing anything wrong — the suggested fix command could never have worked as written.

Quotes (a single matching leading+trailing pair) are now stripped right after parsing, so the WARNING/hint text, classification, and allowlist matching all use the same normalized value.

## Test plan
- [x] Reproduced the exact reported case end-to-end: before the fix, `Exec=` displayed with quotes and the suggested allowlist command silently never matched; after the fix, both the display and the allowlist match are correct.
- [x] New regression tests: quoted `Exec=` shows the unquoted path in WARNING/hint text; allowlisting the unquoted path successfully silences a quoted `Exec=` finding. 48/49 PASS (pre-existing unrelated `cli_flag` failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)