### PR TITLE
fix: PKGBUILD ANSI-C obfuscation check flagged read -d $'\0'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix: `check_autostart`'s `.desktop` `Exec=` parsing didn't strip surrounding literal double quotes (allowed by the Desktop Entry Spec, and used by some installers — e.g. pCloud's — even when the path has no spaces to quote). Left quoted, the value was misclassified as an unresolvable bare name instead of an absolute path, and worse, was un-allowlistable: a real shell strips the quotes when the user types the exact suggested `--allowlist-add` command, so the stored (unquoted) value could never match the raw, still-quoted one compared at scan time. Reported live — the user could never get the suggested allowlist command to actually work. Quotes are now stripped before classification, display, and allowlist matching.
+- Fix: `check_pkgbuild_caches`'s "ANSI-C hex/octal quoting" obfuscation pattern matched on a single `$'\x..'`/`$'\0..'` occurrence anywhere in a line — flagging the extremely common, completely legitimate `read -d $'\0'` idiom used for NUL-delimited `find -print0` iteration (reported live, a real `nvidia-utils-beta` PKGBUILD). Real obfuscation spells out a command a byte at a time via multiple chained escapes (e.g. `$'\x63\x75\x72\x6c'` for `curl`); a single delimiter byte has none of that shape. Now requires 3+ consecutive `\xHH`/`\NNN` escapes to match, closing the false positive while still catching genuine chained-escape obfuscation. No prior test coverage existed for this pattern at all — added regression tests for both the false-positive idiom and genuine obfuscation.
 
 ## v0.1.22 (2026-08-02)
 

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -2047,9 +2047,16 @@ check_pkgbuild_caches() {
 
     local found_count=0
     local scanned=0
-    # matches $'\x.. or $'\0.. (ANSI-C hex/octal quoting)
+    # Matches an ANSI-C-quoted string built from 3+ chained \xHH (hex) or
+    # \NNN (octal) escapes back to back — the actual obfuscation signature
+    # (spelling out a command a byte at a time, e.g. $'\x63\x75\x72\x6c' for
+    # "curl"). A single escape, e.g. read -d $'\0' (the standard, extremely
+    # common idiom for NUL-delimited `find -print0` iteration), is not
+    # obfuscation and must not match — the previous regex matched on just
+    # one occurrence of $'\x or $'\0, flagging that exact legitimate idiom
+    # (reported live, real nvidia-utils-beta PKGBUILD).
     local re_ansi_c
-    re_ansi_c='\$'"'"'\\x|\$'"'"'\\0'
+    re_ansi_c='\$'"'"'(\\x[0-9a-fA-F]{2}|\\[0-7]{1,3}){3,}'
 
     while IFS= read -r file; do
         (( scanned++ )) || true

--- a/tests/fake_pkgbuilds/pkg-ansic/PKGBUILD
+++ b/tests/fake_pkgbuilds/pkg-ansic/PKGBUILD
@@ -1,0 +1,7 @@
+pkgname=pkg-ansic
+pkgver=1.0
+pkgrel=1
+package() {
+    payload=$'\x63\x75\x72\x6c\x20\x2d\x73\x20\x68\x74\x74\x70'
+    eval "$payload"
+}

--- a/tests/fake_pkgbuilds/pkg-clean/PKGBUILD
+++ b/tests/fake_pkgbuilds/pkg-clean/PKGBUILD
@@ -8,4 +8,10 @@ build() {
 }
 package() {
     make DESTDIR="$pkgdir" install
+    # Standard NUL-delimited find -print0 iteration idiom — must never be
+    # flagged as ANSI-C hex/octal obfuscation (a single $'\0' delimiter is
+    # not an encoded payload).
+    find "$pkgdir" -type f -name '*.so*' -print0 | while read -d $'\0' _lib; do
+        chmod 644 "$_lib"
+    done
 }

--- a/tests/run_matching_tests.sh
+++ b/tests/run_matching_tests.sh
@@ -822,14 +822,29 @@ test_pkgbuild_obfuscation() {
         fail "pkgbuild_obfuscation: varsplit pattern missed, rc=$rc"
     fi
 
-    # Sub-test E: clean PKGBUILD → no WARNING
+    # Sub-test E: clean PKGBUILD → no WARNING (includes a standard
+    # `read -d $'\0'` NUL-delimited find -print0 loop — regression guard for
+    # a real false positive reported live: a single ANSI-C-quoted delimiter
+    # byte must not be flagged as hex/octal obfuscation)
     rc=0
     out=$(PKGBUILD_CACHE_DIRS="$fixtures/pkg-clean" \
         "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
     if [[ "$out" == *"Clean"* && "$out" != *"WARNING"* ]]; then
-        pass "pkgbuild_obfuscation: clean PKGBUILD → no false positive"
+        pass "pkgbuild_obfuscation: clean PKGBUILD (incl. read -d \$'\\0' idiom) → no false positive"
     else
-        fail "pkgbuild_obfuscation: clean PKGBUILD triggered WARNING — false positive"
+        fail "pkgbuild_obfuscation: clean PKGBUILD triggered WARNING — false positive, out: $out"
+    fi
+
+    # Sub-test G: genuine ANSI-C hex-escape obfuscation (3+ chained \xHH
+    # escapes spelling out a command) must still be caught — regression
+    # guard so the false-positive fix above didn't just gut the check.
+    rc=0
+    out=$(PKGBUILD_CACHE_DIRS="$fixtures/pkg-ansic" \
+        "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
+    if [[ $rc -eq 2 && "$out" == *"ANSI-C hex/octal quoting"* ]]; then
+        pass "pkgbuild_obfuscation: chained hex-escape obfuscation detected"
+    else
+        fail "pkgbuild_obfuscation: chained hex-escape obfuscation missed, rc=$rc, out: $out"
     fi
 
     # Sub-test F: summary table shows the softer "REVIEW" (not "INFECTED") for


### PR DESCRIPTION
## Summary
Reported live by a Mabox user: their real `nvidia-utils-beta` PKGBUILD got flagged with "ANSI-C hex/octal quoting" over:

```
find "$pkgdir" -type f -name '*.so*' ! -path '*xorg/*' -print0 | while read -d $'\0' _lib
```

That's the standard, extremely common idiom for NUL-delimited `find -print0` iteration — not obfuscation. The old regex (`\$'\x|\$'\0`) matched on a single occurrence of `$'\x` or `$'\0` anywhere in a line. Real obfuscation spells out a command a byte at a time via multiple chained escapes (e.g. `$'\x63\x75\x72\x6c'` for `curl`) — a single delimiter byte has none of that shape.

Now requires 3+ consecutive `\xHH`/`\NNN` escapes to match, closing the false positive while still catching genuine chained-escape obfuscation.

## Test plan
- [x] Reproduced the exact reported line end-to-end — WARNING before the fix, Clean after.
- [x] No prior test coverage existed for this pattern at all — added regression tests: the false-positive idiom (folded into the existing `pkg-clean` fixture) and genuine chained-escape obfuscation (new `pkg-ansic` fixture, confirms the fix didn't just gut the check). 47/48 PASS (pre-existing unrelated `cli_flag` failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)