### PR TITLE
docs: drop the "Unreleased" heading from CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Changelog
 
-## Unreleased
-
 - Fix: `check_autostart`'s `.desktop` `Exec=` parsing didn't strip surrounding literal double quotes (allowed by the Desktop Entry Spec, and used by some installers — e.g. pCloud's — even when the path has no spaces to quote). Left quoted, the value was misclassified as an unresolvable bare name instead of an absolute path, and worse, was un-allowlistable: a real shell strips the quotes when the user types the exact suggested `--allowlist-add` command, so the stored (unquoted) value could never match the raw, still-quoted one compared at scan time. Reported live — the user could never get the suggested allowlist command to actually work. Quotes are now stripped before classification, display, and allowlist matching.
 - Fix: `check_pkgbuild_caches`'s "ANSI-C hex/octal quoting" obfuscation pattern matched on a single `$'\x..'`/`$'\0..'` occurrence anywhere in a line — flagging the extremely common, completely legitimate `read -d $'\0'` idiom used for NUL-delimited `find -print0` iteration (reported live, a real `nvidia-utils-beta` PKGBUILD). Real obfuscation spells out a command a byte at a time via multiple chained escapes (e.g. `$'\x63\x75\x72\x6c'` for `curl`); a single delimiter byte has none of that shape. Now requires 3+ consecutive `\xHH`/`\NNN` escapes to match, closing the false positive while still catching genuine chained-escape obfuscation. No prior test coverage existed for this pattern at all — added regression tests for both the false-positive idiom and genuine obfuscation.
 


### PR DESCRIPTION
## Summary
Reported as confusing: fixes under "Unreleased" are already merged to `master` and available to anyone running from a git checkout, but the heading reads like they're not available yet.

Simpler fix than adding an explanatory note: just drop the heading. pkgver/PKGBUILD version tracking is internal, not something users need to think about — the documented path is always `git pull` + `./install.sh`, never "wait for a release." New entries now sit at the top with no heading; a version heading gets added retroactively only when a pkgver bump actually happens, same as every existing version section already does.

## Test plan
- N/A — documentation only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)