### PR TITLE
chore: set real sha256 for v0.1.23 release tarball

### DIFF
--- a/packaging/.SRCINFO
+++ b/packaging/.SRCINFO
@@ -19,6 +19,6 @@ pkgbase = archcanary
 	backup = etc/archcanary/bpftool_allowlist.conf
 	backup = etc/archcanary/autostart_allowlist.conf
 	source = archcanary-0.1.23.tar.gz::https://github.com/musqz/archcanary/archive/v0.1.23.tar.gz
-	sha256sums = SKIP
+	sha256sums = 2a6ab89e1eb54aff3130ea545f093388c5dd93aa46545c41f7070862fb21bdd7
 
 pkgname = archcanary

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -21,7 +21,7 @@ backup=('etc/archcanary/dkms_allowlist.conf'
         'etc/archcanary/autostart_allowlist.conf')
 install=archcanary.install
 source=("$pkgname-$pkgver.tar.gz::https://github.com/musqz/$pkgname/archive/v$pkgver.tar.gz")
-sha256sums=('SKIP')
+sha256sums=('2a6ab89e1eb54aff3130ea545f093388c5dd93aa46545c41f7070862fb21bdd7')
 
 package() {
   cd "$srcdir/$pkgname-$pkgver"


### PR DESCRIPTION
## Summary
- Sets the real sha256 for the `v0.1.23` release tarball, computed after the tag was pushed and GitHub had generated the archive.
- Verified the tarball's `version.txt` reads `0.1.23` before trusting the hash.

## Test plan
- [x] `curl -sL https://github.com/musqz/archcanary/archive/v0.1.23.tar.gz | sha256sum` matches `sha256sums` in `packaging/PKGBUILD`
- [x] Extracted tarball's `version.txt` confirmed to read `0.1.23`
- [x] `.SRCINFO` regenerated via `makepkg --printsrcinfo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)