### PR TITLE
feat: add --search-packages flag for quick threat-list lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ run everything at once with `--full`.
 | `--run-lynis` | Run `lynis audit system`, stream output | Yes |
 | `--check-pkginteg` | Verify installed file checksums via `pacman -Qkk`. Reports SHA256 mismatches on non-backup, non-factory files. Backup files (pacman-managed configs expected to diverge) and `/factory/` paths are filtered out. Prioritise hits in `/usr/bin/`, `/usr/lib/`, `/usr/sbin/`. | Yes |
 | `--check-list-overlap` | A note, not a warning: custom (`--extra-list`) entries already covered by an official list are grouped by file, with a ready-to-run `sed` command to remove them — safe to remove, since the official list is authoritative. Never affects the exit code or the check summary, and not included in `--full`. Also reachable from the GUI: Edit config → List overlap check. | No |
+| `--search-packages=PKG[,PKG...]` | Check package name(s) against every loaded threat list, independent of what's installed — no scan, prints a ready-to-copy `pacman -Rns` command for any match, and exits. | No |
 | `--full` | All of the above except `--check-list-overlap` | Partial |
 | `--refresh` | Fetch the live package list from the Arch Linux HedgeDoc, plus the supplementary npm/CHAOS RAT/Russian Spam/Community Reports lists and the aur-audit black/red feed | — |
 | `--no-aur-audit` | Skip the aur-audit.wtako.net feed on `--refresh`. Persists via `AUR_AUDIT_ENABLE=false` in `~/.config/archcanary/env`, also toggleable from the GUI's Scan settings menu row | — |

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -86,6 +86,7 @@ NO_NOTIFY=false
 NO_SUMMARY=false
 DOCTOR=false
 DOCTOR_SECTIONS=""
+SEARCH_PACKAGES_ARG=""
 RUN_LYNIS=false
 _COLOR_ARG="auto"
 _FORMAT_ARG="text"
@@ -439,6 +440,7 @@ for arg in "$@"; do
         --russian-spam-list=*)   RUSSIAN_SPAM_LIST_OPT="${arg#*=}" ;;
         --community-list=*)      COMMUNITY_LIST_OPT="${arg#*=}" ;;
         --extra-list=*)          EXTRA_LIST_OPTS+=("${arg#*=}") ;;
+        --search-packages=*)     SEARCH_PACKAGES_ARG="${arg#*=}" ;;
         --start-date=*)          START_DATE_OPT="${arg#*=}" ;;
         --end-date=*)            END_DATE_OPT="${arg#*=}" ;;
         --no-aur-audit)          AUR_AUDIT_ENABLE=false ;;
@@ -484,6 +486,9 @@ for arg in "$@"; do
             echo "  --check-pkginteg   Verify installed file checksums against pacman database (SHA256 mismatch)"
             echo "  --check-list-overlap  Note custom-list entries already covered by an official list, safe to"
             echo "                        remove — advisory only, not included in --full"
+            echo "  --search-packages=PKG[,PKG...]  Check package name(s) against every loaded threat list"
+            echo "                                   (no scan; prints a ready-to-copy 'pacman -Rns' command"
+            echo "                                   for any match) and exit"
             echo "  --run-lynis        Run a full Lynis audit (lynis audit system) and exit — not included in --full"
             echo "  --full             Enable all checks"
             echo "  --refresh          Download the latest package list before scanning (incl. aur-audit black/red feed)"
@@ -3071,6 +3076,57 @@ declare -A INFECTED_LOOKUP
 for p in "${INFECTED_PKGS[@]}"; do
     INFECTED_LOOKUP["$p"]=1
 done
+
+# ---------------------------------------------------------------------------
+# --search-packages=PKG[,PKG...] — standalone list lookup, independent of
+# what's installed locally. Same source-tagging elif chain as check_current/
+# check_logs (kept separate rather than a shared helper, matching how those
+# two already duplicate it). Never runs pacman itself — only echoes the
+# suggested removal command.
+# ---------------------------------------------------------------------------
+_search_packages_cli() {
+    local input="$1" pkg tag
+    local -a names=() hits=()
+    local -A seen=()
+    IFS=',' read -ra names <<< "$input"
+
+    for pkg in "${names[@]}"; do
+        pkg="${pkg//[[:space:]]/}"
+        [[ -n "$pkg" ]] || continue
+        [[ -v seen["$pkg"] ]] && continue
+        seen["$pkg"]=1
+        if [[ -v INFECTED_LOOKUP["$pkg"] ]]; then
+            if [[ -v CHAOS_LOOKUP["$pkg"] ]]; then
+                tag="CHAOS RAT campaign, 2025-07"
+            elif [[ -v AUR_AUDIT_BLACK_LOOKUP["$pkg"] ]]; then
+                tag="aur-audit: black"
+            elif [[ -v AUR_AUDIT_RED_LOOKUP["$pkg"] ]]; then
+                tag="aur-audit: red"
+            elif [[ -v COMMUNITY_REPORTS_LOOKUP["$pkg"] ]]; then
+                tag="community report"
+            else
+                tag="package list"
+            fi
+            echo "  FLAGGED: $pkg [$tag]"
+            hits+=("$pkg")
+        else
+            echo "  clean: $pkg (not on any list)"
+        fi
+    done
+
+    if [[ ${#hits[@]} -gt 0 ]]; then
+        echo
+        echo "  Suggested removal (review before running):"
+        printf '    sudo pacman -Rns -- %s\n' "${hits[*]}"
+        return 2
+    fi
+    return 0
+}
+
+if [[ -n "$SEARCH_PACKAGES_ARG" ]]; then
+    _search_packages_cli "$SEARCH_PACKAGES_ARG"
+    exit $?
+fi
 
 if ! $FOCUSED_MODE; then
     # Per-list pkg counts from the previous run, so the banner below can show

--- a/configs/archcanary-completion.bash
+++ b/configs/archcanary-completion.bash
@@ -50,7 +50,7 @@ _archcanary() {
         --check-systemd --check-ebpf --check-npm-cache --check-bun-cache
         --check-yarn-cache --check-pnpm-cache --check-pkgbuild --check-bpftool
         --check-ldso --check-autostart --check-kmod --check-lynis
-        --check-pkginteg --check-list-overlap --full --refresh --no-aur-audit --verbose -v --debug
+        --check-pkginteg --check-list-overlap --search-packages= --full --refresh --no-aur-audit --verbose -v --debug
         --no-notify --no-summary --run-lynis --doctor --version -V --help -h
         --log-file= --package-list= --malicious-npm-list= --chaos-rat-list=
         --russian-spam-list= --community-list= --extra-list= --start-date= --end-date=

--- a/man/archcanary.1
+++ b/man/archcanary.1
@@ -114,6 +114,12 @@ command per affected file. A note, not a warning: never affects the exit
 status, never warns in the check summary, and not included in
 .BR \-\-full .
 .TP
+.B \-\-search\-packages= PKG [, PKG ...]
+Check package name(s) against every loaded threat list, independent of
+what's installed locally. No scan is run; prints a ready-to-copy
+.B pacman \-Rns
+command for any match, and exits.
+.TP
 .B \-\-full
 Enable all of the above checks.
 .SS List management


### PR DESCRIPTION
## Summary
- Add `--search-packages=PKG[,PKG...]` — checks package name(s) against every loaded threat list (package_list.txt, CHAOS RAT, Russian Spam, Community Reports, aur-audit black/red, extra-lists) without running a full scan, and exits.
- On a match, echoes a ready-to-copy `sudo pacman -Rns -- <pkg>` command — never executed by the script itself.
- Prompted by the org-cli AUR takeover report: a package can be flagged today and legitimate again later if a trusted maintainer regains control, so this is a point-in-time list lookup, not a trust verdict.
- Documented consistently in `--help`, README's flag table, the man page, and bash-completion.

## Test plan
- [x] `./archcanary.sh --search-packages=bash` → clean, exit 0
- [x] `./archcanary.sh --search-packages=caveman` (real community_reports.txt entry) → FLAGGED + suggested `pacman -Rns` command, exit 2
- [x] `./archcanary.sh --search-packages=bash,caveman` → mixed hit/miss in one call
- [x] `./archcanary.sh --search-packages=caveman,caveman` → deduped, single FLAGGED line and single name in the command
- [x] `./archcanary.sh --search-packages=librewolf-fix-bin` (CHAOS RAT entry) → correct source tag
- [x] `bash -n archcanary.sh` and `groff -Tascii -man -z man/archcanary.1` clean
- [x] `--help` output, README table, man page, and bash-completion all show the new flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)