### PR TITLE
fix: use pkexec root-helper in autostart allowlist hint text

### DIFF
--- a/archcanary.sh
+++ b/archcanary.sh
@@ -2508,7 +2508,7 @@ check_autostart() {
                         echo "  WARNING: suspicious autostart entry: $desktop"
                         echo "    Exec=$exec_val (outside standard system path)"
                         echo "    If you recognize this app (e.g. an AppImage/Flatpak launcher or a"
-                        echo "    personal script), mark it known-good: archcanary --allowlist-add=autostart:$exec_val"
+                        echo "    personal script), mark it known-good: pkexec /usr/lib/archcanary/root-helper --allowlist-add=autostart:$exec_val"
                         found=2
                     fi
                 fi
@@ -2548,7 +2548,7 @@ check_autostart() {
                     echo "  WARNING: user service with unowned ExecStart binary: $svc"
                     echo "    ExecStart=$exec_bin (not tracked by pacman)"
                     echo "    If you recognize this (e.g. a package that ships its unit via /etc/skel),"
-                    echo "    mark it known-good: archcanary --allowlist-add=autostart:$exec_bin"
+                    echo "    mark it known-good: pkexec /usr/lib/archcanary/root-helper --allowlist-add=autostart:$exec_bin"
                     found=2
                 fi
             fi


### PR DESCRIPTION
## Summary
- `check_autostart`'s WARNING hints suggested a bare `archcanary --allowlist-add=autostart:...`, which fails ("requires root — run via pkexec (root-helper)") if copy-pasted as-is.
- `--allowlist-add`/`--allowlist-remove` are routed through the polkit-authorized root-helper (`archcanary.sh:109-118`, `/usr/lib/archcanary/root-helper`), not raw sudo — the hint now matches that.

## Test plan
- [x] `bash tests/run_matching_tests.sh` — all `check_autostart` sub-tests pass (substring assertions on `--allowlist-add=autostart:` still match with the `pkexec ...` prefix)
- [x] Manual repro with a fake `eos-update-notifier.service` unit — hint now shows `pkexec /usr/lib/archcanary/root-helper --allowlist-add=autostart:/usr/bin/eos-update-notifier`
- [x] `bash -n archcanary.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)