### PR TITLE
fix: add remediation hint to check_kmod's untracked-DKMS warning

### DIFF
--- a/archcanary.sh
+++ b/archcanary.sh
@@ -2667,17 +2667,31 @@ check_kmod() {
         local dkms_out
         dkms_out=$($dkms_cmd status 2>/dev/null) || dkms_out=""
         if [[ -n "$dkms_out" ]]; then
+            local -A _dkms_hint_shown=()
             while IFS= read -r entry; do
                 [[ -z "$entry" ]] && continue
-                local pkg_name
+                local pkg_name pkg_ver
                 # dkms status format: "name/version, kernel, arch: status"
                 pkg_name=$(awk -F'[/,]' '{print $1}' <<< "$entry" | xargs)
+                pkg_ver=$(awk -F'[/,]' '{print $2}' <<< "$entry" | xargs)
                 # Skip if pacman-tracked
                 pacman -Qi "$pkg_name" &>/dev/null 2>&1 && continue
                 if _allowlist_contains "$pkg_name" _dkms_allow; then
                     echo "  INFO: DKMS module allowlisted (not pacman-tracked): $entry"
                 else
                     echo "  WARNING: DKMS module from untracked source: $entry"
+                    # dkms status lists one entry per kernel a module is built
+                    # for, all sharing the same name/version — only show the
+                    # hint once per module instead of once per kernel.
+                    if [[ -z "${_dkms_hint_shown[$pkg_name/$pkg_ver]:-}" ]]; then
+                        echo "    Still using it (e.g. a proprietary driver never meant to be"
+                        echo "    pacman-tracked)? Mark it known-good:"
+                        echo "      pkexec /usr/lib/archcanary/root-helper --allowlist-add=dkms:$pkg_name"
+                        echo "    Leftover from a package you already removed? Clean up the"
+                        echo "    stale registration instead:"
+                        echo "      sudo dkms remove $pkg_name/$pkg_ver --all"
+                        _dkms_hint_shown["$pkg_name/$pkg_ver"]=1
+                    fi
                     found=2
                 fi
             done <<< "$dkms_out"

--- a/tests/run_matching_tests.sh
+++ b/tests/run_matching_tests.sh
@@ -910,7 +910,27 @@ test_check_kmod() {
         fail "check_kmod: empty lsmod/dkms → expected clean, got: $out"
     fi
 
-    rm -f "$null_dkms" "$lsmod_evil" "$lsmod_empty"
+    # Sub-test C: DKMS module untracked by pacman, built for two kernels —
+    # WARNING + remediation hint (both allowlist and cleanup paths), shown
+    # once per module (not once per kernel entry).
+    local dkms_evil
+    dkms_evil=$(make_cmd_script "$(printf 'evil-driver/1.2.3, 6.18.41-1-lts, x86_64: installed\nevil-driver/1.2.3, 7.1.5-arch1-2, x86_64: installed\n')")
+
+    rc=0
+    out=$(LSMOD_CMD="$lsmod_empty" DKMS_CMD="$dkms_evil" \
+        "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
+    local hint_count
+    hint_count=$(grep -c "pkexec /usr/lib/archcanary/root-helper --allowlist-add=dkms:evil-driver" <<< "$out")
+    if [[ $rc -eq 2 && "$out" == *"WARNING: DKMS module from untracked source: evil-driver/1.2.3"* && \
+          "$out" == *"pkexec /usr/lib/archcanary/root-helper --allowlist-add=dkms:evil-driver"* && \
+          "$out" == *"sudo dkms remove evil-driver/1.2.3 --all"* && \
+          "$hint_count" -eq 1 ]]; then
+        pass "check_kmod: untracked DKMS module → WARNING + both remediation paths, hint shown once"
+    else
+        fail "check_kmod: untracked DKMS module hint missing/wrong/duplicated, rc=$rc, hint_count=$hint_count, out: $out"
+    fi
+
+    rm -f "$null_dkms" "$lsmod_evil" "$lsmod_empty" "$dkms_evil"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `check_kmod`'s DKMS "untracked source" WARNING gave no guidance on what to do about it, unlike `check_autostart`'s hints (reported on the forum, `broadcom-wl` example).
- Unlike autostart's case, "untracked" here has two opposite-action causes archcanary can't tell apart: a proprietary driver never meant to be pacman-tracked (allowlist it) vs. a stale DKMS registration left behind after the owning package was removed (clean it up instead). Both paths are now shown.
- Deduped per module (`name/version`) since `dkms status` lists one entry per kernel — a module built for 3 kernels no longer prints the hint 3 times.

## Test plan
- [x] New sub-test in `test_check_kmod` (`tests/run_matching_tests.sh`) using the existing `DKMS_CMD` fixture-injection pattern — asserts both remediation lines appear and the hint is deduped to exactly one occurrence across two kernel entries
- [x] `bash tests/run_matching_tests.sh` — all `check_kmod` sub-tests pass, no regressions
- [x] Manual repro of the reported 3-kernel `broadcom-wl` case via a fake `DKMS_CMD` script — hint prints once with correct `pkg_name`/`pkg_ver` substitution
- [x] `bash -n archcanary.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)