### PR TITLE
fix: add remediation hints to WARNING findings missing one

### DIFF
--- a/archcanary.sh
+++ b/archcanary.sh
@@ -1543,7 +1543,7 @@ print_list() {
 # (Efficiency from commonsourcecs: pacman -Qmq in batch)
 # ---------------------------------------------------------------------------
 check_current() {
-    local found=()
+    local found=() found_pkgs=()
     declare -gA CURRENTLY_INSTALLED_MAP=()
     while IFS= read -r pkg; do
         CURRENTLY_INSTALLED_MAP[$pkg]=1
@@ -1568,6 +1568,7 @@ check_current() {
         else
             found+=("$pkg (installed: $install_date)")
         fi
+        found_pkgs+=("$pkg")
     done < <(pacman -Qmq "${INFECTED_PKGS[@]}" 2>/dev/null)
 
     if [[ ${#found[@]} -eq 0 ]]; then
@@ -1576,6 +1577,8 @@ check_current() {
     else
         echo "  WARNING: ${#found[@]} possibly infected package(s):"
         print_list found
+        echo "  Remove them:"
+        printf '    sudo pacman -Rns -- %s\n' "${found_pkgs[*]}"
         return 2
     fi
 }
@@ -1795,6 +1798,8 @@ check_systemd() {
     if [[ ${#found[@]} -gt 0 ]]; then
         echo "  WARNING: ${#found[@]} suspicious systemd unit(s) found:"
         print_list found
+        echo "  If you recognize any of these, mark it known-good:"
+        echo "    pkexec /usr/lib/archcanary/root-helper --allowlist-add=systemd:<unit-name>"
         return 2
     fi
     echo "  Clean: no suspicious systemd units found."
@@ -1824,6 +1829,10 @@ check_ebpf() {
     if [[ ${#found[@]} -gt 0 ]]; then
         echo "  WARNING: eBPF rootkit traces found:"
         print_list found
+        echo "  No legitimate software creates files with these names — pinned BPF maps"
+        echo "  named after a hiding technique are a strong compromise indicator, not a"
+        echo "  configuration artifact. Recommend offline analysis before continuing to"
+        echo "  use this system normally."
         return 2
     fi
     echo "  Clean: no eBPF rootkit traces detected."
@@ -1931,6 +1940,8 @@ check_bpftool() {
                 else
                     echo "  WARNING: lsm eBPF programs loaded by unknown process (expected systemd / AppArmor / SELinux)."
                     echo "  Unknown loaders: $resolved_str"
+                    echo "  Recognize this loader? Mark it known-good:"
+                    echo "    pkexec /usr/lib/archcanary/root-helper --allowlist-add=bpftool:<loader-basename>"
                     echo "  If this looks like a false positive, report it at https://github.com/musqz/archcanary/issues"
                     worst_ret=1
                 fi
@@ -2178,6 +2189,11 @@ check_pkgbuild_caches() {
         echo "  Skipped: no AUR helper cache directories found."
     elif [[ $found_count -eq 0 ]]; then
         echo "  Clean: no malicious commands found in $scanned PKGBUILD/install file(s)."
+    else
+        echo
+        echo "  Remove the flagged cache dir(s) rather than building from them, then"
+        echo "  re-fetch the PKGBUILD directly from the AUR and diff it against what's"
+        echo "  flagged above before rebuilding."
     fi
     return $found_count
 }
@@ -2580,6 +2596,7 @@ check_autostart() {
                [[ "$line" =~ $re_eval_net ]]; then
                 echo "  WARNING: suspicious pattern in $rc:$lineno"
                 echo "    $line"
+                echo "    If you don't recognize this, remove the line from $rc."
                 found=2
             fi
         done < "$rc"
@@ -2700,7 +2717,13 @@ check_pkginteg() {
     echo "  (May take 30-60 seconds on large installs)"
 
     local raw findings count
-    raw=$(/usr/bin/pacman -Qkk 2>/dev/null)
+    # The "warning: <pkg>: <path> (SHA256 checksum mismatch)" lines this check
+    # actually cares about go to stderr — only the "backup file: ..." (expected
+    # divergence) and per-package summary lines are on stdout. 2>/dev/null here
+    # discarded exactly the findings the grep -v "^backup file:" below is meant
+    # to keep, so this check could never surface a real mismatch. 2>&1 merges
+    # both streams; the filters below still correctly separate them.
+    raw=$(/usr/bin/pacman -Qkk 2>&1)
 
     findings=$(
         printf '%s\n' "$raw" \
@@ -2716,12 +2739,21 @@ check_pkginteg() {
 
     count=$(wc -l <<< "$findings")
     printf '  %d file(s) with unexpected checksum mismatch:\n\n' "$count"
+    local -A _mismatch_pkgs=()
     while IFS= read -r line; do
         printf '  * %s\n' "$line"
+        # pacman -Qkk line format: "warning: <pkgname>: <path> (SHA256 checksum mismatch)"
+        local mpkg
+        mpkg=$(sed -n 's/^warning: \([^:]*\):.*/\1/p' <<< "$line")
+        [[ -n "$mpkg" ]] && _mismatch_pkgs["$mpkg"]=1
     done <<< "$findings"
     echo
     echo "  Note: some mismatches are benign (app-managed config files, browser policies)."
     echo "  Prioritise binaries in /usr/bin/, /usr/lib/, /usr/sbin/."
+    if [[ ${#_mismatch_pkgs[@]} -gt 0 ]]; then
+        echo "  Reinstall to restore the original files:"
+        printf '    sudo pacman -S -- %s\n' "${!_mismatch_pkgs[*]}"
+    fi
     return 1
 }
 

--- a/tests/run_matching_tests.sh
+++ b/tests/run_matching_tests.sh
@@ -340,6 +340,13 @@ test_check_systemd_hardened() {
         fail "check_systemd: timer not detected — got: $out"
     fi
 
+    # Sub-test B2: WARNING output is followed by the allowlist remediation hint
+    if [[ "$out" == *"pkexec /usr/lib/archcanary/root-helper --allowlist-add=systemd:"* ]]; then
+        pass "check_systemd: allowlist hint present in WARNING output"
+    else
+        fail "check_systemd: allowlist hint missing from WARNING output, got: $out"
+    fi
+
     # Sub-test C: empty dir → clean
     local tmpdir
     tmpdir=$(mktemp -d)
@@ -403,6 +410,13 @@ test_check_autostart() {
         pass "check_autostart: curl|bash in .bashrc detected"
     else
         fail "check_autostart: .bashrc pattern not detected — out: $out"
+    fi
+
+    # Sub-test C2: shell-RC WARNING includes the "remove the line" hint
+    if [[ "$out" == *"If you don't recognize this, remove the line from"* ]]; then
+        pass "check_autostart: shell-RC WARNING includes remediation hint"
+    else
+        fail "check_autostart: shell-RC remediation hint missing — out: $out"
     fi
 
     # Sub-test D: clean home dir → clean
@@ -792,6 +806,16 @@ test_pkgbuild_obfuscation() {
         fail "pkgbuild_obfuscation: base64 pattern missed, rc=$rc"
     fi
 
+    # Sub-test A2: cleanup hint present, exactly once (it's printed once after
+    # the whole scan loop, not per-pattern-match or per-file)
+    local hint_count
+    hint_count=$(grep -c "Remove the flagged cache dir(s)" <<< "$out")
+    if [[ "$out" == *"re-fetch the PKGBUILD directly from the AUR"* && "$hint_count" -eq 1 ]]; then
+        pass "pkgbuild_obfuscation: cleanup hint present exactly once"
+    else
+        fail "pkgbuild_obfuscation: cleanup hint missing/duplicated, hint_count=$hint_count, out: $out"
+    fi
+
     # Sub-test B: eval $(...) → WARNING
     rc=0
     out=$(PKGBUILD_CACHE_DIRS="$fixtures/pkg-eval" \
@@ -957,6 +981,13 @@ SCRIPT
         pass "check_bpftool: unknown lsm loader → WARNING (exit 1)"
     else
         fail "check_bpftool: unknown lsm loader → expected WARNING+exit1, got rc=$rc, out: $out"
+    fi
+
+    # Sub-test A2: WARNING output is followed by the allowlist remediation hint
+    if [[ "$out" == *"pkexec /usr/lib/archcanary/root-helper --allowlist-add=bpftool:"* ]]; then
+        pass "check_bpftool: allowlist hint present in WARNING output"
+    else
+        fail "check_bpftool: allowlist hint missing from WARNING output, got: $out"
     fi
 
     # Sub-test B: same loader, allowlisted by basename → INFO only, exit 0


### PR DESCRIPTION
## Summary
- Inventoried every `WARNING:` call site in `check_*` functions (33 total) — 21 gave no guidance on what to do about the finding, unlike `check_autostart`'s and `check_kmod`'s existing hints (the DKMS fix in #154 that prompted this audit).
- Fixes the 9 sites (across 6 functions) that don't need new ecosystem-specific removal commands. The npm/bun/yarn/pnpm/fnm cache family (12 sites, 5 different removal commands per ecosystem) is intentionally excluded — separate, larger follow-up.
- `check_current`: suggest `sudo pacman -Rns` for installed matches
- `check_systemd`, `check_bpftool`: mention the allowlist mechanism each already has wired up but never told the user about
- `check_ebpf`: no allowlist exists (deliberately — these filenames have no legitimate source), investigative context instead
- `check_autostart`'s shell-RC branch: "remove the line" hint, matching its sibling branches
- `check_pkgbuild_caches`: one shared cleanup hint after the scan, not duplicated across all 7 patterns
- `check_pkginteg`: reinstall hint with resolved package names

**Also fixes a real bug** found while manually verifying `check_pkginteg`: it captured `pacman -Qkk` with `2>/dev/null`, discarding stderr — which is where pacman actually prints the `warning: <pkg>: <path> (SHA256 checksum mismatch)` lines this check exists to surface. Only the expected `backup file: ...` divergences (stdout) ever reached the filter, so the check has likely never detected a real mismatch. Verified live on this machine: 21 real mismatches across 10 packages, previously silently reported as "All accessible installed files match."

## Test plan
- [x] New sub-tests: `check_systemd`/`check_bpftool` allowlist hints, `check_pkgbuild_caches` cleanup hint (asserted to print exactly once), `check_autostart` RC-line hint — all via existing fixture-injection patterns
- [x] `check_current` and `check_pkginteg`/`check_ebpf` verified manually (no existing override var for `pacman -Qmq`/`pacman -Qkk`/`/sys/fs/bpf` — adding one was out of scope for this pass)
- [x] `bash tests/run_matching_tests.sh` — all new + existing sub-tests pass, no regressions (same pre-existing unrelated `cli_flag` failure as prior PRs)
- [x] `bash -n archcanary.sh` clean
- [x] Live repro of the `check_pkginteg` bug fix on this dev machine — 21 mismatches now correctly surfaced with a deduped `sudo pacman -S` reinstall suggestion

🤖 Generated with [Claude Code](https://claude.com/claude-code)