### PR TITLE
fix: stop check_pkginteg gluing stdout/stderr lines together

### DIFF
--- a/archcanary.sh
+++ b/archcanary.sh
@@ -2762,14 +2762,27 @@ check_pkginteg() {
     echo "  Verifying installed file checksums against pacman database..."
     echo "  (May take 30-60 seconds on large installs)"
 
-    local raw findings count
+    local raw findings count stderr_tmp
     # The "warning: <pkg>: <path> (SHA256 checksum mismatch)" lines this check
     # actually cares about go to stderr — only the "backup file: ..." (expected
-    # divergence) and per-package summary lines are on stdout. 2>/dev/null here
-    # discarded exactly the findings the grep -v "^backup file:" below is meant
-    # to keep, so this check could never surface a real mismatch. 2>&1 merges
-    # both streams; the filters below still correctly separate them.
-    raw=$(/usr/bin/pacman -Qkk 2>&1)
+    # divergence) and per-package summary lines are on stdout. 2>/dev/null used
+    # to discard exactly the findings the grep -v "^backup file:" below is meant
+    # to keep, so this check could never surface a real mismatch.
+    #
+    # Fix is NOT `2>&1` — stdout and stderr are buffered differently (stdout is
+    # block-buffered since it's not a TTY, stderr is unbuffered), so merging
+    # them into one command substitution interleaves writes unpredictably and
+    # can glue the tail of one stream's line onto the front of the other's
+    # mid-word (reported live: "backup file: libvirtwarning: libvirt: ..." and
+    # "rubwarning: shadow: ..." — real text from two different lines fused
+    # together with no newline between them). Capture stderr into a real file
+    # instead — same single pacman invocation, but the two streams never share
+    # a buffer, so each capture is clean before they're concatenated as text.
+    stderr_tmp=$(mktemp)
+    CLEANUP_FILES+=("$stderr_tmp")
+    raw=$(/usr/bin/pacman -Qkk 2>"$stderr_tmp")
+    raw+=$'\n'"$(cat "$stderr_tmp")"
+    rm -f "$stderr_tmp"
 
     findings=$(
         printf '%s\n' "$raw" \


### PR DESCRIPTION
## Summary
- Regression from #155: fixing `check_pkginteg` to actually see `pacman -Qkk`'s real mismatch warnings (`2>&1` instead of `2>/dev/null`) introduced line corruption — merging stdout and stderr into one command substitution interleaves their writes unpredictably, since stdout is block-buffered (not a TTY) while stderr isn't.
- Reported live: `backup file: libvirtwarning: libvirt: ...` and `rubwarning: shadow: ...` — real text from two different lines fused together mid-word with no newline between them, showing up as warnings missing their `warning: <pkg>: ` prefix (e.g. `dow: /etc/default/useradd (SHA256 checksum mismatch)` — the tail end of a `warning: shadow: ...` line whose head got glued onto a preceding stdout summary line).
- Fix: same single `pacman -Qkk` invocation, but stderr now goes to a real temp file (`mktemp`, registered in `CLEANUP_FILES`) instead of sharing stdout's fd — each stream captured cleanly before being concatenated as text.

## Test plan
- [x] Directly reproduced the interleaving in raw `pacman -Qkk 2>&1` output before the fix
- [x] 5 consecutive `--check-pkginteg` runs after the fix — zero corrupted lines (previously reproducible most runs)
- [x] Cross-checked the reported mismatch count/packages against a fresh direct `pacman -Qkk` query — matches exactly
- [x] `bash tests/run_matching_tests.sh` — no regressions (same pre-existing unrelated `cli_flag` failure)
- [x] `bash -n archcanary.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)