### PR TITLE
fix: only treat check_pkginteg's binary mismatches as warnings

### DIFF
--- a/archcanary.sh
+++ b/archcanary.sh
@@ -2798,32 +2798,30 @@ check_pkginteg() {
 
     count=$(wc -l <<< "$findings")
     printf '  %d file(s) with unexpected checksum mismatch:\n\n' "$count"
-    # Packages get bucketed by whether reinstalling would actually help. A lot
-    # of what pacman -Qkk flags is a file a pacman hook (or the package's own
-    # tooling) regenerates on every install/upgrade by design — depmod
-    # rewriting modules.dep/.alias/.symbols, vlc-cache-gen rewriting
-    # plugins.dat, Manjaro's firefox/networkmanager hooks overwriting their
-    # own branding, GHC/pacman-mirrors rewriting their own caches/state.
-    # Reinstalling those doesn't fix anything — the hook firing IS what
-    # re-diverges the file, so "reinstall to fix it" is actively wrong advice
-    # there. An ELF binary (magic-byte check, same technique check_pkgbuild_
-    # caches uses) is the case reinstalling genuinely restores: compiled code
-    # doesn't get legitimately regenerated post-install the way a cache/config
-    # file does. A package lands in the ELF bucket if ANY of its mismatched
-    # files is one; only-non-ELF packages go in the other bucket.
+    # Bucketed by whether reinstalling would help — a lot of what pacman -Qkk
+    # flags is a file a pacman hook or the package's own tooling regenerates
+    # on every install/upgrade by design (depmod, vlc-cache-gen, Manjaro's
+    # firefox/networkmanager hooks, GHC/pacman-mirrors caches), so reinstalling
+    # doesn't fix it and it's not a real finding. Only the ELF bucket (magic-
+    # byte check, same as check_pkgbuild_caches) counts as WARNING, below and
+    # in the return code; classify before printing so the label matches.
     local -A _mismatch_pkgs_elf=() _mismatch_pkgs_other=()
     while IFS= read -r line; do
-        printf '  * %s\n' "$line"
         # pacman -Qkk line format: "warning: <pkgname>: <path> (SHA256 checksum mismatch)"
         local mpkg mfile magic
         mpkg=$(sed -n 's/^warning: \([^:]*\):.*/\1/p' <<< "$line")
-        [[ -n "$mpkg" ]] || continue
+        if [[ -z "$mpkg" ]]; then
+            printf '  * %s\n' "$line"
+            continue
+        fi
         mfile=$(sed -n 's/^warning: [^:]*: \(.*\) (SHA256 checksum mismatch)$/\1/p' <<< "$line")
         magic=""
         [[ -n "$mfile" && -r "$mfile" ]] && IFS= read -r -n4 magic < "$mfile" 2>/dev/null
         if [[ "$magic" == $'\x7fELF' ]]; then
+            printf '  * %s\n' "$line"
             _mismatch_pkgs_elf["$mpkg"]=1
         else
+            printf '  * %s\n' "${line/#warning:/info:}"
             _mismatch_pkgs_other["$mpkg"]=1
         fi
     done <<< "$findings"
@@ -2834,20 +2832,22 @@ check_pkginteg() {
         unset '_mismatch_pkgs_other[$p]'
     done
     echo
-    echo "  Note: some mismatches are benign (app-managed config files, browser policies)."
-    echo "  Prioritise binaries in /usr/bin/, /usr/lib/, /usr/sbin/."
     if [[ ${#_mismatch_pkgs_elf[@]} -gt 0 ]]; then
-        echo "  Reinstall to restore the original files:"
+        echo "  WARNING: binary file(s) changed — reinstall to restore the originals:"
         printf '    sudo pacman -S -- %s\n' "${!_mismatch_pkgs_elf[*]}"
     fi
     if [[ ${#_mismatch_pkgs_other[@]} -gt 0 ]]; then
-        echo "  These packages' mismatches are all non-binary files (config/cache/state) —"
-        echo "  likely a pacman hook or the package's own tooling regenerating them by"
-        echo "  design. Reinstalling won't fix this (the hook re-fires and re-diverges"
-        echo "  it immediately), so only worth investigating if the change is unexpected:"
-        printf '    %s\n' "${!_mismatch_pkgs_other[*]}"
+        echo "  INFO: non-binary mismatches (config/cache/state) — likely a pacman hook or"
+        echo "  the package's own tooling regenerating them by design. Reinstalling won't"
+        echo "  fix this; only worth investigating if the change itself looks unexpected."
+        local other_list=""
+        for p in "${!_mismatch_pkgs_other[@]}"; do
+            other_list="${other_list:+$other_list, }$p"
+        done
+        echo "  Packages: $other_list"
     fi
-    return 1
+    [[ ${#_mismatch_pkgs_elf[@]} -gt 0 ]] && return 1
+    return 0
 }
 
 # ---------------------------------------------------------------------------

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -2763,6 +2763,8 @@ check_pkginteg() {
     echo "  (May take 30-60 seconds on large installs)"
 
     local raw findings count stderr_tmp
+    # PACMAN_CMD overrides the real binary for testing (fake pacman script).
+    local pacman_cmd="${PACMAN_CMD:-/usr/bin/pacman}"
     # The "warning: <pkg>: <path> (SHA256 checksum mismatch)" lines this check
     # actually cares about go to stderr — only the "backup file: ..." (expected
     # divergence) and per-package summary lines are on stdout. 2>/dev/null used
@@ -2780,7 +2782,7 @@ check_pkginteg() {
     # a buffer, so each capture is clean before they're concatenated as text.
     stderr_tmp=$(mktemp)
     CLEANUP_FILES+=("$stderr_tmp")
-    raw=$(/usr/bin/pacman -Qkk 2>"$stderr_tmp")
+    raw=$("$pacman_cmd" -Qkk 2>"$stderr_tmp")
     raw+=$'\n'"$(cat "$stderr_tmp")"
     rm -f "$stderr_tmp"
 

--- a/tests/run_matching_tests.sh
+++ b/tests/run_matching_tests.sh
@@ -997,6 +997,66 @@ test_check_kmod() {
 }
 
 # ---------------------------------------------------------------------------
+# Test: check_pkginteg — ELF vs non-binary mismatch classification
+# ---------------------------------------------------------------------------
+test_check_pkginteg() {
+    local base_args=(
+        --package-list="$SCRIPT_DIR/fake_package_lists/simple.txt"
+        --malicious-npm-list="$SCRIPT_DIR/fake_npm_lists/malicious_npm.txt"
+        --check-pkginteg --no-notify
+    )
+    local out rc=0
+    local elf_bin="$SCRIPT_DIR/fake_pkgbuilds/pkg-elf/helper-bin"
+
+    # Sub-test A: one ELF mismatch + one non-binary mismatch → ELF gets
+    # WARNING + reinstall command, non-binary gets softened to info: and
+    # doesn't affect severity, exit 1 (only the ELF one counts).
+    # Real pacman -Qkk splits output: "backup file:"/summary lines on
+    # stdout, the "warning:" lines this check parses on stderr.
+    local fake_pacman
+    fake_pacman=$(mktemp)
+    cat > "$fake_pacman" << EOF
+#!/bin/sh
+echo "fakepkg-elf: 1 total files, 1 altered files"
+echo "fakepkg-conf: 1 total files, 1 altered files"
+echo "warning: fakepkg-elf: $elf_bin (SHA256 checksum mismatch)" >&2
+echo "warning: fakepkg-conf: /etc/fake.conf (SHA256 checksum mismatch)" >&2
+EOF
+    chmod +x "$fake_pacman"
+
+    rc=0
+    out=$(PACMAN_CMD="$fake_pacman" "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
+    if [[ $rc -eq 1 && "$out" == *"warning: fakepkg-elf:"* && "$out" == *"info: fakepkg-conf:"* && \
+          "$out" == *"WARNING: binary file(s) changed"* && "$out" == *"sudo pacman -S -- fakepkg-elf"* && \
+          "$out" == *"INFO: non-binary mismatches"* && "$out" == *"Packages: fakepkg-conf"* ]]; then
+        pass "check_pkginteg: ELF mismatch → WARNING+reinstall, non-binary → info, exit 1"
+    else
+        fail "check_pkginteg: mixed classification wrong, rc=$rc, out: $out"
+    fi
+
+    # Sub-test B: only a non-binary mismatch → exit 0 (clean), no WARNING
+    # anywhere — the whole point of the severity split.
+    local fake_pacman_nonbin
+    fake_pacman_nonbin=$(mktemp)
+    cat > "$fake_pacman_nonbin" << 'EOF'
+#!/bin/sh
+echo "fakepkg-conf: 1 total files, 1 altered files"
+echo "warning: fakepkg-conf: /etc/fake.conf (SHA256 checksum mismatch)" >&2
+EOF
+    chmod +x "$fake_pacman_nonbin"
+
+    rc=0
+    out=$(PACMAN_CMD="$fake_pacman_nonbin" "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
+    if [[ $rc -eq 0 && "$out" == *"info: fakepkg-conf:"* && "$out" != *"WARNING: binary"* ]]; then
+        pass "check_pkginteg: only non-binary mismatch → exit 0 (clean), no WARNING"
+    else
+        fail "check_pkginteg: non-binary-only should be clean, rc=$rc, out: $out"
+    fi
+
+    rm -f "$fake_pacman" "$fake_pacman_nonbin"
+}
+
+# ---------------------------------------------------------------------------
 # Test 14: check_bpftool — unknown LSM loader detection + allowlist
 # ---------------------------------------------------------------------------
 test_check_bpftool_allowlist() {
@@ -1375,6 +1435,9 @@ test_pkgbuild_obfuscation
 
 $VERBOSE && msg "--- Test 13: check_kmod ---"
 test_check_kmod
+
+$VERBOSE && msg "--- Test check_pkginteg: ELF vs non-binary classification ---"
+test_check_pkginteg
 
 $VERBOSE && msg "--- Test 14: check_bpftool allowlist ---"
 test_check_bpftool_allowlist


### PR DESCRIPTION
## Summary
- Reported live: after the ELF/non-binary classification (#158), `check_pkginteg` still labeled every mismatch with pacman's raw `warning:` text and returned a code that showed the summary as `WARNINGS`/`RESULT: WARNINGS` even when none of the findings were binaries — i.e. even when nothing was actually wrong, just expected hook-driven drift (depmod, vlc-cache-gen, Manjaro's firefox/networkmanager hooks, GHC/pacman-mirrors caches).
- Only the ELF bucket now drives the return code and gets the `WARNING:` label; classification happens before printing so each line's prefix (`warning:` vs `info:`) matches its bucket. Non-binary mismatches stay fully visible — still listed, still explained — just no longer read as a problem, same "note, not a warning" treatment `check_list_overlap` already gives its own non-issues.
- Added a `PACMAN_CMD` override (matching `LSMOD_CMD`/`DKMS_CMD`/`BPFTOOL_CMD`) and permanent fixture-based tests — this classification previously only had ad-hoc manual verification against live system state.

## Test plan
- [x] New `test_check_pkginteg`: mixed ELF + non-binary mismatch → WARNING+reinstall for the ELF one, softened `info:` for the other, exit 1; non-binary-only mismatch → exit 0, no WARNING anywhere
- [x] Live run on the reporting machine — summary now shows `Package integrity [ok] clean` and `RESULT: CLEAN` (previously `[!!] warnings`/`RESULT: WARNINGS`) for its 7 confirmed-benign packages
- [x] `bash tests/run_matching_tests.sh` — all new + existing tests pass, no regressions (same pre-existing unrelated `cli_flag` failure)
- [x] `bash -n archcanary.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)