### PR TITLE
feat: let GUI scan results be saved to a remembered location

### DIFF
--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -86,8 +86,10 @@ grep -qiE '^AUR_AUDIT_ENABLE=false' "${XDG_CONFIG_HOME:-$HOME/.config}/archcanar
 # Remembered scan-log save directory (show_output()'s Save button) — same
 # file, same "display cache, updated in place after Save" rule as above.
 GUI_LOG_SAVE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/archcanary"
-_remembered_dir="$(grep -oP '^GUI_LOG_SAVE_DIR=\K.*' "${XDG_CONFIG_HOME:-$HOME/.config}/archcanary/env" 2>/dev/null | tail -1)"
-[[ -n "$_remembered_dir" && -d "$_remembered_dir" ]] && GUI_LOG_SAVE_DIR="$_remembered_dir"
+_remembered_dir="$(grep -oP '^GUI_LOG_SAVE_DIR=\K.*' "${XDG_CONFIG_HOME:-$HOME/.config}/archcanary/env" 2>/dev/null | tail -1)" || true
+if [[ -n "$_remembered_dir" && -d "$_remembered_dir" ]]; then
+    GUI_LOG_SAVE_DIR="$_remembered_dir"
+fi
 unset _remembered_dir
 
 # Rewrites ~/.config/archcanary/env from the two known in-memory settings

--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -481,6 +481,40 @@ Source: <a href=\"${repo}\">${repo}</a>" \
         2>/dev/null || true
 }
 
+# Shared Save-button flow for show_output() and run_action()'s pkexec branch
+# — file picker defaulting to the remembered directory, persists the chosen
+# directory for next time. $1 = path to the completed scan's temp output
+# file. mkdir/cp are guarded (not bare statements) — under this script's
+# set -euo pipefail, an unguarded failing command anywhere outside a
+# condition kills the whole GUI silently (see commit f04cf99).
+_save_scan_log() {
+    local tmpout="$1"
+    if ! mkdir -p "$GUI_LOG_SAVE_DIR" 2>/dev/null; then
+        yad --image=dialog-error --title="Archcanary" --window-icon=security-high --center \
+            --text="Could not create save directory:\n<tt>${GUI_LOG_SAVE_DIR}</tt>" \
+            --width=420 --button="OK:0" 2>/dev/null || true
+        return
+    fi
+    local suggested chosen
+    suggested="$GUI_LOG_SAVE_DIR/aur-check-$(date +%Y%m%d-%H%M%S).log"
+    chosen=$(yad --file --save --confirm-overwrite \
+        --title="Save Scan Log — Archcanary" \
+        --window-icon=security-high --center \
+        --filename="$suggested" 2>/dev/null) || chosen=""
+    [[ -z "$chosen" ]] && return
+    if ! cp "$tmpout" "$chosen" 2>/dev/null; then
+        yad --image=dialog-error --title="Archcanary" --window-icon=security-high --center \
+            --text="Could not save to:\n<tt>${chosen}</tt>" \
+            --width=420 --button="OK:0" 2>/dev/null || true
+        return
+    fi
+    GUI_LOG_SAVE_DIR="$(dirname "$chosen")"
+    _write_gui_env
+    yad --image=dialog-information --title="Archcanary" --window-icon=security-high --center \
+        --text="Scan log saved to:\n<tt>${chosen}</tt>" \
+        --button="OK:0" 2>/dev/null || true
+}
+
 # Run a command, stream output live to a text-info window, return its exit code.
 show_output() {
     local title="$1" scan_exit=0
@@ -517,26 +551,9 @@ show_output() {
     wait "$yad_pid" 2>/dev/null || yad_ret=$?
     exec 8>&-
 
-    # Save:0 — file picker defaults to the remembered directory (or
-    # archcanary.sh's own --log-file default the first time), with the same
-    # auto-timestamped name a CLI run would use. Picking a different
-    # directory updates GUI_LOG_SAVE_DIR for next time.
+    # Save:0
     if [[ "$yad_ret" -eq 0 ]]; then
-        mkdir -p "$GUI_LOG_SAVE_DIR"
-        local suggested chosen
-        suggested="$GUI_LOG_SAVE_DIR/aur-check-$(date +%Y%m%d-%H%M%S).log"
-        chosen=$(yad --file --save --confirm-overwrite \
-            --title="Save Scan Log — Archcanary" \
-            --window-icon=security-high --center \
-            --filename="$suggested" 2>/dev/null) || chosen=""
-        if [[ -n "$chosen" ]]; then
-            cp "$tmpout" "$chosen"
-            GUI_LOG_SAVE_DIR="$(dirname "$chosen")"
-            _write_gui_env
-            yad --image=dialog-information --title="Archcanary" --window-icon=security-high --center \
-                --text="Scan log saved to:\n<tt>${chosen}</tt>" \
-                --button="OK:0" 2>/dev/null || true
-        fi
+        _save_scan_log "$tmpout"
     fi
 
     _SHOW_OUTPUT_INFECTED_PKGS="$(_extract_infected_pkgs "$tmpout")"
@@ -852,23 +869,9 @@ run_action() {
         wait "$yad_pid" 2>/dev/null || yad_ret=$?
         exec 8>&-
 
-        # Save:0 — same picker/remember behavior as show_output()'s Save button.
+        # Save:0
         if [[ "$yad_ret" -eq 0 ]]; then
-            mkdir -p "$GUI_LOG_SAVE_DIR"
-            local suggested chosen
-            suggested="$GUI_LOG_SAVE_DIR/aur-check-$(date +%Y%m%d-%H%M%S).log"
-            chosen=$(yad --file --save --confirm-overwrite \
-                --title="Save Scan Log — Archcanary" \
-                --window-icon=security-high --center \
-                --filename="$suggested" 2>/dev/null) || chosen=""
-            if [[ -n "$chosen" ]]; then
-                cp "$tmpout" "$chosen"
-                GUI_LOG_SAVE_DIR="$(dirname "$chosen")"
-                _write_gui_env
-                yad --image=dialog-information --title="Archcanary" --window-icon=security-high --center \
-                    --text="Scan log saved to:\n<tt>${chosen}</tt>" \
-                    --button="OK:0" 2>/dev/null || true
-            fi
+            _save_scan_log "$tmpout"
         fi
 
         _update_status "$idx" "$scan_exit"

--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -759,7 +759,8 @@ run_action() {
             --width=1000 --height=660 \
             --fontname="Monospace 10" \
             --wrap --tail --editable \
-            --button=Close:0 \
+            --button="Save:0" \
+            --button="Close:1" \
             < "$fifo" 2>/dev/null &
         local yad_pid=$!
         exec 8>"$fifo"
@@ -847,8 +848,29 @@ run_action() {
         # was still running, which closes the FIFO read end before we get here.
         printf '\n─── done ───\n' >&8 || true
 
-        wait "$yad_pid" 2>/dev/null || true
+        local yad_ret=0
+        wait "$yad_pid" 2>/dev/null || yad_ret=$?
         exec 8>&-
+
+        # Save:0 — same picker/remember behavior as show_output()'s Save button.
+        if [[ "$yad_ret" -eq 0 ]]; then
+            mkdir -p "$GUI_LOG_SAVE_DIR"
+            local suggested chosen
+            suggested="$GUI_LOG_SAVE_DIR/aur-check-$(date +%Y%m%d-%H%M%S).log"
+            chosen=$(yad --file --save --confirm-overwrite \
+                --title="Save Scan Log — Archcanary" \
+                --window-icon=security-high --center \
+                --filename="$suggested" 2>/dev/null) || chosen=""
+            if [[ -n "$chosen" ]]; then
+                cp "$tmpout" "$chosen"
+                GUI_LOG_SAVE_DIR="$(dirname "$chosen")"
+                _write_gui_env
+                yad --image=dialog-information --title="Archcanary" --window-icon=security-high --center \
+                    --text="Scan log saved to:\n<tt>${chosen}</tt>" \
+                    --button="OK:0" 2>/dev/null || true
+            fi
+        fi
+
         _update_status "$idx" "$scan_exit"
         if [[ "$idx" -eq 0 ]]; then _propagate_full_scan "$scan_exit" "$tmpout"; fi
         local _inf_pkgs="" _inf_allowlist_hint=""

--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -83,6 +83,27 @@ REFRESHED=false
 AUR_AUDIT_ENABLE_GUI=true
 grep -qiE '^AUR_AUDIT_ENABLE=false' "${XDG_CONFIG_HOME:-$HOME/.config}/archcanary/env" 2>/dev/null && AUR_AUDIT_ENABLE_GUI=false
 
+# Remembered scan-log save directory (show_output()'s Save button) — same
+# file, same "display cache, updated in place after Save" rule as above.
+GUI_LOG_SAVE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/archcanary"
+_remembered_dir="$(grep -oP '^GUI_LOG_SAVE_DIR=\K.*' "${XDG_CONFIG_HOME:-$HOME/.config}/archcanary/env" 2>/dev/null | tail -1)"
+[[ -n "$_remembered_dir" && -d "$_remembered_dir" ]] && GUI_LOG_SAVE_DIR="$_remembered_dir"
+unset _remembered_dir
+
+# Rewrites ~/.config/archcanary/env from the two known in-memory settings
+# (AUR_AUDIT_ENABLE_GUI, GUI_LOG_SAVE_DIR) — shared by scan_settings() and
+# show_output()'s Save button so neither one clobbers the other's line.
+# grep-only file, never sourced — see the security note above scan_settings().
+_write_gui_env() {
+    local cfg_dir="${XDG_CONFIG_HOME:-$HOME/.config}/archcanary"
+    mkdir -p "$cfg_dir"
+    {
+        printf '# archcanary settings — managed by archcanary-gui\n'
+        $AUR_AUDIT_ENABLE_GUI || printf 'AUR_AUDIT_ENABLE=false\n'
+        printf 'GUI_LOG_SAVE_DIR=%s\n' "$GUI_LOG_SAVE_DIR"
+    } > "$cfg_dir/env"
+}
+
 # Action data — order here is the canonical index used by run_action
 LABELS=(
     "Full scan"                 # 0  root
@@ -473,7 +494,8 @@ show_output() {
         --width=1000 --height=660 \
         --fontname="Monospace 10" \
         --wrap --tail --editable \
-        --button=Close:0 \
+        --button="Save:0" \
+        --button="Close:1" \
         < "$fifo" 2>/dev/null &
     yad_pid=$!
     exec 8>"$fifo"
@@ -489,8 +511,32 @@ show_output() {
     wait "$tail_pid" 2>/dev/null || true
     printf '\n─── done ───\n' >&8 || true
 
-    wait "$yad_pid" 2>/dev/null || true
+    local yad_ret=0
+    wait "$yad_pid" 2>/dev/null || yad_ret=$?
     exec 8>&-
+
+    # Save:0 — file picker defaults to the remembered directory (or
+    # archcanary.sh's own --log-file default the first time), with the same
+    # auto-timestamped name a CLI run would use. Picking a different
+    # directory updates GUI_LOG_SAVE_DIR for next time.
+    if [[ "$yad_ret" -eq 0 ]]; then
+        mkdir -p "$GUI_LOG_SAVE_DIR"
+        local suggested chosen
+        suggested="$GUI_LOG_SAVE_DIR/aur-check-$(date +%Y%m%d-%H%M%S).log"
+        chosen=$(yad --file --save --confirm-overwrite \
+            --title="Save Scan Log — Archcanary" \
+            --window-icon=security-high --center \
+            --filename="$suggested" 2>/dev/null) || chosen=""
+        if [[ -n "$chosen" ]]; then
+            cp "$tmpout" "$chosen"
+            GUI_LOG_SAVE_DIR="$(dirname "$chosen")"
+            _write_gui_env
+            yad --image=dialog-information --title="Archcanary" --window-icon=security-high --center \
+                --text="Scan log saved to:\n<tt>${chosen}</tt>" \
+                --button="OK:0" 2>/dev/null || true
+        fi
+    fi
+
     _SHOW_OUTPUT_INFECTED_PKGS="$(_extract_infected_pkgs "$tmpout")"
     _SHOW_OUTPUT_ALLOWLIST_HINT="$(_allowlistable_finding_present "$tmpout")"
     rm -f "$tmpout"
@@ -565,11 +611,8 @@ scan_settings() {
         --button="Save:0" --button="Cancel:1" \
         2>/dev/null) || return 0
 
-    {
-        printf '# archcanary settings — managed by archcanary-gui\n'
-        [[ "$result" == FALSE* ]] && printf 'AUR_AUDIT_ENABLE=false\n'
-    } > "$env_file"
     [[ "$result" == FALSE* ]] && AUR_AUDIT_ENABLE_GUI=false || AUR_AUDIT_ENABLE_GUI=true
+    _write_gui_env
 
     yad --image=dialog-information \
         --title="Archcanary" \

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -320,9 +320,15 @@ _aur_audit_set_cli() {
     local enable="$1" f
     f="$(_aur_audit_env_path)"
     mkdir -p "$(dirname "$f")"
+    # Preserve GUI_LOG_SAVE_DIR (archcanary-gui.sh's remembered scan-log save
+    # directory) — this file has two writers, and rebuilding it from only
+    # this function's own known key would silently wipe the other one out.
+    local gui_log_dir
+    gui_log_dir="$(grep -oP '^GUI_LOG_SAVE_DIR=\K.*' "$f" 2>/dev/null | tail -1)" || true
     {
         printf '# archcanary settings — managed by archcanary-gui\n'
         [[ "$enable" == false ]] && printf 'AUR_AUDIT_ENABLE=false\n'
+        [[ -n "$gui_log_dir" ]] && printf 'GUI_LOG_SAVE_DIR=%s\n' "$gui_log_dir"
     } > "$f"
     if [[ "$enable" == false ]]; then
         echo "aur-audit: disabled"


### PR DESCRIPTION
## Summary
- Reported by a user: no way to keep a scan's output from the GUI — the CLI already has `--log-file` (plus an automatic default log path), but `show_output()`'s scan window wrote to `/tmp` and deleted it the moment the window closed, with only a `Close` button.
- Adds a `Save` button that opens a save-file picker defaulting to a remembered directory (falling back to `archcanary.sh`'s own `--log-file` default the first time), with the same auto-timestamped filename a CLI run would use. The chosen directory persists to `~/.config/archcanary/env` for next time — same file `scan_settings()` already uses for `AUR_AUDIT_ENABLE`, now merged via a shared `_write_gui_env()` helper so neither setting clobbers the other's line.
- **Fixed along the way, both caught live during testing:**
  - The script died silently on first launch after the initial commit — `set -euo pipefail` + a `grep | tail` capture without `|| true`, failing under `pipefail` when no `GUI_LOG_SAVE_DIR=` line exists yet (fresh install). Reproduced with `bash -x`, fixed, reverified.
  - Root-requiring checks (Full scan, eBPF, kmod, etc.) have a **second, separate** pkexec-based scan-display code path that never got the Save button at all — fixed there too, without touching the adjacent polkit-focus logic (explicitly flagged in a comment as having regressed ~5 times before).
- **Then `/code-review high --fix` caught 4 more real issues, all fixed and independently reverified:**
  - `_aur_audit_set_cli()` (the `--aur-audit-enable`/`-disable` CLI flags) had the exact same clobbering bug from the *other* write path into `~/.config/archcanary/env` — now preserves `GUI_LOG_SAVE_DIR` too.
  - `mkdir -p`/`cp` in the Save flow ran unguarded under `set -e` — same failure class as the launch-crash fix above, just not yet triggered. Now guarded with error dialogs.
  - The ~18-line Save flow was duplicated verbatim between the two display paths (why the Save button needed adding twice) — factored into one `_save_scan_log()` helper.
  - Caught and fixed a fresh instance of the same `set -e` footgun introduced while writing that last fix, before it shipped.

## Test plan
- [x] Live, interactive: real yad windows, real clicks (by the reporting user) — Save button appears on both the non-root and root-requiring scan paths, file picker works, confirmation shows the right path
- [x] Live: launch crash reproduced with `bash -x` before the fix, confirmed gone after
- [x] Live: `_aur_audit_set_cli` preservation verified directly (`--aur-audit-disable` no longer wipes a preset `GUI_LOG_SAVE_DIR`)
- [x] Isolated harness tests (extracted functions, synthetic scan output) for the full save flow end-to-end: correct file content, correct persisted config, correct exit-code passthrough
- [x] `bash tests/run_matching_tests.sh` — no regressions (same pre-existing unrelated `cli_flag` failure as every other PR this session)
- [x] `bash -n` clean on both `archcanary.sh` and `archcanary-gui.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)