### PR TITLE
chore: set real sha256 for v0.1.24 release tarball

### DIFF
--- a/packaging/.SRCINFO
+++ b/packaging/.SRCINFO
@@ -19,6 +19,6 @@ pkgbase = archcanary
 	backup = etc/archcanary/bpftool_allowlist.conf
 	backup = etc/archcanary/autostart_allowlist.conf
 	source = archcanary-0.1.24.tar.gz::https://github.com/musqz/archcanary/archive/v0.1.24.tar.gz
-	sha256sums = SKIP
+	sha256sums = c77eed879f4e431cd4a3b39639ecd3637e998bc3a129627d06e754a86b981efd
 
 pkgname = archcanary

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -21,7 +21,7 @@ backup=('etc/archcanary/dkms_allowlist.conf'
         'etc/archcanary/autostart_allowlist.conf')
 install=archcanary.install
 source=("$pkgname-$pkgver.tar.gz::https://github.com/musqz/$pkgname/archive/v$pkgver.tar.gz")
-sha256sums=('SKIP')
+sha256sums=('c77eed879f4e431cd4a3b39639ecd3637e998bc3a129627d06e754a86b981efd')
 
 package() {
   cd "$srcdir/$pkgname-$pkgver"


### PR DESCRIPTION
## Summary
- Replace `sha256sums=('SKIP')` with the real hash of the `v0.1.24` tarball
- Verified `version.txt` inside the tarball reads `0.1.24` before hashing

## Test plan
- [x] `curl -sL https://github.com/musqz/archcanary/archive/v0.1.24.tar.gz \| sha256sum` matches
- [x] Extracted tarball's `version.txt` == `0.1.24`