### PR TITLE
fix: point check_pkgbuild_caches' WARNING at where to report it

### DIFF
--- a/archcanary.sh
+++ b/archcanary.sh
@@ -2232,6 +2232,10 @@ check_pkgbuild_caches() {
         echo "  Remove the flagged cache dir(s) rather than building from them, then"
         echo "  re-fetch the PKGBUILD directly from the AUR and diff it against what's"
         echo "  flagged above before rebuilding."
+        echo
+        echo "  If this holds up, report it so others are protected too:"
+        echo "    archcanary: https://github.com/musqz/archcanary/issues/new?template=report-package.yml"
+        echo "    Arch AUR:   https://lists.archlinux.org/archives/list/aur-general@lists.archlinux.org/"
     fi
     return $found_count
 }


### PR DESCRIPTION
## Summary
- `--check-pkgbuild`'s WARNING output only ever told the user how to protect themselves (remove the cache dir, re-fetch, diff before rebuilding) — nothing pointed at reporting the flagged package anywhere
- Both reporting channels already existed (archcanary's own `community_reports.txt` via CONTRIBUTING.md, and the Arch `aur-general` mailing list via README's "What to Do If Infected"), but were disconnected from the actual scan output
- Adds a two-line pointer to both channels, printed once in the existing shared remediation block (same "one shared hint, not duplicated per pattern" convention this function already follows)

## Test plan
- [x] `bash tests/run_matching_tests.sh` — 67 PASS, 1 pre-existing unrelated FAIL (`cli_flag`, same as noted in PR #150)
- [x] `bash -n archcanary.sh` clean
- [x] Manual run against the `pkg-base64` fixture — hint prints correctly after the existing cleanup guidance