### PR TITLE
fix: check_autostart false-positived on /etc/skel workaround scripts

### DIFF
--- a/archcanary.sh
+++ b/archcanary.sh
@@ -2512,6 +2512,10 @@ check_autostart() {
     local -a _autostart_libdirs
     IFS=: read -ra _autostart_libdirs <<< "${AUTOSTART_LIBDIRS:-/usr/lib:/usr/libexec:/var/lib/flatpak/exports/bin:$home_dir/.local/share/flatpak/exports/bin}"
 
+    # Override with AUTOSTART_SKEL_DIR for testing — real /etc/skel is a
+    # system path, not something a test should write to.
+    local skel_dir="${AUTOSTART_SKEL_DIR:-/etc/skel}"
+
     local desktop_dir="$home_dir/.config/autostart"
     if [[ -d "$desktop_dir" ]]; then
         while IFS= read -r desktop; do
@@ -2554,11 +2558,21 @@ check_autostart() {
                 # $PATH on any Flatpak-enabled system, so a resolved Flatpak
                 # app (command -v succeeds directly) needs to be recognized
                 # here too, not just via the non-PATH libdir search below.
+                # $skel_dir/* is trusted the same as /usr/local/* — both require
+                # root to write and neither is pacman-tracked by definition, but
+                # this check's own threat model is "could an unprivileged
+                # attacker have planted this," not "is this in a package db".
+                # /etc/skel ships distro/admin first-boot workaround scripts
+                # (e.g. an xfce4-panel crash-loop workaround referenced
+                # directly from a copied ~/.config/autostart/*.desktop rather
+                # than duplicated into each home dir) that only root could
+                # have placed there (reported live: xfce-pbw.sh).
                 local suspicious=false
                 if [[ "$exec_val" == /* ]]; then
                     if [[ "$exec_val" != /usr/* && "$exec_val" != /opt/* && \
                           "$exec_val" != /bin/* && "$exec_val" != /sbin/* && \
                           "$exec_val" != /usr/local/* && \
+                          "$exec_val" != "$skel_dir/"* && \
                           "$exec_val" != "$home_dir/bin/"* && \
                           "$exec_val" != "$home_dir/.local/bin/"* && \
                           "$exec_val" != /var/lib/flatpak/exports/bin/* && \
@@ -2572,6 +2586,7 @@ check_autostart() {
                         if [[ "$resolved" != /usr/* && "$resolved" != /opt/* && \
                               "$resolved" != /bin/* && "$resolved" != /sbin/* && \
                               "$resolved" != /usr/local/* && \
+                              "$resolved" != "$skel_dir/"* && \
                               "$resolved" != /var/lib/flatpak/exports/bin/* && \
                               "$resolved" != "$home_dir/.local/share/flatpak/exports/bin/"* && \
                               "$resolved" != "$home_dir/bin/"* && \

--- a/tests/run_matching_tests.sh
+++ b/tests/run_matching_tests.sh
@@ -782,6 +782,33 @@ DESK
     fi
     rm -rf "$tmpdir12"
     rm -f "$allow_file5"
+
+    # Sub-test T: absolute .desktop Exec= path under the skel dir must NOT be
+    # flagged — regression guard for a real false positive (an xfce4-panel
+    # crash-loop workaround script, xfce-pbw.sh, shipped via /etc/skel and
+    # referenced directly by the copied ~/.config/autostart/*.desktop rather
+    # than duplicated into each home dir; only root can write there, same
+    # trust bucket as /usr/local). AUTOSTART_SKEL_DIR overrides the real
+    # /etc/skel so this doesn't touch actual system state.
+    local tmpdir13 skeldir13
+    tmpdir13=$(mktemp -d)
+    skeldir13=$(mktemp -d)
+    mkdir -p "$tmpdir13/.config/autostart" "$skeldir13/.config/autostart"
+    cat > "$tmpdir13/.config/autostart/xfce-panel-workaround.desktop" << DESK
+[Desktop Entry]
+Type=Application
+Name=XfcePanelWorkaround
+Exec=$skeldir13/.config/autostart/xfce-pbw.sh
+DESK
+    rc=0
+    out=$(AUTOSTART_HOME="$tmpdir13" AUTOSTART_SKEL_DIR="$skeldir13" \
+        "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
+    if [[ "$out" == *"Clean"* && "$out" != *"WARNING"* ]]; then
+        pass "check_autostart: absolute Exec= under skel dir not flagged"
+    else
+        fail "check_autostart: skel dir false positive regression, rc=$rc, out: $out"
+    fi
+    rm -rf "$tmpdir13" "$skeldir13"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `check_autostart` flagged legitimate `.desktop` autostart entries whose `Exec=` points into `/etc/skel` (e.g. a distro/admin-shipped xfce4-panel crash-loop workaround script referenced directly from a copied autostart entry rather than duplicated per-user)
- The check's threat model is "could an unprivileged attacker have planted this" — `/etc/skel` requires root to write, same trust bucket as `/usr/local` (already trusted despite not being pacman-tracked)
- Added `/etc/skel/*` to both the absolute-path and resolved-bare-name trust checks, via a new `AUTOSTART_SKEL_DIR` test-injection override (mirrors `AUTOSTART_HOME`/`AUTOSTART_LIBDIRS`)

## Test plan
- [x] `tests/run_matching_tests.sh` — new regression test (Sub-test T) covers the `/etc/skel` false positive without touching real system state
- [x] Full suite: 75 pass, 1 pre-existing unrelated failure (confirmed present on master too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)