### PR TITLE
docs: cover the paru PreBuildCommand hook and yay's clean-message merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ run everything at once with `--full`.
 | `--color=auto\|always\|never` | Control symbol/color output (default: `auto`; also obeys `NO_COLOR` env) | — |
 | `--format=text\|json` | Output a JSON summary instead of the human-readable report | — |
 | `--doctor` | Health check: binary deps, systemd units, install paths | — |
-| `--doctor=SECTION[,...]` | Check only the named section(s) with extra detail (`platform`, `deps`, `user`, `system`, `systemd`, `external`; tool names like `traur`/`yad` also map to a section) | — |
+| `--doctor=SECTION[,...]` | Check only the named section(s) with extra detail (`platform`, `deps`, `user`, `system`, `systemd`, `external`; tool names like `traur`/`paru`/`yad` also map to a section) | — |
 | `--allowlist-list=NAME` | List entries in an allowlist and exit (`NAME`: `dkms`, `systemd`, `bpftool`, `autostart`) | No |
 | `--allowlist-add=NAME:VALUE` | Add `VALUE` to an allowlist and exit | Yes |
 | `--allowlist-remove=NAME:VALUE` | Remove `VALUE` from an allowlist and exit | Yes |
@@ -247,6 +247,7 @@ does and how it's wired in:
 |---------|----------|
 | [traur](https://aur.archlinux.org/packages/traur) | Optional |
 | [yay](https://github.com/Jguer/yay) 13.0 | Optional |
+| [paru](https://github.com/Morganamilo/paru) | Optional |
 | [yad](https://github.com/v1cont/yad) | GUI only |
 | [noto-fonts-emoji](https://archlinux.org/packages/extra/any/noto-fonts-emoji/) | GUI only (🔐 icons) |
 | [bpftool](https://github.com/libbpf/bpftool) (pkg: `bpf`) | Optional (`--check-bpftool`) |
@@ -259,10 +260,11 @@ Started from [lenucksi/aur-malware-check](https://github.com/lenucksi/aur-malwar
 
 ### Detection Layers
 
-Two automatic layers fire at AUR install time — yay's offline `init.lua`
-hooks and traur's pacman `PreTransaction` hook — plus a continuous root
-scan (`archcanary --full`, weekly + on boot + after every pacman
-transaction), a desktop notifier on detection, and the on-demand GUI.
+Automatic layers fire at AUR install time — yay's offline `init.lua` hooks
+(or paru's native `PreBuildCommand` hook, whichever AUR helper you use) and
+traur's pacman `PreTransaction` hook — plus a continuous root scan
+(`archcanary --full`, weekly + on boot + after every pacman transaction), a
+desktop notifier on detection, and the on-demand GUI.
 
 See [docs/overview.md](docs/overview.md) for the full lifecycle diagram
 (at-a-glance table included).
@@ -300,7 +302,7 @@ A hand-curated list (`community_reports.txt`), sourced from AUR malware reports 
 
 **On trusting it:** this is an independent, pseudonymous operator's project ("Saren" / wtako.net), not a security vendor — neither the site nor its API docs publish a scanning methodology or a track record, so there's nothing to verify the operator's credentials against. The trust here is in the integration, not the operator: the API is free, unauthenticated, and read-only (nothing about your system is ever sent to it), its hits are merged alongside archcanary's own sourced/cited lists rather than replacing them (see [SOURCES.md](SOURCES.md#9-aur-auditwtakonet-feed)), and the source is always visible in the `[aur-audit: black/red]` annotation. Treat it like any heuristic scanner: best-effort, not a guarantee.
 
-The same synced lists also gate installs directly: the `AURPreInstall` yay hook (see [yay 13.0 integration](docs/my-setup.md#yay-130-integration)) aborts a build on a black hit and warns on a red hit — a pre-build check that needs no LLM. A black abort is a blocking action driven by this unverified third-party source; there's no per-source toggle, so the only way to opt out is to stop running `--refresh` (or delete `aur_audit_black.txt`/`aur_audit_red.txt` from `~/.config/archcanary/`), which makes both the hook and the scan-side check silently skip it.
+The same synced lists also gate installs directly: yay's `AURPreInstall` hook (see [yay 13.0 integration](docs/my-setup.md#yay-130-integration)) checks the black/red list itself and aborts on a black hit, warns on a red hit — a pre-build check that needs no LLM. This one's yay-only for now — paru's [`PreBuildCommand` hook](docs/my-setup.md#paru-integration) runs `archcanary --check-pkgbuild` before every build, which covers the same PKGBUILD obfuscation patterns as yay's hook, but not this aur-audit lookup. A black abort is a blocking action driven by this unverified third-party source; there's no per-source toggle, so the only way to opt out is to stop running `--refresh` (or delete `aur_audit_black.txt`/`aur_audit_red.txt` from `~/.config/archcanary/`), which makes both the hook and the scan-side check silently skip it.
 
 ---
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -15,12 +15,16 @@ flowchart TD
 
     subgraph AT["2 · AT install — automatic"]
         U["yay -S pkg / yay -Syu / yay &lt;term&gt;"] --> SEL["UpgradeSelect<br/>age warn"]
-        SEL --> PRI["AURPreInstall<br/>pattern block"]
+        SEL --> PRI["AURPreInstall<br/>pattern block + aur-audit"]
+        UP["paru -S pkg"] --> PBC["PreBuildCommand<br/>--check-pkgbuild"]
         PRI -->|blocked| AB["build / install aborted"]
-        PRI -->|OK| TH["traur pacman hook<br/>trust score · AbortOnFail"]
+        PBC -->|blocked| AB
+        PRI -->|clean| TH["traur pacman hook<br/>trust score · AbortOnFail"]
+        PBC -->|clean| TH
         TH -->|low trust| AB
-        TH -->|OK| POST["PostInstall<br/>log AUR installs"]
-        POST --> OK["package installed"]
+        TH -->|OK, yay| POST["PostInstall<br/>log AUR installs"]
+        TH -->|OK, paru| OK["package installed"]
+        POST --> OK
     end
 
     subgraph AFTER["3 · AFTER install / always — automatic, root"]
@@ -35,6 +39,7 @@ flowchart TD
     end
 
     T -.->|install if trusted| U
+    T -.->|install if trusted| UP
     OK -.-> PTH
 ```
 
@@ -43,7 +48,8 @@ flowchart TD
 | Phase | Tool | Trigger | Automatic? | Catches |
 |-------|------|---------|:---------:|---------|
 | 1 · Before (optional) | `traur scan <pkg>` | You run it before installing | ✗ manual | Maintainer reputation, PKGBUILD heuristics (279 signals) |
-| 2 · At install | yay `init.lua` hooks | Every `yay` install/upgrade | ✓ | Known campaign signatures, stale-rewrite upgrades (offline) |
+| 2 · At install | yay `init.lua` hooks | Every `yay` install/upgrade | ✓ | Known campaign signatures, stale-rewrite upgrades, aur-audit black/red (offline + live feed) |
+| 2 · At install | paru `PreBuildCommand` hook | Every `paru` build | ✓ | Same obfuscation patterns as yay's hook (via `archcanary --check-pkgbuild`, scoped to that package) — no aur-audit lookup yet |
 | 2 · At install | `traur` pacman hook | Every pacman install/upgrade (incl. repo pkgs) | ✓ auto | Maintainer/metadata trust score; aborts the transaction on fail |
 | 3 · After / always | `archcanary` | systemd timer (weekly + boot) + `.path` (after each pacman tx) | ✓ root | Known-bad packages, systemd/eBPF/npm persistence, rootkit traces |
 | 4 · On detection | notifier → GUI | `last-scan.log` flips to INFECTED | ✓ | Surfaces a result; review is manual |
@@ -52,7 +58,7 @@ flowchart TD
 
 - **Nothing here removes malware.** Every layer *detects and reports* — remediation is left to you. See [Read-only by design](../README.md).
 - **Pre-install vs post-install.** Phases 1–2 try to stop a bad package before it lands; phase 3 catches anything already installed (or installed before the stack existed).
-- **Defence in depth.** The offline Lua hooks catch known campaign signatures and run even with no network; `traur` (a pacman PreTransaction hook, also runnable by hand) adds maintainer/metadata trust signals no static scan sees and can abort the install. Neither replaces the other.
+- **Defence in depth.** The offline yay Lua hooks (or paru's `PreBuildCommand` hook) catch known campaign signatures and run even with no network; `traur` (a pacman PreTransaction hook, also runnable by hand) adds maintainer/metadata trust signals no static scan sees and can abort the install. None of these replace each other.
 
 ## Go deeper
 


### PR DESCRIPTION
## Summary
- README: dependency table, `--doctor=SECTION` alias help text, detection-layers intro, and the aur-audit paragraph now mention paru's `PreBuildCommand` hook alongside yay's `init.lua` — corrected to be explicit that `--check-pkgbuild` covers the same obfuscation patterns but not the aur-audit black/red lookup, which stays yay-only for now
- docs/overview.md: added a `paru -S pkg` entry point to the mermaid diagram (converging with yay's path at the shared `traur` pacman hook, diverging again since `PostInstall` logging is yay-only) and a matching row in the at-a-glance table
- Verified the mermaid diagram still parses (via `mermaid.parse()`, not just visual review)

## Test plan
- [x] `bash tests/run_matching_tests.sh` — 83 pass, 1 pre-existing unrelated failure (same as on master)
- [x] Mermaid syntax validated programmatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)