### PR TITLE
chore: set real sha256 for v0.1.25 release tarball

### DIFF
--- a/packaging/.SRCINFO
+++ b/packaging/.SRCINFO
@@ -20,6 +20,6 @@ pkgbase = archcanary
 	backup = etc/archcanary/bpftool_allowlist.conf
 	backup = etc/archcanary/autostart_allowlist.conf
 	source = archcanary-0.1.25.tar.gz::https://github.com/musqz/archcanary/archive/v0.1.25.tar.gz
-	sha256sums = SKIP
+	sha256sums = a050d65eb45a95e26fce75d84607c948e2a0f4c221a8ce63ab024791e1d7643f
 
 pkgname = archcanary

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -22,7 +22,7 @@ backup=('etc/archcanary/dkms_allowlist.conf'
         'etc/archcanary/autostart_allowlist.conf')
 install=archcanary.install
 source=("$pkgname-$pkgver.tar.gz::https://github.com/musqz/$pkgname/archive/v$pkgver.tar.gz")
-sha256sums=('SKIP')
+sha256sums=('a050d65eb45a95e26fce75d84607c948e2a0f4c221a8ce63ab024791e1d7643f')
 
 package() {
   cd "$srcdir/$pkgname-$pkgver"


### PR DESCRIPTION
Verified against the actual tagged tarball before trusting the hash: extracted version.txt from it and confirmed it reads 0.1.25.

## Summary

<!-- What does this PR do? For a community_reports.txt addition, the
     package name(s) plus the checklist below is enough. -->

## If this adds to `lists/community_reports.txt`

- [ ] Package name is exact (matches the AUR package name / `pacman -Qm` output)
- [ ] Evidence is linked below — an AUR comment, mailing-list post, PKGBUILD diff, or writeup, not just suspicion
- [ ] Checked it isn't already in `package_list.txt`, `chaos_rat_packages.txt`, `malicious_russian_spam_packages.txt`, or `community_reports.txt`

**Evidence:** <!-- link(s) here -->

## For code changes

- [ ] Ran `bash tests/run_matching_tests.sh` (for `archcanary.sh` changes)
- [ ] Updated `--help`/man page/README if user-facing behavior changed
