### PR TITLE
docs: fix false timeline implication in the Chrome RAT example

### DIFF
--- a/docs/reading-pkgbuilds.md
+++ b/docs/reading-pkgbuilds.md
@@ -158,7 +158,13 @@ default to.
 A real 2025 incident used exactly this: a fake `google-chrome-stable` AUR
 package shipped an `.install` scriptlet that ran a Python command to download
 and execute malware *every single time Chrome launched* — not at build time at
-all, which is part of why it went unnoticed for as long as it did.
+all, so a review habit that only reads `build()`/`package()` would miss it
+entirely. It was still caught fast in practice (reported and removed within
+hours) — but that came from someone noticing odd behavior *after* installing
+it and reporting it on Reddit, not from anyone reading the `.install` file
+first. The point isn't that this technique is slow to get caught; it's that
+catching it this way depends on someone else noticing after the fact, which
+isn't something you want to rely on for your own system.
 
 **If a package ships an `.install` file, read it with the same scrutiny as
 `build()`.** It's not an afterthought.


### PR DESCRIPTION
Reported by a moderator reviewing the doc: "which is part of why it went unnoticed for as long as it did" implied the google-chrome-stable package sat on the AUR for a prolonged period. It didn't -- uploaded and removed the same day (2025-07-31), caught within hours, removed within ~10 minutes of being reported on Reddit.

Reframed around the actual point: a build()-only review habit misses .install scriptlets, and this specific case was caught by someone noticing odd behavior after installing it, not by anyone reading the file first -- not that the technique is slow to get caught.

## Summary

<!-- What does this PR do? For a community_reports.txt addition, the
     package name(s) plus the checklist below is enough. -->

## If this adds to `lists/community_reports.txt`

- [ ] Package name is exact (matches the AUR package name / `pacman -Qm` output)
- [ ] Evidence is linked below — an AUR comment, mailing-list post, PKGBUILD diff, or writeup, not just suspicion
- [ ] Checked it isn't already in `package_list.txt`, `chaos_rat_packages.txt`, `malicious_russian_spam_packages.txt`, or `community_reports.txt`

**Evidence:** <!-- link(s) here -->

## For code changes

- [ ] Ran `bash tests/run_matching_tests.sh` (for `archcanary.sh` changes)
- [ ] Updated `--help`/man page/README if user-facing behavior changed
