### PR TITLE
chore: drop stale python-isounidecode from package list

### DIFF
--- a/lists/package_list.txt
+++ b/lists/package_list.txt
@@ -1419,7 +1419,6 @@ python-hsaudiotag3k
 python-iminuit
 python-iminuit-docs
 python-iso3166
-python-isounidecode
 python-isr-git
 python-jsmin
 python-json2xml


### PR DESCRIPTION
## Summary
- Removes `python-isounidecode` from `lists/package_list.txt` — a false-positive `INFECTED` hit reported from a live scan
- Verified the current AUR PKGBUILD by hand: clean `pypi.org` source, real sha256sums, plain `setup.py build`/`install`, no `.install` file, no obfuscation

## Why
The entry appears to predate the current AUR maintainer (Taiko2k) and was never pruned from the upstream HedgeDoc note that `package_list.txt` mirrors on `--refresh`. Bundled-copy fix only — that refresh source is external, so this can resurface until upstream prunes it too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)