### PR TITLE
fix: don't mark scan INCOMPLETE for lynis unless explicitly requested

### DIFF
--- a/archcanary.sh
+++ b/archcanary.sh
@@ -80,6 +80,8 @@ CHECK_LYNIS=false
 CHECK_PKGINTEG=false
 CHECK_LIST_OVERLAP=false
 CHECK_FULL=false
+# True only if --check-lynis was passed directly, not just via --full.
+EXPLICIT_LYNIS=false
 REFRESH_PACKAGE_LIST=false
 VERBOSE=false
 NO_NOTIFY=false
@@ -432,7 +434,7 @@ for arg in "$@"; do
         --check-ldso)       CHECK_LDSO=true ;;
         --check-autostart)  CHECK_AUTOSTART=true ;;
         --check-kmod)       CHECK_KMOD=true ;;
-        --check-lynis)      CHECK_LYNIS=true ;;
+        --check-lynis)      CHECK_LYNIS=true; EXPLICIT_LYNIS=true ;;
         --check-pkginteg)   CHECK_PKGINTEG=true ;;
         --check-list-overlap) CHECK_LIST_OVERLAP=true ;;
         --full)          CHECK_SYSTEMD=true; CHECK_EBPF=true; CHECK_NPM_CACHE=true; CHECK_BUN_CACHE=true; CHECK_YARN_CACHE=true; CHECK_PNPM_CACHE=true; CHECK_PKGBUILD=true; CHECK_BPFTOOL=true; CHECK_LDSO=true; CHECK_AUTOSTART=true; CHECK_KMOD=true; CHECK_LYNIS=true; CHECK_PKGINTEG=true; CHECK_FULL=true ;;
@@ -3150,12 +3152,15 @@ SKIPPED_ROOT=()
 SKIPPED_MISSING=()
 
 # Fold a check's return code into EXIT_CODE; 77 means "skipped, needs root",
-# 78 means "skipped, optional tool not installed".
-_apply_ret() { # $1=return code  $2=check label
+# 78 means "skipped, optional tool not installed". A 78 only feeds into
+# SKIPPED_MISSING (and the INCOMPLETE verdict) when the check was requested
+# via its own --check-* flag, not just pulled in by --full.
+_apply_ret() { # $1=return code  $2=check label  $3=explicitly requested (true/false)
     if [[ "$1" -eq 77 ]]; then
         SKIPPED_ROOT+=("$2")
     elif [[ "$1" -eq 78 ]]; then
-        SKIPPED_MISSING+=("$2")
+        [[ "${3:-false}" == true ]] && SKIPPED_MISSING+=("$2")
+        true
     elif [[ "$1" -gt $EXIT_CODE ]]; then
         EXIT_CODE="$1"
     fi
@@ -3640,7 +3645,7 @@ fi
 if $CHECK_LYNIS; then
     echo "--- [12] Lynis hardening report ---"
     check_lynis && ret=$? || ret=$?
-    _apply_ret "$ret" lynis
+    _apply_ret "$ret" lynis "$EXPLICIT_LYNIS"
     _rec "Lynis hardening" "$ret"
     echo
 fi

--- a/tests/run_matching_tests.sh
+++ b/tests/run_matching_tests.sh
@@ -1292,6 +1292,19 @@ SCRIPT
     else
         fail "result_banner: real finding should still say WARNINGS, rc=$rc, out: $out"
     fi
+
+    # Sub-test C: lynis pulled in only via --full (never asked for directly)
+    # and not installed — must not appear in the "optional check(s) skipped"
+    # line. Root-only checks (bpftool/kmod, also enabled by --full) still make
+    # the scan INCOMPLETE on their own; the point here is specifically that
+    # lynis's absence doesn't also get blamed.
+    rc=0
+    out=$("$REPO_DIR/archcanary.sh" "${base_args[@]}" --full 2>&1) || rc=$?
+    if [[ "$out" != *"optional check(s) skipped"*"lynis"* ]]; then
+        pass "result_banner: --full doesn't blame missing lynis unless --check-lynis was explicit"
+    else
+        fail "result_banner: lynis should not appear in optional-skip line under bare --full, out: $out"
+    fi
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
--full enables --check-lynis along with everything else, so a clean scan on a machine without lynis installed always reported "CLEAN (INCOMPLETE)" even though the user never asked for that check. SKIPPED_MISSING (and the resulting INCOMPLETE verdict) now only counts a missing-tool skip when the check was requested directly via --check-lynis, not just pulled in by --full.

## Summary

<!-- What does this PR do? For a community_reports.txt addition, the
     package name(s) plus the checklist below is enough. -->

## If this adds to `lists/community_reports.txt`

- [ ] Package name is exact (matches the AUR package name / `pacman -Qm` output)
- [ ] Evidence is linked below — an AUR comment, mailing-list post, PKGBUILD diff, or writeup, not just suspicion
- [ ] Checked it isn't already in `package_list.txt`, `chaos_rat_packages.txt`, `malicious_russian_spam_packages.txt`, or `community_reports.txt`

**Evidence:** <!-- link(s) here -->

## For code changes

- [ ] Ran `bash tests/run_matching_tests.sh` (for `archcanary.sh` changes)
- [ ] Updated `--help`/man page/README if user-facing behavior changed
