### PR TITLE
fix: use --text-info for the infected dialog to respect --height

### DIFF
--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -240,7 +240,8 @@ _show_infected_dialog() {
     yad --image=dialog-error \
         --title="Infected — Archcanary" \
         --window-icon=security-high --center \
-        --width=520 \
+        --width=520 --height=380 \
+        --text-info --fontname="sans 10" \
         --text="<b>Infected or compromised indicators detected.</b>\n\n<b>1.</b>  ${step1}\n\n<b>2.</b>  Check persistence — run <i>Systemd persistence</i> and\n      <i>XDG autostart + shell RCs</i> from this menu.\n\n<b>3.</b>  Rotate credentials: SSH keys, GitHub PATs, Discord\n      tokens, npm tokens, browser sessions.\n\nSee README → <i>What to Do If Infected</i>" \
         --button="OK:0" 2>/dev/null || true
 }


### PR DESCRIPTION
## Summary
- Reported on the Arch forum by a Mabox user: the "Infected" dialog (shown after a scan finds something) rendered inexplicably tall, couldn't be resized, and the OK button was unreachable
- Root cause, confirmed by direct testing: yad's plain `--text=` message dialogs leave GTK to compute the window's natural height from the label, and on this GTK/theme stack that comes back ~700px for content that only needs ~250px — an explicit `--height` on the old widget type is silently ignored once GTK's own natural-size calculation exceeds it
- Fix: switch to `--text-info` (yad's scrollable text widget, already used for every other multi-line dialog in this file) — it treats `--height` as an actual size instead of a hint, so it can't run away
- Verified empirically: bisected the exact yad flags (icon, markup, width, blank lines) to isolate the cause before picking a fix, then confirmed `--text-info` renders correctly sized (380–420px depending on content) with the icon and all markup (bold/italic/monospace) intact, across all three text branches of `_show_infected_dialog`

## Test plan
- [x] `bash -n archcanary-gui.sh` — syntax OK
- [x] Live-rendered the actual dialog (all 3 argument branches) via yad on a real X session, confirmed proportionate sizing and correct markup rendering
- [ ] Not reproducible on the maintainer's own Mabox setup — the original report came from a different Mabox user's system; asking them to confirm the fix on their end

🤖 Generated with [Claude Code](https://claude.com/claude-code)