### PR TITLE
fix: reject unknown CLI flags instead of silently ignoring them

### DIFF
--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -44,6 +44,12 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
     exit 0
 fi
 
+if [[ -n "${1:-}" ]]; then
+    echo "ERROR: unknown option: $1" >&2
+    echo "Run 'archcanary-gui --help' for usage." >&2
+    exit 1
+fi
+
 if [[ $EUID -eq 0 ]]; then
     echo "ERROR: do not run archcanary-gui as root or with sudo." >&2
     echo "Run it as your regular user — root checks are handled via pkexec (polkit)." >&2

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -548,6 +548,10 @@ for arg in "$@"; do
             # shell splits "system" off into its own argument.
             if $DOCTOR && [[ "$arg" != -* ]]; then
                 DOCTOR_SECTIONS+="${DOCTOR_SECTIONS:+,}$arg"
+            else
+                echo "Error: unknown option: $arg" >&2
+                echo "Run '$0 --help' for usage." >&2
+                exit 1
             fi
             ;;
     esac

--- a/install.sh
+++ b/install.sh
@@ -71,17 +71,16 @@ fi
 # Parse arguments: optional "uninstall" verb, optional bin-dir
 UNINSTALL=false
 SYSTEM=false
+USER_BIN="${DEFAULT_BIN}"
 for arg in "$@"; do
     case "$arg" in
         uninstall) UNINSTALL=true ;;
         --system)  SYSTEM=true ;;
-    esac
-done
-
-USER_BIN="${DEFAULT_BIN}"
-for arg in "$@"; do
-    case "$arg" in
-        uninstall|--system) ;;
+        -*)
+            echo "ERROR: unknown option: $arg" >&2
+            echo "Run './install.sh --help' for usage." >&2
+            exit 1
+            ;;
         *) USER_BIN="$arg" ;;
     esac
 done


### PR DESCRIPTION
## Summary
- Found by testing `archcanary --refesh --full` (typo for `--refresh`): the scan ran normally with no warning that the flag was unrecognized and never applied — for a security scanner, silently not doing what you asked is a real problem
- `archcanary.sh`'s arg-parsing catch-all only handled `--doctor` section names; every other unrecognized flag just vanished silently
- `install.sh` was worse: an unrecognized flag got treated as a custom bin-dir path (`./install.sh --systme` → `mkdir: unrecognized option '--systme'`, a confusing shell error instead of a clear message)
- `archcanary-gui.sh` had the same silent-ignore gap for its own top-level arg (e.g. `--nogui` typo just opened the GUI normally)
- All three now print `unknown option: X` and exit 1 instead of silently continuing

## Test plan
- [x] `bash -n` on all three scripts — syntax OK
- [x] `archcanary --refesh --full` → rejected with clear error (previously silent)
- [x] `archcanary --version`, `--doctor deps` — still work
- [x] `install.sh --systme` → rejected with clear error (previously misassigned as bin-dir)
- [x] `install.sh --help`, and a legitimate custom bin-dir positional arg — still work
- [x] `archcanary-gui --nogui` → rejected; `--help` and `--no-gui` (real flag) — still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)