### PR TITLE
docs: note paru's before-review hook timing as a known limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,11 @@ An automatic layer fires at AUR build time — yay's offline `init.lua` hooks,
 or paru's native `PreBuildCommand` hook, whichever AUR helper you use — plus
 a continuous root scan (`archcanary --full`, weekly + on boot + after every
 pacman transaction), a desktop notifier on detection, and the on-demand GUI.
+paru's hook fires before its own diff/edit review menus (a paru limitation —
+it has no post-review hook point) and only runs the PKGBUILD pattern check,
+not the aur-audit black/red lookup, so yay's integration is the more
+complete of the two. Other AUR helpers can still be scanned manually via
+`--check-pkgbuild`, just without an automatic pre-build hook.
 
 See [docs/overview.md](docs/overview.md) for the full lifecycle diagram
 (at-a-glance table included).

--- a/docs/my-setup.md
+++ b/docs/my-setup.md
@@ -194,6 +194,8 @@ paru's native `PreBuildCommand` hook (`~/.config/paru/paru.conf`, `[bin]` sectio
 
 Runs `archcanary --check-pkgbuild` before every AUR build, scoped to just that package's own build directory (`PKGBUILD_CACHE_DIRS=.`) — a nonzero exit (pattern match found) genuinely aborts the build, since paru propagates `PreBuildCommand`'s exit status as a real error. `--no-notify --no-summary` keep this silent-unless-flagged on every single build. Fails open if archcanary isn't on `$PATH` (build proceeds rather than hard-blocking on a missing optional dependency).
 
+**Limitation:** `PreBuildCommand` fires before paru's own diff/edit review menus (confirmed in paru's source, `src/install.rs`) — paru has no post-review hook point to move it to, unlike yay's `AURPostDownload`. It's also narrower in scope than yay's hook: only the PKGBUILD pattern check, no aur-audit black/red lookup.
+
 Uninstalling removes just the two hook lines (marker comment + `PreBuildCommand`) from `paru.conf` — the rest of the file, including the `[bin]` section header itself, is left untouched.
 
 ## Shell completion and the `canary` alias


### PR DESCRIPTION
## Summary
- Follow-up to #187 (yay's hook moved to `AURPostDownload`): checked whether paru's `PreBuildCommand` hook has the same before-review ordering issue
- Confirmed in paru's actual source (`Morganamilo/paru`, `src/install.rs`) — yes, `PreBuildCommand` fires before paru's own diff/edit review menus, same backwards ordering yay had
- Unlike yay, paru has no alternative hook point to move it to (only `PreBuildCommand` exists — no `PostBuildCommand`, no post-review hook anywhere in paru's config surface), so this isn't fixable on archcanary's side alone — decided to leave it as-is and just document it honestly rather than imply parity with yay's integration
- Added a one-line caveat to README's "Detection Layers" section and a "Limitation" note to `docs/my-setup.md`'s paru integration section, plus a generic mention that other AUR helpers still work fine with `--check-pkgbuild` manually (no automatic hook, by design — not going to name/support a third helper)

## Test plan
- Docs-only change, no code touched