### PR TITLE
feat: add --scan-all-homes for multi-user home scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,9 @@ run everything at once with `--full`.
 | `--run-lynis` | Run `lynis audit system`, stream output | Yes |
 | `--check-pkginteg` | Verify installed file checksums via `pacman -Qkk`. Reports SHA256 mismatches on non-backup, non-factory files. Backup files (pacman-managed configs expected to diverge) and `/factory/` paths are filtered out. Prioritise hits in `/usr/bin/`, `/usr/lib/`, `/usr/sbin/`. | Yes |
 | `--check-list-overlap` | A note, not a warning: custom (`--extra-list`) entries already covered by an official list are grouped by file, with a ready-to-run `sed` command to remove them — safe to remove, since the official list is authoritative. Never affects the exit code or the check summary, and not included in `--full`. Also reachable from the GUI: Edit config → List overlap check. | No |
+| `--scan-all-homes` | Enumerate real local users (UID range from `/etc/login.defs`, valid shell, home dir exists) and run the npm/bun/yarn/pnpm/pkgbuild/autostart checks against each of their homes, not just yours — privilege-dropped per user via `sudo -u`. For shared/multi-user machines; not included in `--full`. | Yes |
 | `--search-packages=PKG[,PKG...]` | Check package name(s) against every loaded threat list, independent of what's installed — no scan, prints a ready-to-copy `pacman -Rns` command for any match, and exits. | No |
-| `--full` | All of the above except `--check-list-overlap` | Partial |
+| `--full` | All of the above except `--check-list-overlap` and `--scan-all-homes` | Partial |
 | `--refresh` | Fetch the live package list from the Arch Linux HedgeDoc, plus the supplementary npm/CHAOS RAT/Russian Spam/Community Reports lists and the aur-audit black/red feed | — |
 | `--no-aur-audit` | Skip the aur-audit.wtako.net feed on `--refresh`. Persists via `AUR_AUDIT_ENABLE=false` in `~/.config/archcanary/env`, also toggleable from the GUI's Scan settings menu row | — |
 | `--verbose`, `-v`, `--debug` | Verbose output (`--debug` also enables `set -x`) | — |
@@ -227,6 +228,7 @@ youruser ALL=(root) /usr/bin/bash /path/to/archcanary/lib/archcanary-root-instal
 - User notifier: watches `/var/lib/archcanary/last-scan.log`, fires a desktop alert on `INFECTED`
 - pkexec root helper for GUI-triggered root checks (eBPF, bpftool, kmod, Lynis)
 - auditd ruleset at `/etc/audit/rules.d/30-archcanary.rules` when auditd is installed (seeded from template, editable via GUI)
+- `archcanary-scan-all-homes.timer`, opt-in and disabled by default (see below) — covers other local users' home checks that the per-user timer only covers for whoever enables it themselves
 
 **Neither install path enables the timers automatically** — activation is always a manual, explicit step:
 
@@ -236,6 +238,11 @@ sudo systemctl enable --now archcanary.timer archcanary.path
 
 # User-scope scan and desktop notifier
 systemctl --user enable --now archcanary-user.timer archcanary-notify.path
+
+# Optional, machine-wide: weekly scan of every other real local user's home
+# too, not just yours (see --scan-all-homes above) — off by default even
+# after --system install, since it touches every local user's data
+sudo systemctl enable --now archcanary-scan-all-homes.timer
 ```
 
 Until you run these, `archcanary --doctor` will correctly show `[WARN]` for all four automation entries — that's expected, not a bug. Re-run `--doctor` after enabling to confirm they flip to `[ OK ]`.

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -80,6 +80,7 @@ CHECK_LYNIS=false
 CHECK_PKGINTEG=false
 CHECK_LIST_OVERLAP=false
 CHECK_FULL=false
+SCAN_ALL_HOMES=false
 # True only if --check-lynis was passed directly, not just via --full.
 EXPLICIT_LYNIS=false
 REFRESH_PACKAGE_LIST=false
@@ -437,6 +438,7 @@ for arg in "$@"; do
         --check-lynis)      CHECK_LYNIS=true; EXPLICIT_LYNIS=true ;;
         --check-pkginteg)   CHECK_PKGINTEG=true ;;
         --check-list-overlap) CHECK_LIST_OVERLAP=true ;;
+        --scan-all-homes) SCAN_ALL_HOMES=true ;;
         --full)          CHECK_SYSTEMD=true; CHECK_EBPF=true; CHECK_NPM_CACHE=true; CHECK_BUN_CACHE=true; CHECK_YARN_CACHE=true; CHECK_PNPM_CACHE=true; CHECK_PKGBUILD=true; CHECK_BPFTOOL=true; CHECK_LDSO=true; CHECK_AUTOSTART=true; CHECK_KMOD=true; CHECK_LYNIS=true; CHECK_PKGINTEG=true; CHECK_FULL=true ;;
         --refresh)               REFRESH_PACKAGE_LIST=true ;;
         --verbose|-v)            VERBOSE=true ;;
@@ -494,6 +496,8 @@ for arg in "$@"; do
             echo "  --check-pkginteg   Verify installed file checksums against pacman database (SHA256 mismatch)"
             echo "  --check-list-overlap  Note custom-list entries already covered by an official list, safe to"
             echo "                        remove — advisory only, not included in --full"
+            echo "  --scan-all-homes   Enumerate real local users and run the npm/bun/yarn/pnpm/pkgbuild/autostart"
+            echo "                     checks against each of their homes, not just yours (needs root, not included in --full)"
             echo "  --search-packages=PKG[,PKG...]  Check package name(s) against every loaded threat list"
             echo "                                   (no scan; prints a ready-to-copy 'pacman -Rns' command"
             echo "                                   for any match) and exit"
@@ -604,6 +608,11 @@ case "$_FORMAT_ARG" in
         ;;
 esac
 
+if $SCAN_ALL_HOMES && ! $DOCTOR && [[ $EUID -ne 0 ]]; then
+    echo "Error: --scan-all-homes requires root (enumerating other users' homes needs root) — run via sudo" >&2
+    exit 1
+fi
+
 # Focused mode: a specific --check-* flag was given without --full.
 # Suppresses the campaign header and the always-on package/log checks so
 # each individual check window shows only the output it was asked for.
@@ -611,7 +620,7 @@ FOCUSED_MODE=false
 if ! $CHECK_FULL && { $CHECK_SYSTEMD || $CHECK_EBPF || $CHECK_NPM_CACHE || \
     $CHECK_BUN_CACHE || $CHECK_YARN_CACHE || $CHECK_PNPM_CACHE || $CHECK_PKGBUILD || \
     $CHECK_BPFTOOL || $CHECK_LDSO || $CHECK_AUTOSTART || $CHECK_KMOD || $CHECK_LYNIS || \
-    $CHECK_PKGINTEG; }; then
+    $CHECK_PKGINTEG || $SCAN_ALL_HOMES; }; then
     FOCUSED_MODE=true
 fi
 
@@ -633,6 +642,7 @@ run_doctor() {
     $REFRESH_PACKAGE_LIST             && _ignored+=("--refresh")
     [[ ${#EXTRA_LIST_OPTS[@]} -gt 0 ]] && _ignored+=("--extra-list")
     $CHECK_FULL                       && _ignored+=("--full")
+    $SCAN_ALL_HOMES                   && _ignored+=("--scan-all-homes")
     if [[ ${#_ignored[@]} -gt 0 ]]; then
         printf 'NOTE: the following flags are ignored with --doctor: %s\n\n' "${_ignored[*]}" >&2
     fi
@@ -1097,6 +1107,123 @@ _run_as_invoker() {
     else
         "$@"
     fi
+}
+
+# Populates OUT_ARRAY_NAME with "username:home" entries for real local users
+# — UID in [UID_MIN, UID_MAX] from /etc/login.defs (falls back to Arch's own
+# defaults, 1000-60000, if login.defs is missing/unreadable), shell not
+# ending in nologin or false, home directory exists. SCAN_ALL_HOMES_EXCLUDE
+# (colon-separated usernames) skips additional accounts. Test seam:
+# _SCAN_ALL_HOMES_TEST_PASSWD points at a passwd-format file instead of
+# querying getent, same convention as AUTOSTART_HOME/PKGBUILD_CACHE_DIRS.
+_enumerate_local_users() {
+    local -n _seu_out="$1"
+    _seu_out=()
+
+    local uid_min=1000 uid_max=60000 _v
+    if [[ -r /etc/login.defs ]]; then
+        _v="$(awk '$1=="UID_MIN"{print $2}' /etc/login.defs)"
+        [[ "$_v" =~ ^[0-9]+$ ]] && uid_min="$_v"
+        _v="$(awk '$1=="UID_MAX"{print $2}' /etc/login.defs)"
+        [[ "$_v" =~ ^[0-9]+$ ]] && uid_max="$_v"
+    fi
+
+    local -a _exclude=()
+    IFS=':' read -ra _exclude <<< "${SCAN_ALL_HOMES_EXCLUDE:-}"
+
+    local name uid home shell skip ex
+    while IFS=: read -r name _ uid _ _ home shell; do
+        [[ "$uid" =~ ^[0-9]+$ ]] || continue
+        (( uid >= uid_min && uid <= uid_max )) || continue
+        [[ "$shell" == */nologin || "$shell" == */false ]] && continue
+        [[ -d "$home" ]] || continue
+        skip=false
+        for ex in "${_exclude[@]}"; do
+            [[ -n "$ex" && "$name" == "$ex" ]] && { skip=true; break; }
+        done
+        $skip && continue
+        _seu_out+=("$name:$home")
+    done < <(if [[ -n "${_SCAN_ALL_HOMES_TEST_PASSWD:-}" ]]; then
+                 cat -- "$_SCAN_ALL_HOMES_TEST_PASSWD"
+             else
+                 getent passwd
+             fi)
+}
+
+# --scan-all-homes: enumerates real local users and runs the six
+# home-dependent checks against each of their homes as a privilege-dropped
+# subprocess (the same flag bundle archcanary-user.service already runs in
+# production, just centrally triggered) — not an in-process loop, since
+# check_autostart's `command -v` resolution needs the target user's real
+# PATH, and only check_npm_cache privilege-drops today. Folds each user's
+# worst-of-N result into the existing summary labels/indices (never a
+# per-user-suffixed label — _is_behavior_check_name matches names verbatim).
+_run_scan_all_homes() {
+    local _sah_bin _sah_users=() _sah_any_failed=false
+    _sah_bin="${_SCAN_ALL_HOMES_TEST_BIN:-$(realpath "$0")}"
+    _enumerate_local_users _sah_users
+    if [[ ${#_sah_users[@]} -eq 0 ]]; then
+        echo "  No real local users found (UID range, shell, or home-dir filters excluded everyone)."
+    fi
+
+    local -A _sah_worst=(
+        ["npm cache"]=-1 ["bun cache"]=-1 ["yarn cache"]=-1 ["pnpm cache"]=-1
+        ["PKGBUILD obfuscation scan"]=-1 ["XDG autostart + shell RCs"]=-1
+    )
+    local -A _sah_idx=(
+        ["npm cache"]="5" ["bun cache"]="6" ["yarn cache"]="6b" ["pnpm cache"]="6c"
+        ["PKGBUILD obfuscation scan"]="7" ["XDG autostart + shell RCs"]="10"
+    )
+
+    local _sah_entry _sah_user _sah_home _sah_log _sah_json
+    local _sah_name _sah_status _sah_code
+    for _sah_entry in "${_sah_users[@]}"; do
+        _sah_user="${_sah_entry%%:*}"
+        _sah_home="${_sah_entry#*:}"
+        echo "  === user: $_sah_user ($_sah_home) ==="
+        _sah_log="$_sah_home/.cache/archcanary/last-user-scan.log"
+        # PATH is set via `env` *after* the user switch, not prefixed before
+        # `sudo`, since sudo's own env_reset/secure_path policy (sudoers is
+        # per-machine config, not something to assume about) can silently
+        # discard a PATH set only on the invoking side.
+        _sah_json=$(sudo -H -u "$_sah_user" -- env \
+                PATH="$_sah_home/.local/bin:$_sah_home/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin" \
+                "$_sah_bin" \
+                --check-npm-cache --check-bun-cache --check-yarn-cache \
+                --check-pnpm-cache --check-pkgbuild --check-autostart \
+                --malicious-npm-list="$MALICIOUS_NPM_LIST" \
+                --package-list="$PACKAGE_LIST_FILE" \
+                --chaos-rat-list="$CHAOS_RAT_LIST" \
+                --russian-spam-list="$RUSSIAN_SPAM_LIST" \
+                --community-list="$COMMUNITY_REPORTS_LIST" \
+                --no-notify --color=never --format=json \
+                --log-file="$_sah_log" 2>/dev/null) || true
+        if [[ -f "$_sah_log" ]]; then
+            cat -- "$_sah_log"
+        else
+            echo "  WARNING: no log produced for $_sah_user"
+        fi
+        if [[ -z "$_sah_json" ]]; then
+            echo "  WARNING: could not evaluate result for $_sah_user (no parseable output)"
+            _sah_any_failed=true
+            continue
+        fi
+        while IFS='|' read -r _sah_name _sah_status; do
+            [[ -n "${_sah_worst[$_sah_name]+x}" ]] || continue
+            _sah_code=$(_sah_status_to_code "$_sah_status")
+            (( _sah_code > _sah_worst[$_sah_name] )) && _sah_worst[$_sah_name]=$_sah_code
+        done < <(_sah_parse_checks "$_sah_json")
+    done
+
+    for _sah_name in "npm cache" "bun cache" "yarn cache" "pnpm cache" \
+                      "PKGBUILD obfuscation scan" "XDG autostart + shell RCs"; do
+        _sah_code="${_sah_worst[$_sah_name]}"
+        if [[ $_sah_code -eq -1 ]]; then
+            $_sah_any_failed && _sah_code=1 || _sah_code=0
+        fi
+        [[ $_sah_code -gt $EXIT_CODE ]] && EXIT_CODE=$_sah_code
+        _rec "$_sah_name" "$_sah_code" "${_sah_idx[$_sah_name]}"
+    done
 }
 
 # systemd *system* services (and some cron contexts) start with no $HOME, which
@@ -3256,6 +3383,27 @@ _json_status() {
     esac
 }
 
+# --scan-all-homes: pulls "name|status" lines out of a per-user child's
+# --format=json output (see _print_summary_json's "checks" array below), and
+# the inverse of _json_status to fold each child's result back into a code.
+_sah_parse_checks() {
+    grep -oP '"checks":\[\K[^]]*' <<< "$1" | grep -oP '\{[^}]*\}' | while read -r _sah_obj; do
+        printf '%s|%s\n' \
+            "$(grep -oP '"name":"\K[^"]*' <<< "$_sah_obj")" \
+            "$(grep -oP '"status":"\K[^"]*' <<< "$_sah_obj")"
+    done
+}
+_sah_status_to_code() {
+    case "$1" in
+        clean)           echo 0 ;;
+        warning)         echo 1 ;;
+        infected)        echo 2 ;;
+        skipped_root)    echo 77 ;;
+        skipped_missing) echo 78 ;;
+        *)               echo 1 ;;
+    esac
+}
+
 # --format=json's whole output: a stable {name,status} array built from the
 # same _SUMMARY_NAMES/_SUMMARY_CODES that _print_summary renders as a table,
 # plus scan-level metadata. Written to fd 3 (the real stdout, saved before
@@ -3578,7 +3726,7 @@ if $CHECK_EBPF; then
     echo
 fi
 
-if $CHECK_NPM_CACHE; then
+if $CHECK_NPM_CACHE && ! $SCAN_ALL_HOMES; then
     echo "--- [5] npm cache check ---"
     check_npm_cache && ret=$? || ret=$?
     [[ $ret -gt $EXIT_CODE ]] && EXIT_CODE=$ret
@@ -3586,7 +3734,7 @@ if $CHECK_NPM_CACHE; then
     echo
 fi
 
-if $CHECK_BUN_CACHE; then
+if $CHECK_BUN_CACHE && ! $SCAN_ALL_HOMES; then
     echo "--- [6] bun cache check ---"
     check_bun_cache && ret=$? || ret=$?
     [[ $ret -gt $EXIT_CODE ]] && EXIT_CODE=$ret
@@ -3594,7 +3742,7 @@ if $CHECK_BUN_CACHE; then
     echo
 fi
 
-if $CHECK_YARN_CACHE; then
+if $CHECK_YARN_CACHE && ! $SCAN_ALL_HOMES; then
     echo "--- [6b] yarn cache check ---"
     check_yarn_cache && ret=$? || ret=$?
     [[ $ret -gt $EXIT_CODE ]] && EXIT_CODE=$ret
@@ -3602,7 +3750,7 @@ if $CHECK_YARN_CACHE; then
     echo
 fi
 
-if $CHECK_PNPM_CACHE; then
+if $CHECK_PNPM_CACHE && ! $SCAN_ALL_HOMES; then
     echo "--- [6c] pnpm cache check ---"
     check_pnpm_cache && ret=$? || ret=$?
     [[ $ret -gt $EXIT_CODE ]] && EXIT_CODE=$ret
@@ -3610,7 +3758,7 @@ if $CHECK_PNPM_CACHE; then
     echo
 fi
 
-if $CHECK_PKGBUILD; then
+if $CHECK_PKGBUILD && ! $SCAN_ALL_HOMES; then
     echo "--- [7] PKGBUILD/install file scan (obfuscation-aware) ---"
     check_pkgbuild_caches && ret=$? || ret=$?
     [[ $ret -gt $EXIT_CODE ]] && EXIT_CODE=$ret
@@ -3634,11 +3782,17 @@ if $CHECK_LDSO; then
     echo
 fi
 
-if $CHECK_AUTOSTART; then
+if $CHECK_AUTOSTART && ! $SCAN_ALL_HOMES; then
     echo "--- [10] XDG autostart + shell RC persistence check ---"
     check_autostart && ret=$? || ret=$?
     [[ $ret -gt $EXIT_CODE ]] && EXIT_CODE=$ret
     _rec "XDG autostart + shell RCs" "$ret" "10"
+    echo
+fi
+
+if $SCAN_ALL_HOMES; then
+    echo "--- [10b] Scan all local user homes (npm/bun/yarn/pnpm/pkgbuild/autostart) ---"
+    _run_scan_all_homes
     echo
 fi
 

--- a/configs/archcanary-completion.bash
+++ b/configs/archcanary-completion.bash
@@ -50,7 +50,7 @@ _archcanary() {
         --check-systemd --check-ebpf --check-npm-cache --check-bun-cache
         --check-yarn-cache --check-pnpm-cache --check-pkgbuild --check-bpftool
         --check-ldso --check-autostart --check-kmod --check-lynis
-        --check-pkginteg --check-list-overlap --search-packages= --full --refresh --no-aur-audit --verbose -v --debug
+        --check-pkginteg --check-list-overlap --scan-all-homes --search-packages= --full --refresh --no-aur-audit --verbose -v --debug
         --no-notify --no-summary --run-lynis --doctor --version -V --help -h
         --log-file= --package-list= --malicious-npm-list= --chaos-rat-list=
         --russian-spam-list= --community-list= --extra-list= --start-date= --end-date=

--- a/docs/my-setup.md
+++ b/docs/my-setup.md
@@ -162,9 +162,12 @@ triggers (timer + `.path` units) are in [systemd.md](systemd.md).
     ├── archcanary.service     # system-level scan as root, writes last-scan.log
     ├── archcanary.timer       # weekly + on boot
     ├── archcanary-onchange.service
-    └── archcanary.path        # triggers after each pacman transaction
+    ├── archcanary.path        # triggers after each pacman transaction
+    ├── archcanary-scan-all-homes.service  # opt-in: sudo -u per real local user
+    └── archcanary-scan-all-homes.timer    # weekly, disabled by default
 /var/lib/archcanary/
-    └── last-scan.log                 # shared result the user notifier watches
+    ├── last-scan.log                 # shared result the user notifier watches
+    └── last-scan-all-homes.log       # scan-all-homes result (if enabled)
 ```
 
 ## Dependencies

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -20,14 +20,22 @@ flowchart TD
         POST --> OK
     end
 
-    subgraph AFTER["2 · AFTER install / always — automatic, root"]
-        TIM["systemd timer<br/>weekly + on boot"] --> SCAN["archcanary<br/>--full"]
-        PTH[".path unit<br/>after each pacman tx"] --> SCAN
+    subgraph AFTER["2 · AFTER install / always — automatic"]
+        TIM["archcanary.timer<br/>weekly + on boot, root"] --> SCAN["archcanary<br/>systemd/eBPF/bpftool/ld.so/kmod"]
+        PTH[".path unit<br/>after each pacman tx, root"] --> SCAN
         SCAN --> LOG["last-scan.log"]
+
+        UTIM["archcanary-user.timer<br/>weekly + on boot, per user"] --> USCAN["archcanary-user<br/>npm/bun/yarn/pnpm/pkgbuild/autostart"]
+        USCAN --> ULOG["last-user-scan.log<br/>(self-notifies)"]
+
+        SAHTIM["archcanary-scan-all-homes.timer<br/>(opt-in, off by default)"] -.-> SAH["scan-all-homes<br/>sudo -u per real local user"]
+        SAH -.-> SAHLOG["last-scan-all-homes.log"]
     end
 
     subgraph ALERT["3 · ON detection / review"]
-        LOG -->|INFECTED| NOT["user .path → notify-send<br/>critical desktop alert"]
+        NOT["user .path → notify-send<br/>critical desktop alert"]
+        LOG -->|INFECTED| NOT
+        SAHLOG -.->|INFECTED| NOT
         NOT --> GUI["archcanary-gui<br/>review + root checks"]
     end
 
@@ -41,7 +49,9 @@ flowchart TD
 | 1 · At install | yay `init.lua` hooks | Every `yay` install/upgrade | ✓ | Known campaign signatures, stale-rewrite upgrades, aur-audit black/red (offline + live feed) |
 | 1 · At install | paru `PreBuildCommand` hook | Every `paru` build | ✓ | Same obfuscation patterns as yay's hook (via `archcanary --check-pkgbuild`, scoped to that package) — no aur-audit lookup yet |
 | 2 · After / always | `archcanary` | systemd timer (weekly + boot) + `.path` (after each pacman tx) | ✓ root | Known-bad packages, systemd/eBPF/npm persistence, rootkit traces |
-| 3 · On detection | notifier → GUI | `last-scan.log` flips to INFECTED | ✓ | Surfaces a result; review is manual |
+| 2 · After / always | `archcanary-user` | systemd `--user` timer (weekly + boot) | opt-in, per user | npm/bun/yarn/pnpm/pkgbuild caches, autostart — for whoever enables it |
+| 2 · After / always | `archcanary-scan-all-homes` | systemd timer, weekly | opt-in, off by default | Same as above, for every real local user — not just whoever opted in |
+| 3 · On detection | notifier → GUI | `last-scan.log`/`last-scan-all-homes.log` flips to INFECTED | ✓ | Surfaces a result; review is manual |
 
 ## Read this first
 

--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -27,13 +27,21 @@ user (you) — user-level checks:
                                   --check-autostart   (scans your real ~)
      └─ notifies itself on a detection (runs in your session)
   archcanary-user.timer    weekly + on boot
+
+system (root), opt-in — same user-level checks, every real local user:
+  archcanary-scan-all-homes.service  --scan-all-homes
+     └─ enumerates real local users, runs the user-level checks above as a
+        privilege-dropped (sudo -u) subprocess per user — root orchestrating
+        N copies of the user-lane's own invocation, not a third kind of check
+     └─ writes /var/lib/archcanary/last-scan-all-homes.log   (--no-notify)
+  archcanary-scan-all-homes.timer    weekly (disabled by default)
 ```
 
-The root scan can't notify (no desktop session), so a user `.path` unit watches its result file and raises the alert. The user scan runs in your session, so it just calls `notify-send` itself.
+The root scan can't notify (no desktop session), so a user `.path` unit watches its result file and raises the alert. The user scan runs in your session, so it just calls `notify-send` itself. `archcanary-scan-all-homes` closes the gap the user-level lane leaves on a shared machine — nothing scans a second user's home unless *they* enable `archcanary-user.timer` themselves — without collapsing the root-vs-user distinction: it's root reaching into each user's home on an explicit opt-in, not a merged root+user check.
 
 ## Quick setup (recommended)
 
-`./install.sh --system` does all of this for you — it installs the system scan units, the user-level scan, and the notifier; creates `/var/lib/archcanary/`; seeds the package lists and the system-wide DKMS, systemd, and bpftool allowlists; enables the system timer + pacman-trigger, the user timer, and the notifier; and migrates away any old user-scope scan units:
+`./install.sh --system` does all of this for you — it installs the system scan units, the user-level scan, the notifier, and the opt-in scan-all-homes unit (installed but never enabled — see section 5); creates `/var/lib/archcanary/`; seeds the package lists and the system-wide DKMS, systemd, and bpftool allowlists; enables the system timer + pacman-trigger, the user timer, and the notifier; and migrates away any old user-scope scan units:
 
 ```bash
 ./install.sh --system
@@ -192,6 +200,47 @@ sudo systemctl enable --now archcanary.path
 
 > The path unit only triggers when `/var/log/pacman.log` changes; systemd coalesces rapid writes (e.g. a big `-Syu`) so the scan runs once after the transaction settles. Runs offline against the cached list; freshness comes from the weekly timer's `--refresh`.
 
+## 5. Scan all local user homes (optional, root)
+
+Section 3's user-level scan only covers whoever enables `archcanary-user.timer` for themselves — on a shared machine, another user's npm/bun/pnpm caches and autostart entries are never scanned unless they personally opt in. This unit closes that gap: root enumerates real local users (UID range from `/etc/login.defs`, valid shell, home directory exists) and runs section 3's exact check bundle as a privilege-dropped (`sudo -u`) subprocess per user, so `command -v` autostart resolution and cache paths are evaluated against each real account, not root's.
+
+Off by default even after `--system` install — it's the one unit here that touches every local user's data, so activation is a deliberate, separate step from the rest of `--system`'s setup.
+
+**`/etc/systemd/system/archcanary-scan-all-homes.service`**
+```ini
+[Unit]
+Description=archcanary scan of all local users' homes (root, opt-in)
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+StateDirectory=archcanary
+ExecStart=/usr/lib/archcanary/archcanary.sh --refresh --scan-all-homes --no-notify --log-file=/var/lib/archcanary/last-scan-all-homes.log
+```
+
+**`/etc/systemd/system/archcanary-scan-all-homes.timer`**
+```ini
+[Unit]
+Description=Run archcanary scan of all local users' homes weekly
+
+[Timer]
+OnBootSec=15min
+OnCalendar=weekly
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+A separate result file (`last-scan-all-homes.log`, not `last-scan.log`) — both this timer and `archcanary.timer` fire near-boot and weekly, and each scan truncates its own log file on start, so two units sharing one file would race. The section-2 notifier already watches both files.
+
+Enable and start:
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now archcanary-scan-all-homes.timer
+```
+
 ## Checking results
 
 ```bash
@@ -199,14 +248,18 @@ sudo systemctl enable --now archcanary.path
 sudo cat /var/lib/archcanary/last-scan.log
 # Last user-scan output
 cat ~/.cache/archcanary/last-user-scan.log
+# Last scan-all-homes output (root-owned; if enabled)
+sudo cat /var/lib/archcanary/last-scan-all-homes.log
 
 # Or via the journal
 journalctl -u archcanary            # system scan
 journalctl --user -u archcanary-user   # user scan
+journalctl -u archcanary-scan-all-homes   # scan-all-homes (if enabled)
 
 # Timer / unit status
 systemctl status archcanary.timer
 systemctl --user status archcanary-user.timer archcanary-notify.path
+systemctl status archcanary-scan-all-homes.timer
 ```
 
 ## Why the split?

--- a/lib/archcanary-root-install.sh
+++ b/lib/archcanary-root-install.sh
@@ -203,9 +203,12 @@ EOF
        "$REPO_DIR"/systemd/system/archcanary.timer \
        "$REPO_DIR"/systemd/system/archcanary-onchange.service \
        "$REPO_DIR"/systemd/system/archcanary.path \
+       "$REPO_DIR"/systemd/system/archcanary-scan-all-homes.service \
+       "$REPO_DIR"/systemd/system/archcanary-scan-all-homes.timer \
        /etc/systemd/system/
     systemctl daemon-reload
     echo "  installed: /etc/systemd/system/archcanary.{service,timer,path} + -onchange.service (not enabled — see below)"
+    echo "  installed: /etc/systemd/system/archcanary-scan-all-homes.{service,timer} (opt-in, not enabled — see below)"
     ;;
 
 uninstall-bins)
@@ -226,10 +229,13 @@ uninstall-bins)
 
 uninstall-components)
     systemctl disable --now archcanary.timer archcanary.path 2>/dev/null || true
+    systemctl disable --now archcanary-scan-all-homes.timer 2>/dev/null || true
     rm -f /etc/systemd/system/archcanary.service \
           /etc/systemd/system/archcanary.timer \
           /etc/systemd/system/archcanary-onchange.service \
-          /etc/systemd/system/archcanary.path
+          /etc/systemd/system/archcanary.path \
+          /etc/systemd/system/archcanary-scan-all-homes.service \
+          /etc/systemd/system/archcanary-scan-all-homes.timer
     systemctl daemon-reload
     echo "  kept:    /var/lib/archcanary (scan history — remove manually if desired)"
     echo "  removed: systemd units (system scan + user notifier)"

--- a/man/archcanary.1
+++ b/man/archcanary.1
@@ -118,6 +118,15 @@ command per affected file. A note, not a warning: never affects the exit
 status, never warns in the check summary, and not included in
 .BR \-\-full .
 .TP
+.B \-\-scan\-all\-homes
+Enumerate real local users
+.RI ( /etc/login.defs " UID range, valid shell, home directory exists)"
+and run the npm/bun/yarn/pnpm/pkgbuild/autostart checks against each of
+their homes, not just yours — privilege-dropped per user via
+.BR sudo \-u .
+For shared/multi-user machines. Requires root. Not included in
+.BR \-\-full .
+.TP
 .B \-\-search\-packages= PKG [, PKG ...]
 Check package name(s) against every loaded threat list, independent of
 what's installed locally. No scan is run; prints a ready-to-copy
@@ -256,6 +265,11 @@ Last system scan result.
 .TP
 .I ~/.cache/archcanary/last-user-scan.log
 Last user scan result.
+.TP
+.I /var/lib/archcanary/last-scan-all-homes.log
+Last
+.B \-\-scan\-all\-homes
+result (if enabled).
 .TP
 .I /etc/archcanary/dkms_allowlist.conf
 System-wide DKMS module allowlist for

--- a/systemd/system/archcanary-scan-all-homes.service
+++ b/systemd/system/archcanary-scan-all-homes.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=archcanary scan of all local users' homes (root, opt-in)
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+StateDirectory=archcanary
+ExecStart=/usr/lib/archcanary/archcanary.sh --refresh --scan-all-homes --no-notify --log-file=/var/lib/archcanary/last-scan-all-homes.log

--- a/systemd/system/archcanary-scan-all-homes.timer
+++ b/systemd/system/archcanary-scan-all-homes.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run archcanary scan of all local users' homes weekly
+
+[Timer]
+OnBootSec=15min
+OnCalendar=weekly
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/systemd/user/archcanary-notify.path
+++ b/systemd/user/archcanary-notify.path
@@ -9,6 +9,7 @@ StartLimitIntervalSec=0
 # on every write. The scan streams last-scan.log line-by-line via tee, so
 # PathModified would fire dozens of times per scan and trip the start limit.
 PathChanged=/var/lib/archcanary/last-scan.log
+PathChanged=/var/lib/archcanary/last-scan-all-homes.log
 Unit=archcanary-notify.service
 
 [Install]

--- a/systemd/user/archcanary-notify.service
+++ b/systemd/user/archcanary-notify.service
@@ -6,4 +6,4 @@ StartLimitIntervalSec=0
 
 [Service]
 Type=oneshot
-ExecStart=/bin/sh -c 'grep -q "RESULT: INFECTED" /var/lib/archcanary/last-scan.log && notify-send -u critical -i dialog-warning "archcanary: malicious package detected" "Open Archcanary to review." || true'
+ExecStart=/bin/sh -c 'grep -q "RESULT: INFECTED" /var/lib/archcanary/last-scan.log /var/lib/archcanary/last-scan-all-homes.log 2>/dev/null && notify-send -u critical -i dialog-warning "archcanary: malicious package detected" "Open Archcanary to review." || true'

--- a/tests/run_matching_tests.sh
+++ b/tests/run_matching_tests.sh
@@ -1629,6 +1629,201 @@ test_color_flag_validation() {
 }
 
 # ---------------------------------------------------------------------------
+# --scan-all-homes. _enumerate_local_users and _run_scan_all_homes are only
+# ever reached past archcanary.sh's own `[[ $EUID -eq 0 ]]` guard for this
+# flag, and this suite never runs as real root (never safe to do from a
+# test — see the policy note elsewhere in this file) — so those two are
+# tested by extracting just the function definitions via sed and sourcing
+# them directly, bypassing the CLI/root-guard entirely. The root guard
+# itself and the --full exclusion don't need that: they're testable through
+# the real CLI as a normal non-root user.
+# ---------------------------------------------------------------------------
+_sah_extract_fns() {
+    sed -n '/^_enumerate_local_users()/,/^}/p' "$REPO_DIR/archcanary.sh"
+    sed -n '/^_run_scan_all_homes()/,/^}/p' "$REPO_DIR/archcanary.sh"
+    sed -n '/^_sah_parse_checks()/,/^}/p' "$REPO_DIR/archcanary.sh"
+    sed -n '/^_sah_status_to_code()/,/^}/p' "$REPO_DIR/archcanary.sh"
+}
+
+test_enumerate_local_users() {
+    local fns scratch fake_passwd
+    fns=$(mktemp)
+    _sah_extract_fns > "$fns"
+    scratch=$(mktemp -d)
+    mkdir -p "$scratch/alice" "$scratch/bob" "$scratch/carol"
+    # nohome deliberately not created — the home-dir-exists filter must
+    # exclude it.
+    fake_passwd="$scratch/passwd"
+    cat > "$fake_passwd" <<EOF
+root:x:0:0::/root:/bin/bash
+daemon:x:1:1::/usr/bin:/usr/bin/nologin
+service:x:900:900::/var/lib/service:/usr/bin/nologin
+alice:x:1000:1000::$scratch/alice:/bin/bash
+bob:x:1001:1001::$scratch/bob:/bin/zsh
+carol:x:1002:1002::$scratch/carol:/usr/bin/nologin
+nohome:x:1003:1003::$scratch/nohome:/bin/bash
+EOF
+
+    local out
+    out=$(bash -c "
+        source '$fns'
+        _SCAN_ALL_HOMES_TEST_PASSWD='$fake_passwd'
+        _enumerate_local_users users
+        printf '%s\n' \"\${users[@]}\"
+    ")
+    if [[ "$out" == *"alice:$scratch/alice"* && "$out" == *"bob:$scratch/bob"* && \
+          "$out" != *"root:"* && "$out" != *"daemon:"* && "$out" != *"service:"* && \
+          "$out" != *"carol:"* && "$out" != *"nohome:"* ]]; then
+        pass "enumerate_local_users: UID range, nologin/false shell, and missing-home filters all apply"
+    else
+        fail "enumerate_local_users: unexpected user set, out: $out"
+    fi
+
+    local out2
+    out2=$(bash -c "
+        source '$fns'
+        _SCAN_ALL_HOMES_TEST_PASSWD='$fake_passwd'
+        SCAN_ALL_HOMES_EXCLUDE='bob'
+        _enumerate_local_users users
+        printf '%s\n' \"\${users[@]}\"
+    ")
+    if [[ "$out2" == *"alice:"* && "$out2" != *"bob:"* ]]; then
+        pass "enumerate_local_users: SCAN_ALL_HOMES_EXCLUDE skips the named user"
+    else
+        fail "enumerate_local_users: exclude list not respected, out: $out2"
+    fi
+
+    rm -f "$fns"
+    rm -rf "$scratch"
+}
+
+test_scan_all_homes_worst_of_n() {
+    local fns scratch fake_bin fake_passwd empty_list
+    fns=$(mktemp)
+    _sah_extract_fns > "$fns"
+    scratch=$(mktemp -d)
+    fake_bin="$scratch/bin"
+    mkdir -p "$scratch/alice" "$scratch/bob/.config/autostart" "$scratch/carol" "$fake_bin"
+
+    fake_passwd="$scratch/passwd"
+    cat > "$fake_passwd" <<EOF
+alice:x:1000:1000::$scratch/alice:/bin/bash
+bob:x:1001:1001::$scratch/bob:/bin/bash
+carol:x:1002:1002::$scratch/carol:/bin/bash
+EOF
+
+    cat > "$scratch/bob/.config/autostart/evil.desktop" <<EOF
+[Desktop Entry]
+Type=Application
+Name=Suspicious
+Exec=$scratch/does-not-exist-binary
+EOF
+
+    # Fake sudo: -H -u <user> -- <cmd...>. carol's invocation fails outright
+    # (simulates a real sudo/auth failure) so the "no parseable output ->
+    # WARNING, not silent CLEAN" path gets exercised too.
+    cat > "$fake_bin/sudo" <<EOF
+#!/usr/bin/env bash
+shift; shift
+user="\$1"; shift
+shift
+if [[ "\$user" == carol ]]; then
+    exit 1
+fi
+home=\$(awk -F: -v u="\$user" '\$1==u{print \$6}' "$fake_passwd")
+HOME="\$home" exec "\$@"
+EOF
+    chmod +x "$fake_bin/sudo"
+
+    empty_list="$scratch/empty_list.txt"
+    echo "nonexistent-malicious-pkg-xyz" > "$empty_list"
+
+    local out
+    out=$(PATH="$fake_bin:$PATH" bash -c "
+        source '$fns'
+        _SCAN_ALL_HOMES_TEST_PASSWD='$fake_passwd'
+        _SCAN_ALL_HOMES_TEST_BIN='$REPO_DIR/archcanary.sh'
+        EXIT_CODE=0
+        _SUMMARY_NAMES=(); _SUMMARY_CODES=(); _SUMMARY_IDX=()
+        _rec() { _SUMMARY_NAMES+=(\"\$1\"); _SUMMARY_CODES+=(\"\$2\"); _SUMMARY_IDX+=(\"\${3:-}\"); }
+        MALICIOUS_NPM_LIST='$empty_list'
+        PACKAGE_LIST_FILE='$empty_list'
+        CHAOS_RAT_LIST='$empty_list'
+        RUSSIAN_SPAM_LIST='$empty_list'
+        COMMUNITY_REPORTS_LIST='$empty_list'
+        _run_scan_all_homes
+        for i in \"\${!_SUMMARY_NAMES[@]}\"; do
+            echo \"\${_SUMMARY_NAMES[\$i]}=\${_SUMMARY_CODES[\$i]}\"
+        done
+        echo \"EXIT_CODE=\$EXIT_CODE\"
+    " 2>&1)
+
+    if [[ "$out" == *"XDG autostart + shell RCs=2"* ]]; then
+        pass "scan_all_homes: worst-of-N reflects the flagged user's autostart finding"
+    else
+        fail "scan_all_homes: expected 'XDG autostart + shell RCs=2', out: $out"
+    fi
+    if [[ "$out" == *"npm cache=0"* ]]; then
+        pass "scan_all_homes: an unrelated check stays clean when no user triggers it"
+    else
+        fail "scan_all_homes: expected 'npm cache=0', out: $out"
+    fi
+    if [[ "$out" == *"=== user: alice"* && "$out" == *"=== user: bob"* ]]; then
+        pass "scan_all_homes: narrative log includes per-user sections"
+    else
+        fail "scan_all_homes: expected per-user narrative sections, out: $out"
+    fi
+    if [[ "$out" == *"WARNING: no log produced for carol"* || \
+          "$out" == *"WARNING: could not evaluate result for carol"* ]]; then
+        pass "scan_all_homes: a failed per-user subprocess is reported as WARNING, not silently CLEAN"
+    else
+        fail "scan_all_homes: expected a WARNING for carol's failed subprocess, out: $out"
+    fi
+    if [[ "$out" == *"EXIT_CODE=2"* ]]; then
+        pass "scan_all_homes: EXIT_CODE reflects the worst finding across all users"
+    else
+        fail "scan_all_homes: expected EXIT_CODE=2, out: $out"
+    fi
+
+    rm -f "$fns"
+    rm -rf "$scratch"
+}
+
+test_scan_all_homes_root_guard() {
+    local out rc=0
+    out=$("$REPO_DIR/archcanary.sh" --scan-all-homes 2>&1) || rc=$?
+    if [[ $rc -eq 1 && "$out" == *"--scan-all-homes requires root"* ]]; then
+        pass "scan_all_homes: non-root invocation rejected with a clear error"
+    else
+        fail "scan_all_homes: expected root-required rejection, rc=$rc, out: $out"
+    fi
+
+    # --doctor bypasses the guard (nothing root-requiring actually runs) and
+    # instead reports the flag as ignored, matching --refresh/--full's
+    # existing "ignored under --doctor" convention.
+    rc=0
+    out=$("$REPO_DIR/archcanary.sh" --doctor --scan-all-homes 2>&1) || rc=$?
+    if [[ "$out" == *"following flags are ignored with --doctor"*"--scan-all-homes"* ]]; then
+        pass "scan_all_homes: --doctor --scan-all-homes bypasses the root guard, reports as ignored"
+    else
+        fail "scan_all_homes: expected --doctor to bypass the guard and report ignored flag, rc=$rc, out: $out"
+    fi
+}
+
+test_scan_all_homes_flag_wiring() {
+    local out rc=0
+    out=$("$REPO_DIR/archcanary.sh" --full \
+        --package-list="$SCRIPT_DIR/fake_package_lists/simple.txt" \
+        --malicious-npm-list="$SCRIPT_DIR/fake_npm_lists/malicious_npm.txt" \
+        --no-notify --no-summary 2>&1) || rc=$?
+    if [[ "$out" != *"--scan-all-homes requires root"* ]]; then
+        pass "scan_all_homes: --full does not implicitly enable --scan-all-homes"
+    else
+        fail "scan_all_homes: --full incorrectly triggered the --scan-all-homes root guard, out: $out"
+    fi
+}
+
+# ---------------------------------------------------------------------------
 # _allowlist_cli value validation — regression coverage for the bug found
 # 2026-08-02: the value regex required the first char to be alphanumeric
 # and never allowed '/', so a real full-path autostart value (as required by
@@ -1941,6 +2136,18 @@ test_install_paru_conf
 
 $VERBOSE && msg "--- Test 23: --color flag validation ---"
 test_color_flag_validation
+
+$VERBOSE && msg "--- Test 24: enumerate_local_users filtering ---"
+test_enumerate_local_users
+
+$VERBOSE && msg "--- Test 25: scan-all-homes worst-of-N aggregation ---"
+test_scan_all_homes_worst_of_n
+
+$VERBOSE && msg "--- Test 26: scan-all-homes root guard ---"
+test_scan_all_homes_root_guard
+
+$VERBOSE && msg "--- Test 27: scan-all-homes flag wiring (--full exclusion) ---"
+test_scan_all_homes_flag_wiring
 
 echo "=== Results: $PASS_COUNT PASS, $FAIL_COUNT FAIL ==="
 [[ $FAIL_COUNT -eq 0 ]] || exit 1


### PR DESCRIPTION
archcanary-user.timer covers the npm/bun/yarn/pnpm/pkgbuild/autostart checks correctly, but only for whoever enables it themselves — on a shared machine, other users' homes are never scanned by anything unless they personally opt in.

--scan-all-homes closes that gap from the root side: enumerates real local users (UID range from /etc/login.defs, valid shell, home dir exists) and runs the exact same check bundle archcanary-user.service already runs in production, as a privilege-dropped (sudo -u) subprocess per user rather than an in-process loop — check_autostart's `command -v` PATH resolution needs the target user's real PATH, and bun/yarn/pnpm have no privilege-drop today (only npm does), so a real subprocess sidesteps both problems without touching any of the six check functions themselves. Results fold into the existing summary labels (never per-user-suffixed — _is_behavior_check_name matches names verbatim) as a worst-of-N across all enumerated users.

New archcanary-scan-all-homes.service/.timer, weekly, off by default even after --system install — it's the one unit that touches every local user's data, kept as a deliberate separate opt-in rather than folded into the existing pacman-transaction-triggered root scan.

## Summary

<!-- What does this PR do? For a community_reports.txt addition, the
     package name(s) plus the checklist below is enough. -->

## If this adds to `lists/community_reports.txt`

- [ ] Package name is exact (matches the AUR package name / `pacman -Qm` output)
- [ ] Evidence is linked below — an AUR comment, mailing-list post, PKGBUILD diff, or writeup, not just suspicion
- [ ] Checked it isn't already in `package_list.txt`, `chaos_rat_packages.txt`, `malicious_russian_spam_packages.txt`, or `community_reports.txt`

**Evidence:** <!-- link(s) here -->

## For code changes

- [ ] Ran `bash tests/run_matching_tests.sh` (for `archcanary.sh` changes)
- [ ] Updated `--help`/man page/README if user-facing behavior changed
