### PR TITLE
chore: set real sha256 for v0.1.26 release tarball

### DIFF
--- a/packaging/.SRCINFO
+++ b/packaging/.SRCINFO
@@ -20,6 +20,6 @@ pkgbase = archcanary
 	backup = etc/archcanary/bpftool_allowlist.conf
 	backup = etc/archcanary/autostart_allowlist.conf
 	source = archcanary-0.1.26.tar.gz::https://github.com/musqz/archcanary/archive/v0.1.26.tar.gz
-	sha256sums = SKIP
+	sha256sums = b250346e3cbf8d6d0a0bb8bd44593ad5bcb8de6d288c191db2f621b1149b34e6
 
 pkgname = archcanary

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -22,7 +22,7 @@ backup=('etc/archcanary/dkms_allowlist.conf'
         'etc/archcanary/autostart_allowlist.conf')
 install=archcanary.install
 source=("$pkgname-$pkgver.tar.gz::https://github.com/musqz/$pkgname/archive/v$pkgver.tar.gz")
-sha256sums=('SKIP')
+sha256sums=('b250346e3cbf8d6d0a0bb8bd44593ad5bcb8de6d288c191db2f621b1149b34e6')
 
 package() {
   cd "$srcdir/$pkgname-$pkgver"


### PR DESCRIPTION
## Summary
- Final step of the v0.1.26 release: replaces the `SKIP` placeholder from #192 with the real sha256 of the tagged tarball
- Verified before trusting the hash: downloaded `v0.1.26.tar.gz`, extracted it, confirmed `version.txt` reads `0.1.26` and the new `archcanary-scan-all-homes` unit files/code are present

## Test plan
- [x] `makepkg --printsrcinfo` regenerated `.SRCINFO` — sha256sums matches PKGBUILD
- [x] Tarball content verified (not just hash) before trusting it

The tag `v0.1.26` is not touched by this PR — same commit as before, per the release checklist (never move a tag).