### PR TITLE
fix: resolve DKMS module ownership by dkms.conf, not name-guessing

### DIFF
--- a/archcanary.sh
+++ b/archcanary.sh
@@ -2995,8 +2995,13 @@ check_kmod() {
                 # dkms status format: "name/version, kernel, arch: status"
                 pkg_name=$(awk -F'[/,]' '{print $1}' <<< "$entry" | xargs)
                 pkg_ver=$(awk -F'[/,]' '{print $2}' <<< "$entry" | xargs)
-                # Skip if pacman-tracked
-                pacman -Qi "$pkg_name" &>/dev/null 2>&1 && continue
+                # Skip if pacman-tracked. dkms's own self-reported name is
+                # often the upstream driver name without Arch's "-dkms"
+                # package suffix (e.g. module "broadcom-wl" vs package
+                # "broadcom-wl-dkms"), so also resolve ownership via the
+                # module's own dkms.conf before concluding it's untracked.
+                { pacman -Qi "$pkg_name" ||
+                  pacman -Qo "/usr/src/$pkg_name-$pkg_ver/dkms.conf"; } &>/dev/null 2>&1 && continue
                 if _allowlist_contains "$pkg_name" _dkms_allow; then
                     echo "  INFO: DKMS module allowlisted (not pacman-tracked): $entry"
                 else

--- a/tests/run_matching_tests.sh
+++ b/tests/run_matching_tests.sh
@@ -1067,7 +1067,44 @@ test_check_kmod() {
         fail "check_kmod: untracked DKMS module hint missing/wrong/duplicated, rc=$rc, hint_count=$hint_count, out: $out"
     fi
 
-    rm -f "$null_dkms" "$lsmod_evil" "$lsmod_empty" "$dkms_evil"
+    # Sub-test D: DKMS's self-reported module name doesn't match its actual
+    # pacman package (the common "-dkms" suffix convention, e.g. module
+    # "broadcom-wl" <- package "broadcom-wl-dkms") — must resolve via the
+    # module's own dkms.conf ownership, not just `pacman -Qi <bare name>`,
+    # or every such package false-positives as untracked.
+    local fake_bin
+    fake_bin=$(mktemp -d)
+    cat > "$fake_bin/pacman" << 'FAKEPACMAN'
+#!/bin/sh
+case "$1" in
+    -Ql) exit 0 ;;
+    -Qi) exit 1 ;;
+    -Qo)
+        case "$2" in
+            */broadcom-wl-*/dkms.conf) echo "broadcom-wl-dkms is owned by broadcom-wl-dkms 1.0-1"; exit 0 ;;
+            *) exit 1 ;;
+        esac
+        ;;
+    *) exit 1 ;;
+esac
+FAKEPACMAN
+    chmod +x "$fake_bin/pacman"
+
+    local dkms_suffix_mismatch
+    dkms_suffix_mismatch=$(make_cmd_script "broadcom-wl/6.30.223.271, 6.18.39-1-arch, x86_64: installed
+")
+
+    rc=0
+    out=$(PATH="$fake_bin:$PATH" LSMOD_CMD="$lsmod_empty" DKMS_CMD="$dkms_suffix_mismatch" \
+        "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
+    if [[ $rc -eq 0 && "$out" != *"untracked source"* ]]; then
+        pass "check_kmod: DKMS module name with -dkms-suffixed package resolved via dkms.conf ownership, not flagged"
+    else
+        fail "check_kmod: -dkms suffix mismatch incorrectly flagged untracked, rc=$rc, out: $out"
+    fi
+
+    rm -f "$null_dkms" "$lsmod_evil" "$lsmod_empty" "$dkms_evil" "$dkms_suffix_mismatch"
+    rm -rf "$fake_bin"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
check_kmod flagged pacman-tracked DKMS drivers as "untracked source" whenever the module's self-reported dkms status name didn't exactly match its pacman package name -- the common case, since Arch packages almost always suffix these with -dkms (broadcom-wl-dkms, tuxedo-drivers-dkms, v4l2loopback-dkms) while dkms.conf keeps the upstream driver's own undecorated PACKAGE_NAME. Reported by users hitting this on the Apple-wifi broadcom-wl-dkms driver; reproduced live on this machine with tuxedo-drivers-dkms.

Falls back to resolving ownership of the module's own dkms.conf under /usr/src/<name>-<version>/ (same file-based approach the lsmod half of this check already uses) instead of guessing a package name.

## Summary

<!-- What does this PR do? For a community_reports.txt addition, the
     package name(s) plus the checklist below is enough. -->

## If this adds to `lists/community_reports.txt`

- [ ] Package name is exact (matches the AUR package name / `pacman -Qm` output)
- [ ] Evidence is linked below — an AUR comment, mailing-list post, PKGBUILD diff, or writeup, not just suspicion
- [ ] Checked it isn't already in `package_list.txt`, `chaos_rat_packages.txt`, `malicious_russian_spam_packages.txt`, or `community_reports.txt`

**Evidence:** <!-- link(s) here -->

## For code changes

- [ ] Ran `bash tests/run_matching_tests.sh` (for `archcanary.sh` changes)
- [ ] Updated `--help`/man page/README if user-facing behavior changed
