### PR TITLE
docs: drop the canary alias story

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ run everything at once with `--full`.
 | `--version`, `-V` | Show version and exit | — |
 | `--help`, `-h` | Show this help and exit | — |
 
-Both `install.sh` and the AUR package install bash tab-completion for every flag above (`archcanary --<TAB>`), loaded automatically via the `bash-completion` package — no `.bashrc` edits needed. If you'd rather type `canary`, add `alias canary=archcanary` to your `.bashrc`/`.zshrc`; the completion is already registered for that name too, so it works immediately.
+Both `install.sh` and the AUR package install bash tab-completion for every flag above (`archcanary --<TAB>`), loaded automatically via the `bash-completion` package — no `.bashrc` edits needed.
 
 </details>
 

--- a/docs/my-setup.md
+++ b/docs/my-setup.md
@@ -190,11 +190,9 @@ Options set in `init.lua`: `diff_menu = true`, `clean_menu = true`, `sort_by = "
 
 Using paru instead of yay? See [paru integration](paru-integration.md) for the equivalent hook.
 
-## Shell completion and the `canary` alias
+## Shell completion
 
-Both install paths (`install.sh` and the AUR package) drop a bash-completion script into `/usr/share/bash-completion/completions/archcanary` (system) or `~/.local/share/bash-completion/completions/archcanary` (user), plus a `canary` symlink alongside it — both load automatically via the `bash-completion` package, no `.bashrc` edits required. `archcanary --<TAB>` lists every flag; `--doctor=<TAB>`, `--color=<TAB>`, and the `--*-list=<TAB>`/`--log-file=<TAB>` flags complete their values (section names, `auto|always|never`, and file paths respectively).
-
-The `canary` completion works standalone, but `canary` itself is only a *name* until you actually alias it — add `alias canary=archcanary` to `.bashrc`/`.zshrc` yourself if you want the shorter command; `install.sh` deliberately doesn't inject this (same "never touch the user's shell rc" rule as everything else here).
+Both install paths (`install.sh` and the AUR package) drop a bash-completion script into `/usr/share/bash-completion/completions/archcanary` (system) or `~/.local/share/bash-completion/completions/archcanary` (user) — loads automatically via the `bash-completion` package, no `.bashrc` edits required. `archcanary --<TAB>` lists every flag; `--doctor=<TAB>`, `--color=<TAB>`, and the `--*-list=<TAB>`/`--log-file=<TAB>` flags complete their values (section names, `auto|always|never`, and file paths respectively).
 
 ## Systemd unit files
 


### PR DESCRIPTION
## Summary
- Removes the `canary` manual-alias narrative from `docs/my-setup.md` and `README.md` — no symlink/binary ships for it, only the bash-completion registration, so leading with an alias story was misleading
- Keeps the real, automatic bash tab-completion facts intact

## Test plan
- [x] Reviewed diff, no other stray `alias canary=archcanary` references left in docs (CHANGELOG.md entries are historical, left untouched)