### PR TITLE
docs: clarify yay hook doesn't call the archcanary binary

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -11,8 +11,8 @@ flowchart TD
     subgraph AT["1 · AT install — automatic"]
         U["yay -S pkg / yay -Syu / yay &lt;term&gt;"] --> SEL["UpgradeSelect<br/>age warn"]
         SEL --> REV["yay diff/edit/clean menus<br/>(human review) + source download"]
-        REV --> PDL["AURPostDownload<br/>pattern block + aur-audit"]
-        UP["paru -S pkg"] --> PBC["PreBuildCommand<br/>--check-pkgbuild"]
+        REV --> PDL["AURPostDownload<br/>Lua port: pattern block + aur-audit<br/>(not the archcanary binary)"]
+        UP["paru -S pkg"] --> PBC["PreBuildCommand<br/>archcanary --check-pkgbuild"]
         PDL -->|blocked| AB["build / install aborted"]
         PBC -->|blocked| AB
         PDL -->|clean| POST["PostInstall<br/>log AUR installs"]


### PR DESCRIPTION
## Summary
- `docs/overview.md`'s AT-install flowchart showed the yay and paru branches with parallel-looking labels, implying both invoke the same thing
- Only paru's `PreBuildCommand` actually shells out to the real `archcanary --check-pkgbuild`; yay's `AURPostDownload` hook is a Lua reimplementation of the same checks (`configs/yay-init.lua`) that never calls the binary
- Relabeled both diagram nodes to make that distinction explicit

## Test plan
- [x] Validated the updated mermaid diagram with `mermaid.parse()` (npm+jsdom)