### PR TITLE
Fix/aur audit red version aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.27 (2026-08-06)
+
+- Fix: `configs/yay-init.lua`'s aur-audit RED warning matched by package name only, so a once-flagged package kept warning on every future install even after a newer version was rescanned clean — reported live on `firefox-pure`. `--refresh` now also captures the flagged version into `aur_audit_red_versions.txt` (RED only; BLACK's block stays unconditional); the hook compares it against the installing PKGBUILD's own `pkgver`/`pkgrel` and only keeps full severity on an exact match. Marker bumped to `(v6)`.
+
 ## v0.1.26 (2026-08-05)
 
 - Added: `--scan-all-homes` — enumerates real local users and runs the npm/bun/yarn/pnpm/pkgbuild/autostart checks against each of their homes, not just yours (privilege-dropped per user via `sudo -u`). Closes the gap where `archcanary-user.timer` only covers whoever enables it themselves. New `archcanary-scan-all-homes.service`/`.timer`, opt-in and off by default.

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -1599,9 +1599,23 @@ load_packages() {
                 printf '%s\n' "${all_dates[@]}" | sort -u > "$dates_dest"
                 _chown_to_invoker "$dates_dest"
             fi
-            if [[ -n "$versions_dest" && ${#all_versions[@]} -gt 0 ]]; then
-                printf '%s\n' "${all_versions[@]}" | sort -u > "$versions_dest"
-                _chown_to_invoker "$versions_dest"
+            if [[ -n "$versions_dest" ]]; then
+                if [[ ${#all_versions[@]} -gt 0 ]]; then
+                    printf '%s\n' "${all_versions[@]}" | sort -u > "$versions_dest"
+                    _chown_to_invoker "$versions_dest"
+                else
+                    # Unlike dest/dates_dest above, an empty capture here is
+                    # NOT left stale -- a stale flagged-version line drives an
+                    # active severity *downgrade* in the Lua hook (full
+                    # warning vs. "different version, might be stale"), not
+                    # just outdated-but-still-flagged threat data. If a
+                    # future page format ever breaks this extraction, fail
+                    # toward the conservative default (no data -> full
+                    # warning for every RED match) rather than risk a wrong
+                    # version silently softening a warning that shouldn't be.
+                    : > "$versions_dest"
+                    _chown_to_invoker "$versions_dest"
+                fi
             fi
         }
         if [[ "$AUR_AUDIT_ENABLE" == true ]]; then

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -944,7 +944,7 @@ run_doctor() {
         # silently (reports a working hook as missing) rather than erroring
         # out.
         local _ARCHCANARY_LUA_MARKER_STABLE='yay 13.0 Lua hooks for the AUR security stack'
-        local _ARCHCANARY_LUA_MARKER_CURRENT="$_ARCHCANARY_LUA_MARKER_STABLE (v5)"
+        local _ARCHCANARY_LUA_MARKER_CURRENT="$_ARCHCANARY_LUA_MARKER_STABLE (v6)"
         local _lua_label="yay init.lua (archcanary's hooks: upgrade-age warning, pattern block, aur-audit black/red check, install log)"
         _opt_dep "lynis (system hardening auditor)" lynis lynis "post-install hardening audit"
         if [[ "$(_marker "$_ARCHCANARY_LUA_MARKER_CURRENT" "$yay_init_lua")" -eq 0 ]]; then
@@ -1307,6 +1307,14 @@ AUR_AUDIT_RED_LIST="${AUR_AUDIT_RED_LIST:-$AUR_CONFIG_DIR/aur_audit_red.txt}"
 AUR_AUDIT_RED_PKGS=()
 AUR_AUDIT_RED_DATES_LIST="${AUR_AUDIT_RED_DATES_LIST:-$AUR_CONFIG_DIR/aur_audit_red_dates.txt}"
 AUR_AUDIT_RED_DATE_LINES=()
+# Companion file: "pkgname pkgver-pkgrel" per line, the flagged version's own
+# Arch version string (wtako's "version" field). Read directly by
+# configs/yay-init.lua's Lua hook, which compares it against the PKGBUILD
+# currently being installed so a name-only match doesn't warn forever once a
+# newer version has been rescanned clean. RED only -- BLACK's yay.abort()
+# stays unconditional regardless of version. No bash-side consumer, so unlike
+# the dates file above this gets no *_LINES array or associative lookup.
+AUR_AUDIT_RED_VERSIONS_LIST="${AUR_AUDIT_RED_VERSIONS_LIST:-$AUR_CONFIG_DIR/aur_audit_red_versions.txt}"
 
 # Fetch the aur-audit.wtako.net black/red feed on --refresh. Disable via
 # AUR_AUDIT_ENABLE=false (env), --no-aur-audit (one-off), or the GUI checkbox.
@@ -1530,12 +1538,18 @@ load_packages() {
         # name/date counts are verified equal before pairing — if a future
         # API response ever drops the field for some entries, dates are
         # skipped for that page (names still update) rather than risk
-        # silently misaligning name[i] with date[j].
+        # silently misaligning name[i] with date[j]. RED's call also passes a
+        # versions_dest, capturing the flagged version's own "pkgver-pkgrel"
+        # string into a companion versions file — configs/yay-init.lua's Lua
+        # hook compares it against the PKGBUILD being installed so a
+        # name-only match doesn't warn forever once a newer version is
+        # rescanned clean. BLACK gets no versions_dest: a confirmed-malicious
+        # verdict stays an unconditional block regardless of version.
         _refresh_aur_audit() {
-            local filter="$1" dest="$2" label="$3" dates_dest="$4"
+            local filter="$1" dest="$2" label="$3" dates_dest="$4" versions_dest="${5:-}"
             local base="https://aur-audit.wtako.net/packages"
             local cursor="" page pages=0
-            local -a page_names page_dates_ms all=() all_dates=()
+            local -a page_names page_dates_ms all=() all_dates=() all_versions=()
             echo "Fetching aur-audit $label list..."
             while :; do
                 page=$(curl -fsSL "${base}?filter=${filter}&limit=500${cursor:+&before=$cursor}" 2>/dev/null) || {
@@ -1550,6 +1564,24 @@ load_packages() {
                     for i in "${!page_names[@]}"; do
                         ds=$(date -d "@$(( page_dates_ms[i] / 1000 ))" +%F 2>/dev/null) || continue
                         all_dates+=("${page_names[i]} $ds")
+                    done
+                fi
+                if [[ -n "$versions_dest" ]]; then
+                    # Not every entry carries a "version" field (live feed:
+                    # ~3% don't) -- the flat index-pairing used for dates
+                    # above would silently drop the whole page on any count
+                    # mismatch, and a lazy cross-field regex risks pairing a
+                    # name with the WRONG object's version. Split into one
+                    # record per package object first (each starts with the
+                    # fixed "guid" field) so packageName/version are pulled
+                    # from the same object and never misattributed.
+                    local -a page_objs
+                    mapfile -t page_objs < <(awk -v RS='{"guid":"' 'NR>1{print RS $0}' <<<"$page")
+                    local obj oname over
+                    for obj in "${page_objs[@]}"; do
+                        oname=$(grep -oP '"packageName":"\K[^"]*' <<<"$obj" | head -1) || true
+                        over=$(grep -oP '"version":"\K[^"]*' <<<"$obj" | head -1) || true
+                        [[ -n "$oname" && -n "$over" ]] && all_versions+=("$oname $over")
                     done
                 fi
                 cursor=$(grep -oP '"nextCursor":\K[0-9]+' <<<"$page" || true)
@@ -1567,10 +1599,14 @@ load_packages() {
                 printf '%s\n' "${all_dates[@]}" | sort -u > "$dates_dest"
                 _chown_to_invoker "$dates_dest"
             fi
+            if [[ -n "$versions_dest" && ${#all_versions[@]} -gt 0 ]]; then
+                printf '%s\n' "${all_versions[@]}" | sort -u > "$versions_dest"
+                _chown_to_invoker "$versions_dest"
+            fi
         }
         if [[ "$AUR_AUDIT_ENABLE" == true ]]; then
             _refresh_aur_audit black "$AUR_AUDIT_BLACK_LIST" "black" "$AUR_AUDIT_BLACK_DATES_LIST"
-            _refresh_aur_audit red   "$AUR_AUDIT_RED_LIST"   "red"   "$AUR_AUDIT_RED_DATES_LIST"
+            _refresh_aur_audit red   "$AUR_AUDIT_RED_LIST"   "red"   "$AUR_AUDIT_RED_DATES_LIST" "$AUR_AUDIT_RED_VERSIONS_LIST"
         else
             echo "Skipping aur-audit.wtako.net fetch (disabled)."
         fi

--- a/configs/yay-init.lua
+++ b/configs/yay-init.lua
@@ -1,6 +1,6 @@
 -- ~/.config/yay/init.lua
 --
--- yay 13.0 Lua hooks for the AUR security stack (v5).
+-- yay 13.0 Lua hooks for the AUR security stack (v6).
 -- Seeded to ~/.config/yay/init.lua by install.sh if not already present.
 -- An offline backstop that runs on every AUR install/upgrade: warns on
 -- recently-modified PKGBUILDs and blocks known malicious patterns before
@@ -95,6 +95,47 @@ local function _archcanary_load_pkg_set(path)
   return set
 end
 
+-- Same "pkgname value" companion-file shape as aur_audit_red_dates.txt and
+-- aur_audit_red_versions.txt -> name-to-value map. One loader for both, since
+-- the format is identical.
+local function _archcanary_load_pkg_map(path)
+  local map = {}
+  local f = io.open(path, "r")
+  if not f then return map end
+  for line in f:lines() do
+    if not line:match("^#") and line:match("%S") then
+      local name, value = line:match("^(%S+)%s+(%S+)")
+      if name and value then map[name] = value end
+    end
+  end
+  f:close()
+  return map
+end
+
+-- Extracts "pkgver-pkgrel" from the freshly-downloaded PKGBUILD's raw text,
+-- matching wtako's "version" field format (e.g. "0.5.8-2"), entirely offline
+-- via string.match. Returns nil -- not a best-effort guess -- for anything
+-- that isn't a simple static assignment: a pkgver() function (VCS/-git
+-- packages compute this dynamically at build time, so a static pkgver= line,
+-- if present at all, is just a stale placeholder) or a missing/unparseable
+-- pkgver=/pkgrel= line. Callers must treat nil as "unknown" and fall back to
+-- the unconditional warning -- never fail open.
+local function _archcanary_pkgbuild_version(pkgbuild)
+  local pkgver, pkgrel, dynamic
+  for line in (pkgbuild .. "\n"):gmatch("([^\n]*)\n") do
+    if line:match("^%s*pkgver%s*%(%s*%)") then
+      dynamic = true
+    elseif not pkgver then
+      pkgver = line:match("^pkgver=['\"]([^'\"]+)['\"]") or line:match("^pkgver=(%S+)")
+    end
+    if not pkgrel then
+      pkgrel = line:match("^pkgrel=['\"]([^'\"]+)['\"]") or line:match("^pkgrel=(%S+)")
+    end
+  end
+  if dynamic or not pkgver or not pkgrel then return nil end
+  return pkgver .. "-" .. pkgrel
+end
+
 -- Static pattern check + aur-audit.wtako.net black/red check, combined into
 -- one hook (rather than two separate AURPostDownload registrations) so
 -- there's a single "clean" confirmation line when nothing is found. Silence
@@ -158,16 +199,35 @@ yay.create_autocmd("AURPostDownload", {
       yay.abort(pkg .. ": blocked — suspicious pattern: rev/tr piped to shell")
     end
 
-    local dir   = _archcanary_config_dir()
-    local black = _archcanary_load_pkg_set(dir .. "/aur_audit_black.txt")
-    local red   = _archcanary_load_pkg_set(dir .. "/aur_audit_red.txt")
+    local dir          = _archcanary_config_dir()
+    local black        = _archcanary_load_pkg_set(dir .. "/aur_audit_black.txt")
+    local red          = _archcanary_load_pkg_set(dir .. "/aur_audit_red.txt")
+    local red_versions = _archcanary_load_pkg_map(dir .. "/aur_audit_red_versions.txt")
+    local red_dates    = _archcanary_load_pkg_map(dir .. "/aur_audit_red_dates.txt")
 
     if black[pkg] then
       flagged = true
       yay.abort(pkg .. ": aur-audit flagged BLACK (confirmed malicious) — https://aur-audit.wtako.net")
     elseif red[pkg] then
       flagged = true
-      yay.log.warn(pkg .. ": aur-audit flagged RED (high-risk, unconfirmed) — review before continuing")
+      -- A name-only match would otherwise warn forever, even once a newer
+      -- version is rescanned clean (e.g. firefox-pure: flagged red on an old
+      -- version, current version already clean on wtako's own site). Exact
+      -- version-string match, not vercmp ordering -- deliberately simple.
+      -- Any missing piece (versions file not yet refreshed, dynamic
+      -- pkgver(), unparseable PKGBUILD) falls through to the original
+      -- unconditional wording below.
+      local flagged_ver = red_versions[pkg]
+      local current_ver = _archcanary_pkgbuild_version(pkgbuild)
+      if flagged_ver and current_ver and current_ver ~= flagged_ver then
+        local flagged_date = red_dates[pkg]
+        local ver_info = flagged_ver .. (flagged_date and (", " .. flagged_date) or "")
+        yay.log.warn(pkg .. ": aur-audit flagged RED for a different version (" .. ver_info
+                     .. ") — installing " .. current_ver
+                     .. " — verify at aur-audit.wtako.net if this looks stale")
+      else
+        yay.log.warn(pkg .. ": aur-audit flagged RED (high-risk, unconfirmed) — review before continuing")
+      end
     end
 
     if not flagged then

--- a/configs/yay-init.lua
+++ b/configs/yay-init.lua
@@ -115,21 +115,32 @@ end
 -- Extracts "pkgver-pkgrel" from the freshly-downloaded PKGBUILD's raw text,
 -- matching wtako's "version" field format (e.g. "0.5.8-2"), entirely offline
 -- via string.match. Returns nil -- not a best-effort guess -- for anything
--- that isn't a simple static assignment: a pkgver() function (VCS/-git
--- packages compute this dynamically at build time, so a static pkgver= line,
--- if present at all, is just a stale placeholder) or a missing/unparseable
--- pkgver=/pkgrel= line. Callers must treat nil as "unknown" and fall back to
--- the unconditional warning -- never fail open.
+-- that isn't a simple static literal assignment: a pkgver() function
+-- (VCS/-git packages compute this dynamically at build time, so a static
+-- pkgver= line, if present at all, is just a stale placeholder), a
+-- pkgver=/pkgrel= line that itself uses command or variable substitution
+-- (e.g. pkgver=$(date +%Y%m%d), pkgver=${_ver} -- not a literal value, and
+-- $(...)/${...} would otherwise leak into the captured string verbatim), or
+-- a missing/unparseable line. Callers must treat nil as "unknown" and fall
+-- back to the unconditional warning -- never fail open.
 local function _archcanary_pkgbuild_version(pkgbuild)
   local pkgver, pkgrel, dynamic
   for line in (pkgbuild .. "\n"):gmatch("([^\n]*)\n") do
     if line:match("^%s*pkgver%s*%(%s*%)") then
       dynamic = true
-    elseif not pkgver then
-      pkgver = line:match("^pkgver=['\"]([^'\"]+)['\"]") or line:match("^pkgver=(%S+)")
+    elseif not pkgver and line:match("^pkgver=") then
+      if line:find("$", 1, true) then
+        dynamic = true
+      else
+        pkgver = line:match("^pkgver=['\"]([^'\"]+)['\"]") or line:match("^pkgver=(%S+)")
+      end
     end
-    if not pkgrel then
-      pkgrel = line:match("^pkgrel=['\"]([^'\"]+)['\"]") or line:match("^pkgrel=(%S+)")
+    if not pkgrel and line:match("^pkgrel=") then
+      if line:find("$", 1, true) then
+        dynamic = true
+      else
+        pkgrel = line:match("^pkgrel=['\"]([^'\"]+)['\"]") or line:match("^pkgrel=(%S+)")
+      end
     end
   end
   if dynamic or not pkgver or not pkgrel then return nil end

--- a/tests/run_matching_tests.sh
+++ b/tests/run_matching_tests.sh
@@ -1425,7 +1425,7 @@ test_doctor_stale_yay_init() {
     # with the exact re-copy fix command.
     fake_home=$(mktemp -d)
     mkdir -p "$fake_home/.config/yay"
-    sed 's/ (v5)\.$/./' "$REPO_DIR/configs/yay-init.lua" > "$fake_home/.config/yay/init.lua"
+    sed 's/ (v6)\.$/./' "$REPO_DIR/configs/yay-init.lua" > "$fake_home/.config/yay/init.lua"
     out=$(XDG_CONFIG_HOME="$fake_home/.config" "$REPO_DIR/archcanary.sh" --doctor=external 2>&1) || true
     if [[ "$out" == *"yay init.lua"*"(outdated)"* && "$out" == *"cp "*"configs/yay-init.lua"* ]]; then
         pass "doctor: outdated yay init.lua marker -> WARN with fix hint"
@@ -1861,6 +1861,90 @@ test_scan_all_homes_flag_wiring() {
 }
 
 # ---------------------------------------------------------------------------
+# _refresh_aur_audit — RED-only versions companion file. Regression coverage
+# for the name-only-forever bug: a package's aur-audit RED verdict belongs to
+# a specific version, but configs/yay-init.lua's Lua hook only ever matched
+# by name, so it kept warning on every future install of that name even
+# after a newer version was rescanned clean (reported live on firefox-pure).
+# --refresh now also captures wtako's "version" field into
+# aur_audit_red_versions.txt (RED only -- BLACK stays unconditional, no
+# versions file). No CURL_CMD-style override exists for this script, so this
+# stubs curl itself via a fake binary on $PATH, same technique as the fake
+# pacman/dkms scripts above.
+# ---------------------------------------------------------------------------
+test_refresh_aur_audit_versions() {
+    local tmpdir fake_bin
+    tmpdir=$(mktemp -d)
+    fake_bin=$(mktemp -d)
+
+    cat > "$fake_bin/curl" << 'FAKECURL'
+#!/bin/sh
+case "$*" in
+    *aur-audit.wtako.net*filter=red*)
+        # Second entry has no "version" field -- regression coverage for a
+        # real bug: the live feed has some entries missing this field, and
+        # an earlier version of this extraction silently dropped the WHOLE
+        # page (not just the sparse entry) whenever any count mismatched,
+        # then a fix attempt crashed the whole --refresh outright under
+        # set -e/pipefail when grep found no match on a sparse object.
+        printf '%s' '{"packages":[{"guid":"zzz-test-refresh-red-1785585570","packageName":"zzz-test-refresh-red","pubDateTs":1785585570000,"version":"9.9.9-1"},{"guid":"zzz-test-refresh-red-sparse-1785585571","packageName":"zzz-test-refresh-red-sparse","pubDateTs":1785585571000}]}'
+        ;;
+    *aur-audit.wtako.net*filter=black*)
+        printf '%s' '{"packages":[{"guid":"zzz-test-refresh-black-1785585570","packageName":"zzz-test-refresh-black","pubDateTs":1785585570000,"version":"1.1.1-1"}]}'
+        ;;
+    *)
+        printf '%s\n' zzz-test-refresh-dummy
+        ;;
+esac
+FAKECURL
+    chmod +x "$fake_bin/curl"
+
+    local redlist reddates redversions blacklist blackdates
+    redlist="$tmpdir/aur_audit_red.txt"
+    reddates="$tmpdir/aur_audit_red_dates.txt"
+    redversions="$tmpdir/aur_audit_red_versions.txt"
+    blacklist="$tmpdir/aur_audit_black.txt"
+    blackdates="$tmpdir/aur_audit_black_dates.txt"
+
+    local out rc=0
+    out=$(PATH="$fake_bin:$PATH" \
+        AUR_AUDIT_RED_LIST="$redlist" AUR_AUDIT_RED_DATES_LIST="$reddates" \
+        AUR_AUDIT_RED_VERSIONS_LIST="$redversions" \
+        AUR_AUDIT_BLACK_LIST="$blacklist" AUR_AUDIT_BLACK_DATES_LIST="$blackdates" \
+        PACKAGE_LIST_FILE="$tmpdir/package_list.txt" \
+        MALICIOUS_NPM_LIST="$tmpdir/malicious_npm.txt" \
+        CHAOS_RAT_LIST="$tmpdir/chaos_rat.txt" \
+        RUSSIAN_SPAM_LIST="$tmpdir/russian_spam.txt" \
+        COMMUNITY_REPORTS_LIST="$tmpdir/community_reports.txt" \
+        EXTRA_LISTS_CONF="$tmpdir/extra_lists.conf" \
+        "$REPO_DIR/archcanary.sh" --refresh --no-notify --no-summary 2>&1) || rc=$?
+
+    # A sparse entry (no version field) must not abort the whole --refresh
+    # under set -e/pipefail (the actual bug this fixture caught live) --
+    # verified by the next two checks actually finding file content at all,
+    # since a mid-loop abort would leave $redversions unwritten entirely.
+    if grep -qxF "zzz-test-refresh-red 9.9.9-1" "$redversions" 2>/dev/null; then
+        pass "_refresh_aur_audit: RED versions companion file captures wtako's version field"
+    else
+        fail "_refresh_aur_audit: RED versions file missing/wrong content, rc=$rc, out: $out"
+    fi
+
+    if ! grep -q "^zzz-test-refresh-red-sparse " "$redversions" 2>/dev/null; then
+        pass "_refresh_aur_audit: sparse entry (no version field) is skipped, not misattributed"
+    else
+        fail "_refresh_aur_audit: sparse entry got a version line it shouldn't have, out: $(cat "$redversions")"
+    fi
+
+    if ! compgen -G "$tmpdir"'/*black*version*' > /dev/null; then
+        pass "_refresh_aur_audit: BLACK gets no versions companion file (untouched)"
+    else
+        fail "_refresh_aur_audit: unexpected BLACK versions file written"
+    fi
+
+    rm -rf "$tmpdir" "$fake_bin"
+}
+
+# ---------------------------------------------------------------------------
 # _allowlist_cli value validation — regression coverage for the bug found
 # 2026-08-02: the value regex required the first char to be alphanumeric
 # and never allowed '/', so a real full-path autostart value (as required by
@@ -2185,6 +2269,9 @@ test_scan_all_homes_root_guard
 
 $VERBOSE && msg "--- Test 27: scan-all-homes flag wiring (--full exclusion) ---"
 test_scan_all_homes_flag_wiring
+
+$VERBOSE && msg "--- Test 28: _refresh_aur_audit RED versions companion file ---"
+test_refresh_aur_audit_versions
 
 echo "=== Results: $PASS_COUNT PASS, $FAIL_COUNT FAIL ==="
 [[ $FAIL_COUNT -eq 0 ]] || exit 1

--- a/tests/run_matching_tests.sh
+++ b/tests/run_matching_tests.sh
@@ -1945,6 +1945,72 @@ FAKECURL
 }
 
 # ---------------------------------------------------------------------------
+# _refresh_aur_audit — a versions capture that comes back empty must CLEAR
+# aur_audit_red_versions.txt, not leave a prior refresh's data in place.
+# Unlike the plain names/dates lists (which intentionally keep stale data on
+# a failed/empty fetch -- still-useful threat data, same severity either
+# way), a stale flagged-version line drives an active severity *downgrade* in
+# configs/yay-init.lua (full warning vs. "different version, might be
+# stale"). Found by /code-review: trusting old version data here could
+# understate severity for a package now flagged at the very version being
+# installed. On doubt, must fail toward the conservative default (no data ->
+# full warning), never toward stale-and-silently-softened.
+# ---------------------------------------------------------------------------
+test_refresh_aur_audit_versions_stale_clear() {
+    local tmpdir fake_bin
+    tmpdir=$(mktemp -d)
+    fake_bin=$(mktemp -d)
+
+    cat > "$fake_bin/curl" << 'FAKECURL'
+#!/bin/sh
+case "$*" in
+    *aur-audit.wtako.net*filter=red*)
+        # No "version" field on this round -- simulates the upstream field
+        # disappearing/reformatting between refreshes.
+        printf '%s' '{"packages":[{"guid":"zzz-test-refresh-stale-1785585570","packageName":"zzz-test-refresh-stale","pubDateTs":1785585570000}]}'
+        ;;
+    *aur-audit.wtako.net*filter=black*)
+        printf '%s' '{"packages":[]}'
+        ;;
+    *)
+        printf '%s\n' zzz-test-refresh-dummy
+        ;;
+esac
+FAKECURL
+    chmod +x "$fake_bin/curl"
+
+    local redlist reddates redversions blacklist blackdates
+    redlist="$tmpdir/aur_audit_red.txt"
+    reddates="$tmpdir/aur_audit_red_dates.txt"
+    redversions="$tmpdir/aur_audit_red_versions.txt"
+    blacklist="$tmpdir/aur_audit_black.txt"
+    blackdates="$tmpdir/aur_audit_black_dates.txt"
+
+    # Pre-seed a stale entry from an earlier, successful refresh.
+    printf 'zzz-test-refresh-stale 1.0.0-1\n' > "$redversions"
+
+    out=$(PATH="$fake_bin:$PATH" \
+        AUR_AUDIT_RED_LIST="$redlist" AUR_AUDIT_RED_DATES_LIST="$reddates" \
+        AUR_AUDIT_RED_VERSIONS_LIST="$redversions" \
+        AUR_AUDIT_BLACK_LIST="$blacklist" AUR_AUDIT_BLACK_DATES_LIST="$blackdates" \
+        PACKAGE_LIST_FILE="$tmpdir/package_list.txt" \
+        MALICIOUS_NPM_LIST="$tmpdir/malicious_npm.txt" \
+        CHAOS_RAT_LIST="$tmpdir/chaos_rat.txt" \
+        RUSSIAN_SPAM_LIST="$tmpdir/russian_spam.txt" \
+        COMMUNITY_REPORTS_LIST="$tmpdir/community_reports.txt" \
+        EXTRA_LISTS_CONF="$tmpdir/extra_lists.conf" \
+        "$REPO_DIR/archcanary.sh" --refresh --no-notify --no-summary 2>&1) || true
+
+    if [[ -f "$redversions" && ! -s "$redversions" ]]; then
+        pass "_refresh_aur_audit: an empty versions capture clears stale prior data"
+    else
+        fail "_refresh_aur_audit: stale versions data survived an empty capture, content: $(cat "$redversions" 2>&1), out: $out"
+    fi
+
+    rm -rf "$tmpdir" "$fake_bin"
+}
+
+# ---------------------------------------------------------------------------
 # _allowlist_cli value validation — regression coverage for the bug found
 # 2026-08-02: the value regex required the first char to be alphanumeric
 # and never allowed '/', so a real full-path autostart value (as required by
@@ -2272,6 +2338,9 @@ test_scan_all_homes_flag_wiring
 
 $VERBOSE && msg "--- Test 28: _refresh_aur_audit RED versions companion file ---"
 test_refresh_aur_audit_versions
+
+$VERBOSE && msg "--- Test 29: _refresh_aur_audit clears stale versions data on empty capture ---"
+test_refresh_aur_audit_versions_stale_clear
 
 echo "=== Results: $PASS_COUNT PASS, $FAIL_COUNT FAIL ==="
 [[ $FAIL_COUNT -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

<!-- What does this PR do? For a community_reports.txt addition, the
     package name(s) plus the checklist below is enough. -->

## If this adds to `lists/community_reports.txt`

- [ ] Package name is exact (matches the AUR package name / `pacman -Qm` output)
- [ ] Evidence is linked below — an AUR comment, mailing-list post, PKGBUILD diff, or writeup, not just suspicion
- [ ] Checked it isn't already in `package_list.txt`, `chaos_rat_packages.txt`, `malicious_russian_spam_packages.txt`, or `community_reports.txt`

**Evidence:** <!-- link(s) here -->

## For code changes

- [ ] Ran `bash tests/run_matching_tests.sh` (for `archcanary.sh` changes)
- [ ] Updated `--help`/man page/README if user-facing behavior changed
