### PR TITLE
docs: trim _center_pos comment, add v0.1.27 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.1.27 (2026-08-06)
 
 - Fix: `configs/yay-init.lua`'s aur-audit RED warning matched by package name only, so a once-flagged package kept warning on every future install even after a newer version was rescanned clean — reported live on `firefox-pure`. `--refresh` now also captures the flagged version into `aur_audit_red_versions.txt` (RED only; BLACK's block stays unconditional); the hook compares it against the installing PKGBUILD's own `pkgver`/`pkgrel` and only keeps full severity on an exact match. Marker bumped to `(v6)`.
+- Fix: `archcanary-gui`'s yad dialogs jumped every time you resized one, since `--center` maps to GTK's `GTK_WIN_POS_CENTER_ALWAYS`, which GTK re-applies on every resize instead of just once at open. Replaced with a one-time computed `--posx`/`--posy` (via `xdotool`, falling back to `--center` if it's not installed) across every sizable dialog in `archcanary-gui.sh`.
 
 ## v0.1.26 (2026-08-05)
 

--- a/archcanary-gui.sh
+++ b/archcanary-gui.sh
@@ -4,17 +4,8 @@ set -euo pipefail
 HAS_XDOTOOL=false
 command -v xdotool &>/dev/null && HAS_XDOTOOL=true
 
-# yad's --center maps to GTK_WIN_POS_CENTER_ALWAYS, which GTK re-applies on
-# every resize — the window snaps back to center the instant you drag an
-# edge, which reads as the whole window "jumping". Compute a one-time
-# centered position instead: --posx/--posy place the window once at open
-# without GTK fighting a manual resize afterward. $1=width, $2=height
-# (omit height for auto-sized dialogs — those only get centered
-# horizontally, since the final height isn't known up front). Sets the
-# global _POS array for the caller to splice into its yad invocation.
-# Falls back to plain --center (old jump-on-resize behavior, not a hard
-# failure) when xdotool is missing — same optional-dependency treatment as
-# the pkexec focus loop in run_action().
+# One-time centered position for a yad window, into $_POS. $1=width, $2=height (optional).
+# Falls back to --center without xdotool.
 _center_pos() {
     local width="$1" height="${2:-}"
     if ! $HAS_XDOTOOL; then


### PR DESCRIPTION
## Summary
- Trimmed the `_center_pos()` helper's comment in `archcanary-gui.sh` down to a what-only, 2-line note — the GTK-internals/rationale narrative belongs in commit history, not the file.
- Added the `--center`-jump fix as a second bullet under the existing v0.1.27 CHANGELOG entry.

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)