### PR TITLE
feat: downgrade repeat LOG_HIST matches to informational after first …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix: `configs/yay-init.lua`'s aur-audit RED warning matched by package name only, so a once-flagged package kept warning on every future install even after a newer version was rescanned clean — reported live on `firefox-pure`. `--refresh` now also captures the flagged version into `aur_audit_red_versions.txt` (RED only; BLACK's block stays unconditional); the hook compares it against the installing PKGBUILD's own `pkgver`/`pkgrel` and only keeps full severity on an exact match. Marker bumped to `(v6)`.
 - Fix: `archcanary-gui`'s yad dialogs jumped every time you resized one, since `--center` maps to GTK's `GTK_WIN_POS_CENTER_ALWAYS`, which GTK re-applies on every resize instead of just once at open. Replaced with a one-time computed `--posx`/`--posy` (via `xdotool`, falling back to `--center` if it's not installed) across every sizable dialog in `archcanary-gui.sh`.
+- Added: a `LOG_HIST` match (historical — package no longer installed) now only counts as a WARNING the first time. A repeat scan of the exact same install event prints `LOG_HIST_SEEN` instead — informational only, like `LOG_OLD` — so a name you've already reviewed doesn't keep raising the exit code on every future scan. A genuinely new install of the same package name is still flagged fresh. State tracked in `~/.cache/archcanary/log_hist_seen.txt`. Prompted by a live report where a since-removed `discord-qt` install kept re-triggering a WARNING on every scan.
 
 ## v0.1.26 (2026-08-05)
 

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -1851,6 +1851,15 @@ check_logs() {
     local campaign_cutoff="2026-06-09"  # earliest documented malicious commit
     local chaos_cutoff="2025-07-22"     # CHAOS RAT campaign discovery date
 
+    local seen_file="${XDG_CACHE_HOME:-$HOME/.cache}/archcanary/log_hist_seen.txt"
+    declare -A seen_map
+    if [[ -r "$seen_file" ]]; then
+        while IFS=$'\t' read -r _sp _sd; do
+            seen_map["$_sp"$'\t'"$_sd"]=1
+        done < "$seen_file"
+    fi
+    local -a new_seen=()
+
     # shellcheck disable=SC2086
     for file in $PACMAN_LOG_GLOB; do
         [[ -e "$file" ]] && log_files+=("$file")
@@ -1935,8 +1944,11 @@ check_logs() {
                 tag="LOG_OLD"
             elif [[ -v CURRENTLY_INSTALLED_MAP[$pkg] ]]; then
                 tag="LOG_HIT"
+            elif [[ -v seen_map["$pkg"$'\t'"$datetime_str"] ]]; then
+                tag="LOG_HIST_SEEN"
             else
                 tag="LOG_HIST"
+                new_seen+=("$pkg"$'\t'"$datetime_str")
             fi
 
             echo "$tag: $pkg ($action on $datetime_str)$annotation"
@@ -1944,6 +1956,12 @@ check_logs() {
 
         log_info "[$idx/$total] Done with $(basename "$file")"
     done
+
+    if [[ ${#new_seen[@]} -gt 0 ]]; then
+        mkdir -p "$(dirname "$seen_file")"
+        printf '%s\n' "${new_seen[@]}" >> "$seen_file"
+        _chown_to_invoker "$seen_file"
+    fi
 }
 
 # ---------------------------------------------------------------------------
@@ -3724,9 +3742,11 @@ if ! $FOCUSED_MODE; then
         _has_current_hit=false
         _has_hist_hit=false
         _has_old_hit=false
+        _has_seen_hit=false
         grep -q '^LOG_HIT:' "$LOGS_TMP" 2>/dev/null && _has_current_hit=true
         grep -q '^LOG_HIST:' "$LOGS_TMP" 2>/dev/null && _has_hist_hit=true
         grep -q '^LOG_OLD:' "$LOGS_TMP" 2>/dev/null && _has_old_hit=true
+        grep -q '^LOG_HIST_SEEN:' "$LOGS_TMP" 2>/dev/null && _has_seen_hit=true
 
         if $_has_current_hit; then
             echo "  WARNING: currently-installed package(s) with a matching log entry"
@@ -3753,10 +3773,15 @@ if ! $FOCUSED_MODE; then
             echo "  install/upgrade happened before that) — almost certainly unrelated:"
             grep '^LOG_OLD:' "$LOGS_TMP" | sed 's/^LOG_OLD: /  - /'
         fi
-        if ! $_has_current_hit && ! $_has_hist_hit && ! $_has_old_hit; then
+        if $_has_seen_hit; then
+            echo "  NOTE: log match(es) already flagged in a previous scan (package no"
+            echo "  longer installed) — shown for the record, not re-counted as a warning:"
+            grep '^LOG_HIST_SEEN:' "$LOGS_TMP" | sed 's/^LOG_HIST_SEEN: /  - /'
+        fi
+        if ! $_has_current_hit && ! $_has_hist_hit && ! $_has_old_hit && ! $_has_seen_hit; then
             echo "  Clean: no historical log matches found."
         fi
-        unset _has_current_hit _has_hist_hit _has_old_hit
+        unset _has_current_hit _has_hist_hit _has_old_hit _has_seen_hit
         rm -f "$LOGS_TMP"
     else
         echo "  Skipped: /var/log/pacman.log not found."

--- a/tests/run_matching_tests.sh
+++ b/tests/run_matching_tests.sh
@@ -2246,6 +2246,86 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
+# check_logs — LOG_HIST "seen once" downgrade. A historical (no-longer-
+# installed) match only counts as a warning the first time; a repeat scan of
+# the exact same install event prints LOG_HIST_SEEN instead and stays
+# exit-code-neutral, while a genuinely new install of the same package name
+# is still flagged fresh.
+# ---------------------------------------------------------------------------
+test_check_logs_seen_once() {
+    local tmpdir log_file pkglist cache_home out rc
+
+    tmpdir=$(mktemp -d)
+    log_file="$tmpdir/pacman.log"
+    pkglist="$tmpdir/package_list.txt"
+    cache_home="$tmpdir/xdg-cache"
+    printf 'zzz-test-seen-pkg\n' > "$pkglist"
+
+    cat > "$log_file" <<'EOF'
+[2026-07-01T10:00:00-0600] [ALPM] installed zzz-test-seen-pkg (1.0-1)
+EOF
+
+    local base_args=(
+        --package-list="$pkglist"
+        --malicious-npm-list="$SCRIPT_DIR/fake_npm_lists/malicious_npm.txt"
+        --chaos-rat-list="$tmpdir/chaos_rat_empty.txt"
+        --no-notify
+    )
+
+    # First run: fresh finding -> LOG_HIST, exit code reflects a warning.
+    rc=0
+    out=$(XDG_CACHE_HOME="$cache_home" PACMAN_LOG_GLOB="$log_file" \
+        COMMUNITY_REPORTS_LIST="$tmpdir/community_reports_empty.txt" \
+        "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
+    if [[ "$out" == *"LOG_HIST: zzz-test-seen-pkg"* && $rc -ge 1 ]]; then
+        pass "check_logs: first-time historical match tagged LOG_HIST and flagged"
+    else
+        fail "check_logs: expected first-run LOG_HIST + nonzero exit, out: $out rc=$rc"
+    fi
+    if [[ -s "$cache_home/archcanary/log_hist_seen.txt" ]]; then
+        pass "check_logs: first run recorded the match in log_hist_seen.txt"
+    else
+        fail "check_logs: log_hist_seen.txt missing/empty after first run"
+    fi
+
+    # Second run, same log + same seen-file: downgraded to LOG_HIST_SEEN,
+    # exit-code-neutral like LOG_OLD.
+    rc=0
+    out=$(XDG_CACHE_HOME="$cache_home" PACMAN_LOG_GLOB="$log_file" \
+        COMMUNITY_REPORTS_LIST="$tmpdir/community_reports_empty.txt" \
+        "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
+    if [[ "$out" == *"LOG_HIST_SEEN: zzz-test-seen-pkg"* && "$out" != *"LOG_HIST: zzz-test-seen-pkg"* ]]; then
+        pass "check_logs: repeat scan of the same event downgraded to LOG_HIST_SEEN"
+    else
+        fail "check_logs: expected LOG_HIST_SEEN on repeat scan, out: $out"
+    fi
+    if [[ $rc -eq 0 ]]; then
+        pass "check_logs: LOG_HIST_SEEN-only scan is exit-code-neutral (exit 0)"
+    else
+        fail "check_logs: LOG_HIST_SEEN-only scan should exit 0, got rc=$rc"
+    fi
+
+    # A genuinely new install (different timestamp) of the same package name
+    # is a distinct event -> fresh LOG_HIST, not silenced by the earlier one.
+    cat > "$log_file" <<'EOF'
+[2026-07-01T10:00:00-0600] [ALPM] installed zzz-test-seen-pkg (1.0-1)
+[2026-08-01T10:00:00-0600] [ALPM] installed zzz-test-seen-pkg (2.0-1)
+EOF
+    rc=0
+    out=$(XDG_CACHE_HOME="$cache_home" PACMAN_LOG_GLOB="$log_file" \
+        COMMUNITY_REPORTS_LIST="$tmpdir/community_reports_empty.txt" \
+        "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
+    if [[ "$out" == *"LOG_HIST: zzz-test-seen-pkg (installed on 2026-08-01"* && \
+          "$out" == *"LOG_HIST_SEEN: zzz-test-seen-pkg (installed on 2026-07-01"* ]]; then
+        pass "check_logs: a new install event for the same name is flagged fresh"
+    else
+        fail "check_logs: new install event wrongly silenced by earlier seen entry, out: $out"
+    fi
+
+    rm -rf "$tmpdir"
+}
+
+# ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
 echo "=== Matching Tests ==="
@@ -2341,6 +2421,9 @@ test_refresh_aur_audit_versions
 
 $VERBOSE && msg "--- Test 29: _refresh_aur_audit clears stale versions data on empty capture ---"
 test_refresh_aur_audit_versions_stale_clear
+
+$VERBOSE && msg "--- Test 30: check_logs LOG_HIST seen-once downgrade ---"
+test_check_logs_seen_once
 
 echo "=== Results: $PASS_COUNT PASS, $FAIL_COUNT FAIL ==="
 [[ $FAIL_COUNT -eq 0 ]] || exit 1


### PR DESCRIPTION
…warning

A historical pacman.log match (package no longer installed) kept re-triggering a WARNING on every scan indefinitely, since pacman.log is never rotated by default. Now only the first sighting of a given (package, install-timestamp) counts toward the exit code; repeat scans print LOG_HIST_SEEN instead, exit-code-neutral like LOG_OLD. A new install of the same package name is still flagged fresh.

## Summary

<!-- What does this PR do? For a community_reports.txt addition, the
     package name(s) plus the checklist below is enough. -->

## If this adds to `lists/community_reports.txt`

- [ ] Package name is exact (matches the AUR package name / `pacman -Qm` output)
- [ ] Evidence is linked below — an AUR comment, mailing-list post, PKGBUILD diff, or writeup, not just suspicion
- [ ] Checked it isn't already in `package_list.txt`, `chaos_rat_packages.txt`, `malicious_russian_spam_packages.txt`, or `community_reports.txt`

**Evidence:** <!-- link(s) here -->

## For code changes

- [ ] Ran `bash tests/run_matching_tests.sh` (for `archcanary.sh` changes)
- [ ] Updated `--help`/man page/README if user-facing behavior changed
