### PR TITLE
fix: isolate check_logs test fixtures from the real seen-file cache

### DIFF
--- a/tests/run_matching_tests.sh
+++ b/tests/run_matching_tests.sh
@@ -2089,9 +2089,10 @@ test_allowlist_cli() {
 # mechanism available today.
 # ---------------------------------------------------------------------------
 test_check_logs() {
-    local tmpdir log_file pkglist chaoslist out rc
+    local tmpdir log_file pkglist chaoslist cache_home out rc
 
     tmpdir=$(mktemp -d)
+    cache_home="$tmpdir/xdg-cache"
     log_file="$tmpdir/pacman.log"
     pkglist="$tmpdir/package_list.txt"
     chaoslist="$tmpdir/chaos_rat.txt"
@@ -2114,7 +2115,7 @@ EOF
     )
 
     rc=0
-    out=$(PACMAN_LOG_GLOB="$log_file" \
+    out=$(XDG_CACHE_HOME="$cache_home" PACMAN_LOG_GLOB="$log_file" \
         COMMUNITY_REPORTS_LIST="$tmpdir/community_reports.txt" \
         "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
 
@@ -2154,7 +2155,7 @@ EOF
     # downgraded to LOG_OLD, no matter how old the date is
     rc=0
     printf 'zzz-test-community-ancient\n' > "$tmpdir/community_reports.txt"
-    out=$(PACMAN_LOG_GLOB="$log_file" \
+    out=$(XDG_CACHE_HOME="$cache_home" PACMAN_LOG_GLOB="$log_file" \
         COMMUNITY_REPORTS_LIST="$tmpdir/community_reports.txt" \
         "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
     if [[ "$out" == *"LOG_HIST: zzz-test-community-ancient"*"[community report]"* && \
@@ -2169,7 +2170,7 @@ EOF
     local only_old_log="$tmpdir/pacman-old-only.log"
     printf '[2026-06-01T10:00:00-0600] [ALPM] installed zzz-test-old-pkg (1.0-1)\n' > "$only_old_log"
     rc=0
-    out=$(PACMAN_LOG_GLOB="$only_old_log" \
+    out=$(XDG_CACHE_HOME="$cache_home" PACMAN_LOG_GLOB="$only_old_log" \
         COMMUNITY_REPORTS_LIST="$tmpdir/community_reports.txt" \
         "$REPO_DIR/archcanary.sh" "${base_args[@]}" >/dev/null 2>&1) || rc=$?
     if [[ $rc -eq 0 ]]; then
@@ -2204,7 +2205,7 @@ EOF
 EOF
 
     rc=0
-    out=$(PACMAN_LOG_GLOB="$audit_log" \
+    out=$(XDG_CACHE_HOME="$cache_home" PACMAN_LOG_GLOB="$audit_log" \
         COMMUNITY_REPORTS_LIST="$tmpdir/community_reports_empty.txt" \
         AUR_AUDIT_RED_LIST="$audit_redlist" AUR_AUDIT_RED_DATES_LIST="$audit_reddates" \
         AUR_AUDIT_BLACK_LIST="$audit_blacklist" AUR_AUDIT_BLACK_DATES_LIST="$audit_blackdates" \


### PR DESCRIPTION
## Summary
- `test_check_logs` didn't override `XDG_CACHE_HOME`, so its `zzz-test-*` fixture packages got written into the real `~/.cache/archcanary/log_hist_seen.txt` on whatever machine runs the suite (a side effect of the `LOG_HIST_SEEN` feature merged in #204).
- A second run of the suite then saw those fixture names as already "seen" and downgraded them to `LOG_HIST_SEEN`, failing 5 assertions that expect a fresh `LOG_HIST` every time — caught by running the suite twice back-to-back after adding the new feature.
- Isolated `XDG_CACHE_HOME` to a per-test tmpdir across all 4 `archcanary.sh` invocations in `test_check_logs`, same pattern `test_check_logs_seen_once` already uses.
- Also manually cleaned the polluted `~/.cache/archcanary/log_hist_seen.txt` on this machine (test fixture names only, harmless, but shouldn't have been there).

## Test plan
- [x] `bash tests/run_matching_tests.sh` — 113 pass, 0 fail
- [x] Ran it a second time immediately after — still 113/0, confirming no cross-run state leakage
- [x] Confirmed the real `~/.cache/archcanary/log_hist_seen.txt` stays untouched by the suite now

🤖 Generated with [Claude Code](https://claude.com/claude-code)