### PR TITLE
docs: drop possessive apostrophe from doctor's hook labels

### DIFF
--- a/archcanary.sh
+++ b/archcanary.sh
@@ -945,7 +945,7 @@ run_doctor() {
         # out.
         local _ARCHCANARY_LUA_MARKER_STABLE='yay 13.0 Lua hooks for the AUR security stack'
         local _ARCHCANARY_LUA_MARKER_CURRENT="$_ARCHCANARY_LUA_MARKER_STABLE (v6)"
-        local _lua_label="yay init.lua (archcanary's hooks: upgrade-age warning, pattern block, aur-audit black/red check, install log)"
+        local _lua_label="yay init.lua (archcanary hooks: upgrade-age warning, pattern block, aur-audit black/red check, install log)"
         _opt_dep "lynis (system hardening auditor)" lynis lynis "post-install hardening audit"
         if [[ "$(_marker "$_ARCHCANARY_LUA_MARKER_CURRENT" "$yay_init_lua")" -eq 0 ]]; then
             _ok "$_lua_label" "path: $yay_init_lua"
@@ -960,7 +960,7 @@ run_doctor() {
             local paru_conf="${XDG_CONFIG_HOME:-$real_home/.config}/paru/paru.conf"
             local _ARCHCANARY_PARU_MARKER_STABLE='archcanary PreBuildCommand hook'
             local _ARCHCANARY_PARU_MARKER_CURRENT="$_ARCHCANARY_PARU_MARKER_STABLE (v1)"
-            local _paru_label="paru PreBuildCommand hook (archcanary's pre-build PKGBUILD scan)"
+            local _paru_label="paru PreBuildCommand hook (archcanary pre-build PKGBUILD scan)"
             if [[ "$(_marker "$_ARCHCANARY_PARU_MARKER_CURRENT" "$paru_conf")" -eq 0 ]]; then
                 _ok "$_paru_label" "path: $paru_conf"
             elif [[ "$(_marker "$_ARCHCANARY_PARU_MARKER_STABLE" "$paru_conf")" -eq 0 ]]; then


### PR DESCRIPTION
## Summary
- Reported live: on a forum user's terminal, `--doctor`'s output showed part of one line and all of the next rendered yellow with no corresponding color code in the source.
- Root cause identified: `"archcanary's hooks..."` and `"archcanary's pre-build..."` are the *only* two apostrophes anywhere in `--doctor`'s printed output. Their terminal-side renderer/highlighter was treating the straight `'` as an unmatched string-quote and highlighting everything through the *next* apostrophe it found — which happened to be the other label, one line down.
- Not an archcanary color-code bug (verified: no color codes wrap those words), but a text-level trap worth avoiding regardless of what's rendering it. Dropped the possessive apostrophe from both labels — `"archcanary's hooks"` → `"archcanary hooks"`, `"archcanary's pre-build"` → `"archcanary pre-build"`.

## Test plan
- [x] `./archcanary.sh --doctor=external` — output reads correctly, no apostrophe remaining
- [x] Confirmed no tests or other docs reference the old exact label text

🤖 Generated with [Claude Code](https://claude.com/claude-code)