### PR TITLE
chore: fill in real sha256 for the v0.1.27 release tarball

### DIFF
--- a/packaging/.SRCINFO
+++ b/packaging/.SRCINFO
@@ -20,6 +20,6 @@ pkgbase = archcanary
 	backup = etc/archcanary/bpftool_allowlist.conf
 	backup = etc/archcanary/autostart_allowlist.conf
 	source = archcanary-0.1.27.tar.gz::https://github.com/musqz/archcanary/archive/v0.1.27.tar.gz
-	sha256sums = 0000000000000000000000000000000000000000000000000000000000000000
+	sha256sums = 738f852901b09a34d18c303e48dd410d680e1cdb958585f915f2149eb44ba870
 
 pkgname = archcanary

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -22,7 +22,7 @@ backup=('etc/archcanary/dkms_allowlist.conf'
         'etc/archcanary/autostart_allowlist.conf')
 install=archcanary.install
 source=("$pkgname-$pkgver.tar.gz::https://github.com/musqz/$pkgname/archive/v$pkgver.tar.gz")
-sha256sums=('0000000000000000000000000000000000000000000000000000000000000000')
+sha256sums=('738f852901b09a34d18c303e48dd410d680e1cdb958585f915f2149eb44ba870')
 
 package() {
   cd "$srcdir/$pkgname-$pkgver"


### PR DESCRIPTION
## Summary
- Follow-up to #208: the `v0.1.27` tag is pushed and the release tarball is live, so this fills in the real `sha256sums` (was a placeholder) in `packaging/PKGBUILD` and regenerates `packaging/.SRCINFO`.
- Tag itself is untouched — this only fills in the checksum, per the standard release order (tag once, never retag, since force-pushing regenerates the tarball with a new hash each time).

## Test plan
- [x] Downloaded `https://github.com/musqz/archcanary/archive/v0.1.27.tar.gz`
- [x] Verified it extracts as `archcanary-0.1.27/` with `version.txt` reading `0.1.27` — confirms it's the right tarball, not stale/incomplete
- [x] `sha256sum` computed: `738f852901b09a34d18c303e48dd410d680e1cdb958585f915f2149eb44ba870`
- [x] `(cd packaging && makepkg --printsrcinfo > .SRCINFO)` — regenerated cleanly, matches `PKGBUILD`

🤖 Generated with [Claude Code](https://claude.com/claude-code)