### PR TITLE
fix: scan-all-homes cross-user list-path leak + unreadable bundled lists

### DIFF
--- a/archcanary.sh
+++ b/archcanary.sh
@@ -1186,16 +1186,23 @@ _run_scan_all_homes() {
         # `sudo`, since sudo's own env_reset/secure_path policy (sudoers is
         # per-machine config, not something to assume about) can silently
         # discard a PATH set only on the invoking side.
+        # Deliberately no --malicious-npm-list/--package-list/--chaos-rat-list/
+        # --russian-spam-list/--community-list here: those default to
+        # $MALICIOUS_NPM_LIST etc. in *this* (root) process, which — thanks to
+        # the SUDO_USER HOME-rebind above — resolve to the invoking user's own
+        # $HOME/.config/archcanary/. Passing them through would point every
+        # other user's child scan at a directory only the invoking user can
+        # read (typically 700), making the list look "missing" and sending the
+        # self-heal `cp` in the bundled-default fallback at a destination it
+        # can't write either — a guaranteed permission-denied, unparseable-JSON
+        # failure for every user but the invoking one. Let each child resolve
+        # its own list paths from its own $HOME instead, same as a standalone
+        # run or archcanary-user.service.
         _sah_json=$(sudo -H -u "$_sah_user" -- env \
                 PATH="$_sah_home/.local/bin:$_sah_home/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin" \
                 "$_sah_bin" \
                 --check-npm-cache --check-bun-cache --check-yarn-cache \
                 --check-pnpm-cache --check-pkgbuild --check-autostart \
-                --malicious-npm-list="$MALICIOUS_NPM_LIST" \
-                --package-list="$PACKAGE_LIST_FILE" \
-                --chaos-rat-list="$CHAOS_RAT_LIST" \
-                --russian-spam-list="$RUSSIAN_SPAM_LIST" \
-                --community-list="$COMMUNITY_REPORTS_LIST" \
                 --no-notify --color=never --format=json \
                 --log-file="$_sah_log" 2>/dev/null) || true
         if [[ -f "$_sah_log" ]]; then

--- a/lib/archcanary-root-install.sh
+++ b/lib/archcanary-root-install.sh
@@ -60,8 +60,16 @@ install-components)
     cp "$REPO_DIR/configs/org.archcanary.policy" /usr/share/polkit-1/actions/
     # Seed the bundled package lists next to the system script so a root scan
     # (system service) finds them — root's $HOME is /root, which is not seeded.
+    # Also the fallback every non-root local user's own first-ever run
+    # self-heals from (_bundled_list_path's third candidate). Explicit 644:
+    # plain `cp` inherits root's umask, which on a restrictive umask (0027)
+    # left these unreadable outside root/root's group — breaking that
+    # self-heal for every user but root.
     for _list in package_list.txt malicious_npm_packages.txt chaos_rat_packages.txt malicious_russian_spam_packages.txt community_reports.txt; do
-        [[ -f "$REPO_DIR/lists/$_list" ]] && cp "$REPO_DIR/lists/$_list" "$SYSTEM_LIB/$_list"
+        if [[ -f "$REPO_DIR/lists/$_list" ]]; then
+            cp "$REPO_DIR/lists/$_list" "$SYSTEM_LIB/$_list"
+            chmod 644 "$SYSTEM_LIB/$_list"
+        fi
     done
 
     # DKMS allowlist — single system-wide file (the kmod audit only runs as root).

--- a/tests/run_matching_tests.sh
+++ b/tests/run_matching_tests.sh
@@ -1272,6 +1272,50 @@ test_bundled_list_path_usr_bin_layout() {
 }
 
 # ---------------------------------------------------------------------------
+# lib/archcanary-root-install.sh's bundled-list seeding loop must leave
+# /usr/lib/archcanary/*.txt world-readable regardless of root's umask at
+# install time. Regression coverage for a real bug: plain `cp` (no explicit
+# mode) inherits the invoking (root) shell's umask, and a restrictive umask
+# (0027, reported live) left these files 640 root:root -- unreadable by any
+# non-root user, breaking _bundled_list_path's system-lib fallback for every
+# local user but root. This only exercises the seeding loop itself (safe to
+# run unprivileged against a temp dir) -- not the rest of the root-only
+# installer, which needs real root and isn't run by this suite.
+# ---------------------------------------------------------------------------
+test_root_install_bundled_lists_world_readable() {
+    local fake_repo fake_lib snippet f mode
+    fake_repo=$(mktemp -d)
+    fake_lib=$(mktemp -d)
+    mkdir -p "$fake_repo/lists"
+    for f in package_list.txt malicious_npm_packages.txt chaos_rat_packages.txt \
+             malicious_russian_spam_packages.txt community_reports.txt; do
+        echo "dummy" > "$fake_repo/lists/$f"
+    done
+
+    snippet=$(sed -n '/^    for _list in package_list\.txt/,/^    done$/p' \
+        "$REPO_DIR/lib/archcanary-root-install.sh")
+
+    ( umask 0027
+      REPO_DIR="$fake_repo" SYSTEM_LIB="$fake_lib"
+      eval "$snippet" )
+
+    local bad=()
+    for f in package_list.txt malicious_npm_packages.txt chaos_rat_packages.txt \
+             malicious_russian_spam_packages.txt community_reports.txt; do
+        mode=$(stat -c '%a' "$fake_lib/$f" 2>/dev/null)
+        [[ "$mode" == "644" ]] || bad+=("$f:${mode:-missing}")
+    done
+
+    if [[ ${#bad[@]} -eq 0 ]]; then
+        pass "root_install: bundled list files are 644 regardless of umask at install time"
+    else
+        fail "root_install: expected 644 on all bundled lists, got: ${bad[*]}"
+    fi
+
+    rm -rf "$fake_repo" "$fake_lib"
+}
+
+# ---------------------------------------------------------------------------
 # RESULT banner wording — regression coverage for a real report: a scan
 # where every check that ran was clean, and the only reason for a non-zero
 # exit code was an optional/root-only check being skipped, still printed
@@ -2503,6 +2547,9 @@ test_check_logs_seen_once
 
 $VERBOSE && msg "--- Test 31: scan-all-homes doesn't leak invoking user's list paths to other users ---"
 test_scan_all_homes_no_cross_user_list_paths
+
+$VERBOSE && msg "--- Test 32: root-install bundled lists are world-readable regardless of umask ---"
+test_root_install_bundled_lists_world_readable
 
 echo "=== Results: $PASS_COUNT PASS, $FAIL_COUNT FAIL ==="
 [[ $FAIL_COUNT -eq 0 ]] || exit 1

--- a/tests/run_matching_tests.sh
+++ b/tests/run_matching_tests.sh
@@ -1861,6 +1861,81 @@ test_scan_all_homes_flag_wiring() {
 }
 
 # ---------------------------------------------------------------------------
+# scan_all_homes must not leak the invoking (root/sudo) process's own list
+# paths into other users' child scans. Regression coverage for a real bug:
+# `sudo archcanary --scan-all-homes`'s $MALICIOUS_NPM_LIST/$PACKAGE_LIST_FILE/
+# etc. resolve to the SUDO_USER's own $HOME/.config/archcanary (via the
+# HOME-rebind earlier in the script) -- fine for that user's own child scan,
+# but a second real account (e.g. a freshly-created `leonie`) has no access
+# into the first user's home. Passing those paths through via
+# --malicious-npm-list=/--package-list=/etc made the file look "missing" to
+# every other user, and the self-heal bundled-default `cp` then also failed
+# (no write access into someone else's home), producing an unparseable
+# WARNING for every user but the invoking one. Fix: don't pass those flags at
+# all -- each child resolves its own list paths from its own $HOME, same as
+# a standalone run or archcanary-user.service.
+# ---------------------------------------------------------------------------
+test_scan_all_homes_no_cross_user_list_paths() {
+    local fns scratch fake_bin fake_passwd argv_log
+    fns=$(mktemp)
+    _sah_extract_fns > "$fns"
+    scratch=$(mktemp -d)
+    fake_bin="$scratch/bin"
+    mkdir -p "$scratch/alice" "$scratch/bob" "$fake_bin"
+
+    fake_passwd="$scratch/passwd"
+    cat > "$fake_passwd" <<EOF
+alice:x:1000:1000::$scratch/alice:/bin/bash
+bob:x:1001:1001::$scratch/bob:/bin/bash
+EOF
+
+    argv_log="$scratch/argv.log"
+    # Fake sudo: -H -u <user> -- <cmd...>. Logs the full argv it was asked to
+    # run instead of execing anything -- this test only cares what
+    # _run_scan_all_homes decided to pass, not a child's actual scan result.
+    cat > "$fake_bin/sudo" <<EOF
+#!/usr/bin/env bash
+shift; shift
+user="\$1"; shift
+shift
+{ printf 'user=%s' "\$user"; printf ' %q' "\$@"; printf '\n'; } >> "$argv_log"
+echo '{}'
+EOF
+    chmod +x "$fake_bin/sudo"
+
+    # Realistic invoking-process state: paths rebound into one real user's
+    # home, exactly like $MALICIOUS_NPM_LIST etc. after the SUDO_USER
+    # HOME-rebind in the real report.
+    PATH="$fake_bin:$PATH" bash -c "
+        source '$fns'
+        _SCAN_ALL_HOMES_TEST_PASSWD='$fake_passwd'
+        _SCAN_ALL_HOMES_TEST_BIN='/usr/bin/true'
+        EXIT_CODE=0
+        _rec() { :; }
+        MALICIOUS_NPM_LIST='/home/vogel/.config/archcanary/malicious_npm_packages.txt'
+        PACKAGE_LIST_FILE='/home/vogel/.config/archcanary/package_list.txt'
+        CHAOS_RAT_LIST='/home/vogel/.config/archcanary/chaos_rat_packages.txt'
+        RUSSIAN_SPAM_LIST='/home/vogel/.config/archcanary/malicious_russian_spam_packages.txt'
+        COMMUNITY_REPORTS_LIST='/home/vogel/.config/archcanary/community_reports.txt'
+        _run_scan_all_homes
+    " >/dev/null 2>&1
+
+    local argv
+    argv=$(cat "$argv_log" 2>/dev/null)
+    if [[ "$argv" == *"user=alice"* && "$argv" == *"user=bob"* && \
+          "$argv" != *"--malicious-npm-list"* && "$argv" != *"--package-list"* && \
+          "$argv" != *"--chaos-rat-list"* && "$argv" != *"--russian-spam-list"* && \
+          "$argv" != *"--community-list"* ]]; then
+        pass "scan_all_homes: per-user child invocations don't leak the invoking user's list paths"
+    else
+        fail "scan_all_homes: expected no --*-list flags in child invocations, argv: $argv"
+    fi
+
+    rm -f "$fns"
+    rm -rf "$scratch"
+}
+
+# ---------------------------------------------------------------------------
 # _refresh_aur_audit — RED-only versions companion file. Regression coverage
 # for the name-only-forever bug: a package's aur-audit RED verdict belongs to
 # a specific version, but configs/yay-init.lua's Lua hook only ever matched
@@ -2425,6 +2500,9 @@ test_refresh_aur_audit_versions_stale_clear
 
 $VERBOSE && msg "--- Test 30: check_logs LOG_HIST seen-once downgrade ---"
 test_check_logs_seen_once
+
+$VERBOSE && msg "--- Test 31: scan-all-homes doesn't leak invoking user's list paths to other users ---"
+test_scan_all_homes_no_cross_user_list_paths
 
 echo "=== Results: $PASS_COUNT PASS, $FAIL_COUNT FAIL ==="
 [[ $FAIL_COUNT -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary
- `_run_scan_all_homes` was forwarding the invoking (sudo) user's `--malicious-npm-list=`/`--package-list=`/`--chaos-rat-list=`/`--russian-spam-list=`/`--community-list=` paths into every other local user's per-user child scan. Those paths resolve into the invoking user's own `~/.config/archcanary` (via the SUDO_USER HOME-rebind), which a second real account has no read access into — the list looked "missing" and the self-heal bundled-default `cp` then also failed writing into someone else's home, producing an unparseable WARNING for every user but the invoking one. Fix: drop those flags so each child resolves its own list paths from its own `$HOME`, matching the `archcanary-user.service` parity `_run_scan_all_homes`'s own comment already describes.
- That fix surfaced a second bug: `lib/archcanary-root-install.sh` seeded `/usr/lib/archcanary/*.txt` (the bundled-default fallback every non-root user's first-ever run self-heals from) with a plain `cp` and no explicit mode, so the result inherited root's umask at install time — on a restrictive umask (0027) that left the files `640 root:root`, unreadable by any non-root user. Fixed with an explicit `chmod 644` after the copy.

Both reproduced live via a fresh bare `leonie` account and `sudo archcanary --scan-all-homes`; now comes back clean.

## Test plan
- [x] `tests/run_matching_tests.sh` — 114 pass, 1 pre-existing unrelated failure (`doctor: expected outdated-yay-init WARN`, confirmed present on master before this branch)
- [x] New regression test: `test_scan_all_homes_no_cross_user_list_paths` — asserts per-user child invocations never carry the `--*-list=` flags
- [x] New regression test: `test_root_install_bundled_lists_world_readable` — asserts the bundled-list seeding loop produces 644 regardless of umask
- [x] Live end-to-end verification with a real second local account (`leonie`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)