### PR TITLE
chore: fill in real sha256 for the v0.1.28 release tarball

### DIFF
--- a/packaging/.SRCINFO
+++ b/packaging/.SRCINFO
@@ -20,6 +20,6 @@ pkgbase = archcanary
 	backup = etc/archcanary/bpftool_allowlist.conf
 	backup = etc/archcanary/autostart_allowlist.conf
 	source = archcanary-0.1.28.tar.gz::https://github.com/musqz/archcanary/archive/v0.1.28.tar.gz
-	sha256sums = 0000000000000000000000000000000000000000000000000000000000000000
+	sha256sums = 6b0b05b904338eacc67041d57309b188149468afa1b8564ae1036e6a21562b4c
 
 pkgname = archcanary

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -22,7 +22,7 @@ backup=('etc/archcanary/dkms_allowlist.conf'
         'etc/archcanary/autostart_allowlist.conf')
 install=archcanary.install
 source=("$pkgname-$pkgver.tar.gz::https://github.com/musqz/$pkgname/archive/v$pkgver.tar.gz")
-sha256sums=('0000000000000000000000000000000000000000000000000000000000000000')
+sha256sums=('6b0b05b904338eacc67041d57309b188149468afa1b8564ae1036e6a21562b4c')
 
 package() {
   cd "$srcdir/$pkgname-$pkgver"


### PR DESCRIPTION
## Summary
- Real sha256 for the `v0.1.28` tag's tarball, replacing the placeholder from #216. Verified the tarball contents (`version.txt` reads `0.1.28`, `pkgver=0.1.28` in `PKGBUILD`, `storageexplorer-bin` present in `community_reports.txt`) before trusting the hash.
- `packaging/.SRCINFO` regenerated.

Does not move the `v0.1.28` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)