### PR TITLE
docs: add aurweb v6.5.0 adoption-review fix to SOURCES.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.29 (unreleased)
+
+- Docs: added aurweb v6.5.0 to `SOURCES.md` (§11.7) — the permanent structural fix for the orphan/instant-adoption takeover pattern (sections 11.1 and 12): package adoption now files a review request a Package Maintainer must grant (auto-rejected after 14 days unactioned) instead of transferring maintainership immediately, and unverified accounts are warned at 7 days and removed at 14. Closes out the "adoption disabled" containment measure from July 2026's second wave with a lasting fix rather than an indefinite lock. Purely AUR-side infrastructure policy — no code or list change in archcanary follows from it.
+
 ## v0.1.28 (2026-08-12)
 
 - Added: `check_pkgbuild_caches` Pattern 9 — flags a PKGBUILD that declares the same `source=()`/`source_$CARCH=()` key more than once. makepkg only ever honors the last assignment, so an earlier one is dead code; a legitimate PKGBUILD never has a reason to declare the same key twice (per-arch keys are tracked separately and don't collide with each other or the bare `source=`, so the normal multi-arch idiom isn't flagged). Prompted by `storageexplorer-bin` (below): a fake `source=('optimizer')` prepended above the real array to stage a git-tracked binary makepkg never actually references — a later push correcting the array would silently arm it.

--- a/SOURCES.md
+++ b/SOURCES.md
@@ -336,6 +336,14 @@ A separate, later campaign from the June 2026 atomic-lockfile/js-digest attack (
 - **Added to:** `lists/community_reports.txt` (2026-08-02), annotated `[community report]` on hit.
 - **Why here and not a dedicated campaign list:** as of 11.2's last update the full scope of this wave isn't known yet — a single confirmed package fits the Community Reports list's stated purpose (11 above) better than a new campaign-specific list, which would imply a settled, bounded scope this wave doesn't have yet. Revisit if/when this wave gets its own confirmed package count and closure, the way the June campaign did.
 
+### 11.7 aurweb v6.5.0 — Adoption Review, the Structural Fix
+- **URL:** https://gitlab.archlinux.org/archlinux/aurweb/-/commits/v6.5.0 (primary — GitLab commit history for the tagged release); https://github.com/archlinux/aurweb (read-only mirror of the same repo)
+- **Date:** Tagged 2026-08-11 (`chore(release): prepare version 6.5.0`, Leonidas Spyropoulos); announced on aur-general and deployed to aur.archlinux.org 2026-08-12.
+- **Author:** Leonidas Spyropoulos, Arch Linux DevOps/aurweb maintainer — confirmed as the commit author for the relevant changes, matching the aur-general announcement's signature (PGP `244740D17C7FD0EC`). No direct message-ID/URL for the aur-general post itself was located; sourced from the forwarded announcement text plus the GitLab commit history that implements it.
+- **Content:** SSH/git push and package adoption are re-enabled (both suspended since 11.1's 2026-07-30 containment measure) — but adoption now files a review request instead of transferring maintainership immediately (`659472f7`, "feat: add adoption request expiry and filtering by request type"): a Package Maintainer must grant it, only one request can be pending per package base, and an unactioned request auto-rejects after 14 days. Separately, unverified accounts get a warning at 7 days and are removed at 14 (`9f700307`, "feat: automatic cleanup for unverified accounts") — explicitly framed as prep for eventual SSO integration and ongoing anti-spam/anti-malicious-account work. Registration itself remains closed for now.
+- **Relevant for:** This is the permanent structural fix for the vulnerability 11.1's "adoption disabled" was only ever a stopgap for — the *orphan/instant-adoption takeover* pattern that both this second wave and the 2018 Acroread incident (section 12) share. Closes out the open thread flagged in 11.6 ("revisit if/when this wave gets its own... closure") for the adoption-lock angle specifically, though 11.2's broader "not a closed incident" caveat about new malicious commits still stands independently.
+- **Not actionable in archcanary:** this is AUR-side infrastructure/policy, not something a client-side scanner interacts with — no code or list change follows from it. Documented here purely for the incident timeline.
+
 ---
 
 ## 12. Acroread (2018) — Orphan Package Takeover


### PR DESCRIPTION
## Summary
- Documents aurweb v6.5.0 (SOURCES.md §11.7) — the permanent structural fix for the orphan/instant-adoption takeover pattern (sections 11.1, 12): package adoption now files a review request a Package Maintainer must grant (auto-rejected after 14 days unactioned), and unverified accounts are warned at 7 days and removed at 14. Closes the "adoption disabled" containment measure from the July 2026 second wave with a lasting fix instead of an indefinite lock.
- Cites the GitLab commit history for the `v6.5.0` tag as the primary source (verifiable against the actual code, e.g. `659472f7` adoption-expiry, `9f700307` account cleanup) plus the GitHub mirror as secondary — no public archive link for the original aur-general email itself was located, noted explicitly.
- Purely AUR-side infrastructure/policy — no code or list change in archcanary follows from it. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)