### PR TITLE
fix: don't flag source+=() as duplicate source=() in PKGBUILD scan

### DIFF
--- a/archcanary.sh
+++ b/archcanary.sh
@@ -2682,9 +2682,25 @@ check_pkgbuild_caches() {
             # bin prepended a fake source=('optimizer') above the real
             # source=() to stage a git-tracked binary makepkg never actually
             # references -- a later push correcting the array would arm it.
-            if $_is_pkgbuild && [[ "$line" =~ ^[[:space:]]*(source(_[A-Za-z0-9_]+)?)\+?=\( ]]; then
+            # Only a bare `=` is destructive -- it unconditionally replaces
+            # the whole array, silently discarding anything assigned to the
+            # same key before it (via `=` or `+=`). `source+=(...)` never
+            # discards anything, so it must never itself trip this check
+            # (e.g. vscodium-bin's legitimate source=(...) then
+            # source+=("...code.svg")) -- but a prior `+=` still counts as
+            # "already assigned" for the purpose of catching a *later* bare
+            # `=` that wipes it out, since `source+=('optimizer')` staged
+            # before the real `source=(...)` is the storageexplorer-bin
+            # attack with the two operators swapped, not a different case.
+            # Known limitation: `unset source` between two assignments resets
+            # the array outside what this line-by-line tracker models, so
+            # `source=(A); unset source; source+=(B)` still isn't caught --
+            # not worth chasing further; Pattern 9 is a best-effort heuristic
+            # like the others in this scan, not an adversarial-proof parser.
+            if $_is_pkgbuild && [[ "$line" =~ ^[[:space:]]*(source(_[A-Za-z0-9_]+)?)(\+?)=\( ]]; then
                 local _key="${BASH_REMATCH[1]}"
-                if [[ -n "${_source_seen[$_key]:-}" ]]; then
+                local _is_append="${BASH_REMATCH[3]}"
+                if [[ -z "$_is_append" && -n "${_source_seen[$_key]:-}" ]]; then
                     _dup_source_key="$_key"
                 fi
                 _source_seen["$_key"]=1

--- a/tests/fake_pkgbuilds/pkg-source-append-before-dup/PKGBUILD
+++ b/tests/fake_pkgbuilds/pkg-source-append-before-dup/PKGBUILD
@@ -1,0 +1,11 @@
+# Maintainer: Someone <someone@example.com>
+pkgname=pkg-source-append-before-dup
+pkgver=1.0
+pkgrel=1
+arch=('x86_64')
+source+=('optimizer')
+source=('https://example.com/pkg-1.0.tar.gz')
+sha256sums=('0000000000000000000000000000000000000000000000000000000000000000')
+package() {
+    install -m 755 "pkg-1.0/pkg" "${pkgdir}/usr/bin/pkg"
+}

--- a/tests/fake_pkgbuilds/pkg-source-append/PKGBUILD
+++ b/tests/fake_pkgbuilds/pkg-source-append/PKGBUILD
@@ -1,0 +1,13 @@
+# Maintainer: Someone <someone@example.com>
+pkgname=pkg-source-append
+pkgver=1.0
+pkgrel=1
+arch=('x86_64')
+source=('pkg.desktop' 'pkg.install')
+source+=("https://example.com/icon.svg")
+sha256sums=('0000000000000000000000000000000000000000000000000000000000000000'
+            '0000000000000000000000000000000000000000000000000000000000000000'
+            '0000000000000000000000000000000000000000000000000000000000000000')
+package() {
+    install -m 755 "pkg-1.0/pkg" "${pkgdir}/usr/bin/pkg"
+}

--- a/tests/run_matching_tests.sh
+++ b/tests/run_matching_tests.sh
@@ -1023,6 +1023,37 @@ test_pkgbuild_obfuscation() {
     else
         fail "pkgbuild_obfuscation: per-arch source_\$CARCH=() incorrectly flagged, rc=$rc, out: $out"
     fi
+
+    # Sub-test N: source=() followed by source+=(...) (idiomatic array
+    # append) -> NOT flagged. Regression guard for a real false positive
+    # reported live on vscodium-bin: its PKGBUILD declares source=(...) then
+    # appends one more entry via source+=("...code.svg"), which the
+    # duplicate-source regex used to conflate with a second cold source=()
+    # declaration since its capture group didn't distinguish "=" from "+=".
+    rc=0
+    out=$(PKGBUILD_CACHE_DIRS="$fixtures/pkg-source-append" \
+        "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
+    if [[ "$out" == *"Clean"* && "$out" != *"WARNING"* && "$out" != *"duplicate"* ]]; then
+        pass "pkgbuild_obfuscation: source=() then source+=() append not flagged as duplicate"
+    else
+        fail "pkgbuild_obfuscation: source=() then source+=() append incorrectly flagged, rc=$rc, out: $out"
+    fi
+
+    # Sub-test O: source+=('optimizer') staged BEFORE the real source=(...)
+    # -> WARNING. Regression guard for the storageexplorer-bin attack with
+    # the two operators swapped: source+=(...) on an as-yet-unset array is
+    # bash-equivalent to source=(...), so a fake entry staged via += before
+    # a later bare source=() is silently discarded exactly like the
+    # already-caught two-bare-= case (Sub-test L) -- the Sub-test N fix must
+    # not blind the check to this ordering just because a `+=` is involved.
+    rc=0
+    out=$(PKGBUILD_CACHE_DIRS="$fixtures/pkg-source-append-before-dup" \
+        "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
+    if [[ $rc -eq 2 && "$out" == *"WARNING: duplicate source=() declaration in"* ]]; then
+        pass "pkgbuild_obfuscation: source+=() staged before real source=() detected as duplicate"
+    else
+        fail "pkgbuild_obfuscation: source+=() staged before real source=() not detected, rc=$rc, out: $out"
+    fi
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Pattern 9's duplicate-`source=()` detector collapsed `source=(...)` and `source+=(...)` into the same key, so a legitimate `source=(...)` followed by `source+=(...)` (e.g. vscodium-bin appending one extra file) tripped the "duplicate source=() declaration" warning.
- Fix: only a bare `=` is destructive (it overwrites the whole array); `+=` never discards prior content, so it must never self-trigger the check. A prior `+=` still arms a later bare `=` as a duplicate, so the storageexplorer-bin attack shape (a fake entry silently discarded by a later real declaration) is still caught even with the operators swapped.

## Test plan
- [x] `tests/run_matching_tests.sh` — 137/137 pass, including two new sub-tests (N/O) covering the false positive and the operators-swapped attack variant
- [x] Verified against the real cached vscodium-bin PKGBUILD that originally triggered this — now scans clean
- [x] Reporter (musqz) re-ran `./archcanary.sh --refresh --full` locally and confirms the PKGBUILD warning is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)