### PR TITLE
chore: set real sha256 for v0.1.29 tarball

### DIFF
--- a/packaging/.SRCINFO
+++ b/packaging/.SRCINFO
@@ -20,6 +20,6 @@ pkgbase = archcanary
 	backup = etc/archcanary/bpftool_allowlist.conf
 	backup = etc/archcanary/autostart_allowlist.conf
 	source = archcanary-0.1.29.tar.gz::https://github.com/musqz/archcanary/archive/v0.1.29.tar.gz
-	sha256sums = SKIP
+	sha256sums = 4a043acdc8eafdcdcc8b13adeb26cd38e54c0b54ea6f12e3feed5655beae107c
 
 pkgname = archcanary

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -22,7 +22,7 @@ backup=('etc/archcanary/dkms_allowlist.conf'
         'etc/archcanary/autostart_allowlist.conf')
 install=archcanary.install
 source=("$pkgname-$pkgver.tar.gz::https://github.com/musqz/$pkgname/archive/v$pkgver.tar.gz")
-sha256sums=('SKIP')
+sha256sums=('4a043acdc8eafdcdcc8b13adeb26cd38e54c0b54ea6f12e3feed5655beae107c')
 
 package() {
   cd "$srcdir/$pkgname-$pkgver"


### PR DESCRIPTION
chore: set real sha256 for v0.1.29 tarball

Second step of the standard 2-PR release flow for v0.1.29 — the tag (already pushed, pointing at PR #222's merge commit) is not moved by this PR.

## Summary

Verified the actual tagged tarball before trusting its hash: extracted `version.txt` (0.1.29) and `CHANGELOG.md` (heading `v0.1.29 (2026-08-24)`) from `https://github.com/musqz/archcanary/archive/v0.1.29.tar.gz`, confirmed both match, then computed the real sha256 and set it in `packaging/PKGBUILD` (was `SKIP`), regenerating `.SRCINFO`.

## For code changes

- [x] Ran `bash tests/run_matching_tests.sh` (for `archcanary.sh` changes) — N/A, packaging-only change
- [ ] Updated `--help`/man page/README if user-facing behavior changed — N/A