### PR TITLE
fix: ship yay-init.lua as a system-wide template, fix doctor hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.1.30 (unreleased)
+
+- Changed: the yay Lua hook template (`configs/yay-init.lua`) is now also shipped read-only to `/usr/lib/archcanary/yay-init.lua` (AUR package and `install.sh --system`), same pattern as `lynis-custom.prf`. v0.1.29 stopped seeding `~/.config/yay/init.lua` automatically (correctly — it's a per-user path no install step should reach, and the hook is opt-in) but left AUR-only installs with no local copy to `cp` from at all. `archcanary --doctor` now resolves the fix command against this path when no git clone is present.
+- Fix: `archcanary --doctor` printed no actionable guidance at all when `~/.config/yay/init.lua` was simply never installed (the common case) — just a silent `[OPT ]` line. Now prints a one-line `cp` command to enable it (falling back to a plain-language pointer at the GitHub repo when neither a git clone nor the new system template is present, rather than embedding a `# comment`-truncated, non-pasteable command — the same latent bug this also fixed in the pre-existing "outdated copy" warning).
+
 ## v0.1.29 (2026-08-24)
 
 - Added: `check_pkgbuild_caches` gained four patterns — Tor/SOCKS-proxied fetches (`curl -x socks5h://...`, `torsocks`, bare `.onion` URLs), downloads written straight into a system path (`/usr`, `/etc`, `/opt`, `/boot`) instead of the makepkg build sandbox, references to the AUR's own git SSH remote (`aur@aur.archlinux.org`), and non-interactive `pacman` calls (`--noconfirm`) from inside a scriptlet. Prompted by the `xsnow`/`xsnow-bin` AUR incident (2026-08-23, aur-general mailing list): a dot-prefixed `.install` scriptlet pulled a payload binary through Tor into `/usr/local/bin`, then harvested every local user's SSH keys to self-propagate a trojaned `install=` field into other AUR repos reachable with them. Both curl/tor patterns account for bundled short-option style (`-fsSLx`, `-fsSLo`) and a delimiter-less end-of-line `.onion` host — both evasions found and fixed during review before merge.

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -744,7 +744,21 @@ run_doctor() {
         installer="install.sh  # (cd to the archcanary repo first)"
         installer_sys="install.sh --system  # (cd to the archcanary repo first)"
     fi
-    [[ -f $luasrc ]] || luasrc="configs/yay-init.lua  # (from the archcanary repo)"
+    # Not run from a clone (AUR install): fall back to the read-only template
+    # the package ships at /usr/lib/archcanary/yay-init.lua so there's still
+    # something to `cp` from without needing a git clone. (Not reusing
+    # _bundled_list_path for this — it's defined much later in this script,
+    # past the --doctor dispatch's own `exit`, so it isn't callable yet.)
+    # luasrc_found tracks whether $luasrc is an actual file — when it's
+    # neither, no path is safe to embed in a literal `cp` command below.
+    local luasrc_found=1
+    if [[ ! -f $luasrc ]]; then
+        if [[ -f /usr/lib/archcanary/yay-init.lua ]]; then
+            luasrc="/usr/lib/archcanary/yay-init.lua"
+        else
+            luasrc_found=0
+        fi
+    fi
 
     # --- Section selection -------------------------------------------------
     # Sections are listed in install order (prerequisite chain) so a full run
@@ -1012,23 +1026,35 @@ run_doctor() {
         # comment (not a public API, just this project's own convention) — if
         # that header ever changes, bump these too. STABLE prefix-matches any
         # archcanary-authored version; CURRENT matches only the exact latest
-        # one, so a present-but-outdated copy (install.sh never overwrites an
-        # existing init.lua — see docs/my-setup.md, "yay 13.0 integration")
-        # is distinguishable from "never installed". This check fails
-        # silently (reports a working hook as missing) rather than erroring
-        # out.
+        # one, so a present-but-outdated copy is distinguishable from "never
+        # installed". Nothing ever writes $yay_init_lua automatically — it's
+        # a per-user path no install path can reach, and the hook is opt-in
+        # either way (see docs/my-setup.md, "yay 13.0 integration") — so
+        # "never installed" is the common, unremarkable case, not a failure.
+        # This check fails silently (reports a working hook as missing)
+        # rather than erroring out.
         local _ARCHCANARY_LUA_MARKER_STABLE='yay 13.0 Lua hooks for the AUR security stack'
         local _ARCHCANARY_LUA_MARKER_CURRENT="$_ARCHCANARY_LUA_MARKER_STABLE (v9)"
         local _lua_label="yay init.lua (archcanary hooks: upgrade-age warning, pattern block, aur-audit black/red check, install log)"
+        # No local copy at all (neither a git clone nor an AUR/--system
+        # install) — nothing safe to embed in a literal `cp` command.
+        local _lua_fix
+        if [[ $luasrc_found -eq 1 ]]; then
+            _lua_fix="cp $luasrc $yay_init_lua"
+        else
+            _lua_fix="grab configs/yay-init.lua from https://github.com/musqz/archcanary, then cp it to $yay_init_lua"
+        fi
         _opt_dep "lynis (system hardening auditor)" lynis lynis "post-install hardening audit"
         if [[ "$(_marker "$_ARCHCANARY_LUA_MARKER_CURRENT" "$yay_init_lua")" -eq 0 ]]; then
             _ok "$_lua_label" "path: $yay_init_lua"
         elif [[ "$(_marker "$_ARCHCANARY_LUA_MARKER_STABLE" "$yay_init_lua")" -eq 0 ]]; then
             _warn "$_lua_label (outdated)" \
-                "cp $luasrc $yay_init_lua   # merge in any of your own customizations first" \
+                "$_lua_fix   # merge in any of your own customizations first" \
                 "$yay_init_lua's archcanary-managed hooks are from an older version"
         else
-            _opt "$_lua_label" "" "path: $yay_init_lua"
+            _opt "$_lua_label" \
+                "$_lua_fix" \
+                "not installed — hooks are opt-in, never installed automatically; path once enabled: $yay_init_lua"
         fi
         if command -v paru >/dev/null 2>&1; then
             local paru_conf="${XDG_CONFIG_HOME:-$real_home/.config}/paru/paru.conf"

--- a/configs/yay-init.lua
+++ b/configs/yay-init.lua
@@ -1,13 +1,19 @@
--- ~/.config/yay/init.lua
+-- Template for ~/.config/yay/init.lua — yay's own hook filename, hardcoded
+-- by yay itself (not archcanary's choice). This file is never copied there
+-- automatically by any archcanary install path (AUR package or install.sh):
+-- it's your per-user yay config, and the hook is opt-in. Copy it yourself:
+--   cp configs/yay-init.lua ~/.config/yay/init.lua      # from a git clone
+--   cp /usr/lib/archcanary/yay-init.lua ~/.config/yay/init.lua   # AUR package
+-- `archcanary --doctor` prints the exact command for your install and flags
+-- an existing copy as outdated when the hooks below have moved on.
 --
 -- yay 13.0 Lua hooks for the AUR security stack (v9).
--- Seeded to ~/.config/yay/init.lua by install.sh if not already present.
 -- An offline backstop that runs on every AUR install/upgrade: warns on
 -- recently-modified PKGBUILDs and blocks known malicious patterns before
 -- build. See docs/my-setup.md, "yay 13.0 integration".
 --
 -- Version marker above (the "(vN)" suffix) is checked by `--doctor` to
--- detect a stale local copy, since install.sh never overwrites an existing
+-- detect a stale local copy, since nothing ever overwrites an existing
 -- init.lua. Bump it whenever the hooks below change; never touch the text
 -- before "(vN)", since --doctor also prefix-matches on that stable part to
 -- tell "some archcanary version present" from "never installed".

--- a/docs/my-setup.md
+++ b/docs/my-setup.md
@@ -178,7 +178,17 @@ sudo pacman -S libnotify bpf yad polkit
 
 ## yay 13.0 integration
 
-The yay 13.0 Lua hooks (`~/.config/yay/init.lua`) — seeded by `install.sh` **only if the file doesn't already exist** (source: [`configs/yay-init.lua`](../configs/yay-init.lua)). If you already have an `init.lua` from before a hook was added here, `install.sh` won't retrofit it — re-copy `configs/yay-init.lua` by hand (merging in any of your own customizations) to pick up new hooks. An offline backstop that fires on every AUR build:
+The yay 13.0 Lua hooks (`~/.config/yay/init.lua`) — **never installed automatically**, by either the AUR package or `install.sh`: it's a per-user path no install path can reach, and the hook is opt-in regardless. Copy the template in yourself:
+
+```bash
+# from a git clone
+cp configs/yay-init.lua ~/.config/yay/init.lua
+
+# from the AUR package
+cp /usr/lib/archcanary/yay-init.lua ~/.config/yay/init.lua
+```
+
+`archcanary --doctor` prints the exact command for your install (source: [`configs/yay-init.lua`](../configs/yay-init.lua)) and re-copy it by hand (merging in any of your own customizations) whenever `--doctor` flags your copy as outdated — nothing ever overwrites an existing `init.lua` for you. An offline backstop that fires on every AUR build:
 
 | Hook | Event | What it does |
 |------|-------|--------------|
@@ -208,7 +218,6 @@ git clone https://github.com/musqz/archcanary.git ~/Github/archcanary
 sudo pacman -S libnotify bpf yad polkit
 
 # 3. Run install script (installs to ~/.local/bin by default)
-#    Also seeds ~/.config/yay/init.lua if not already present
 bash ~/Github/archcanary/install.sh
 
 # Also install root helper + polkit policy (enables eBPF/kmod checks in the GUI)

--- a/install.sh
+++ b/install.sh
@@ -235,7 +235,8 @@ done
 
 # Seed paru's PreBuildCommand hook — only when paru is actually installed.
 # Never touches an existing PreBuildCommand line, ours or the user's own,
-# at any version — same "never overwrite" rule as yay's init.lua above.
+# at any version. (yay's equivalent, configs/yay-init.lua, is never seeded
+# here at all — copy it in yourself, see `archcanary --doctor`.)
 if command -v paru >/dev/null 2>&1; then
     PARU_CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/paru"
     PARU_CONF="$PARU_CONFIG_DIR/paru.conf"

--- a/lib/archcanary-root-install.sh
+++ b/lib/archcanary-root-install.sh
@@ -57,6 +57,10 @@ install-components)
     chmod 755 "$SYSTEM_LIB/root-helper"
     install -m 644 "$REPO_DIR/configs/lynis-custom.prf" \
         "$SYSTEM_LIB/lynis-custom.prf"
+    # yay Lua hook template — read-only reference copy, never installed to
+    # ~/.config/yay/init.lua automatically (per-user path, hooks are opt-in).
+    install -m 644 "$REPO_DIR/configs/yay-init.lua" \
+        "$SYSTEM_LIB/yay-init.lua"
     cp "$REPO_DIR/configs/org.archcanary.policy" /usr/share/polkit-1/actions/
     # Seed the bundled package lists next to the system script so a root scan
     # (system service) finds them — root's $HOME is /root, which is not seeded.
@@ -169,6 +173,7 @@ EOF
     echo "  installed: $SYSTEM_LIB/archcanary.sh"
     echo "  installed: $SYSTEM_LIB/root-helper"
     echo "  installed: $SYSTEM_LIB/lynis-custom.prf (template for /etc/lynis/custom.prf)"
+    echo "  installed: $SYSTEM_LIB/yay-init.lua (template — cp to ~/.config/yay/init.lua yourself to enable, see --doctor)"
     echo "  installed: $SYSTEM_LIB/{package_list,malicious_npm_packages,chaos_rat_packages,malicious_russian_spam_packages,community_reports}.txt"
     echo "  installed: /etc/archcanary/dkms_allowlist.conf (system-wide DKMS allowlist for the root scan)"
     echo "  installed: /etc/archcanary/systemd_allowlist.conf (system-wide systemd allowlist for the persistence check)"

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -59,6 +59,13 @@ package() {
     "$pkgdir/usr/lib/archcanary/lynis-custom.prf"
   install -Dm644 configs/audit-rules.conf \
     "$pkgdir/usr/lib/archcanary/audit-rules.conf"
+  # yay Lua hook template — read-only reference copy, never installed to
+  # ~/.config/yay/init.lua automatically (that's a per-user path a pacman
+  # transaction can't reach, and hooks are opt-in either way). Lets an
+  # AUR-only install (no git clone) still have something to `cp`; see
+  # `archcanary --doctor`.
+  install -Dm644 configs/yay-init.lua \
+    "$pkgdir/usr/lib/archcanary/yay-init.lua"
 
   # Polkit policy (authorises root-helper via pkexec)
   install -Dm644 configs/org.archcanary.policy \


### PR DESCRIPTION
v0.1.29 correctly stopped auto-seeding ~/.config/yay/init.lua (a per-user path no install step should reach; the hook is opt-in), but that left an AUR-only install with no local copy to `cp` from at all, and --doctor's "not installed" case printed no guidance whatsoever.

Ship configs/yay-init.lua read-only to /usr/lib/archcanary/yay-init.lua (AUR package + install.sh --system), same pattern as lynis-custom.prf. --doctor now prints a working one-line `cp` fix in every case: git clone, AUR/system install, or neither (falls back to a plain pointer at the repo instead of a `# comment`-truncated command — the same latent bug this also fixes in the pre-existing "outdated copy" warning).

## Summary

<!-- What does this PR do? For a community_reports.txt addition, the
     package name(s) plus the checklist below is enough. -->

## If this adds to `lists/community_reports.txt`

- [ ] Package name is exact (matches the AUR package name / `pacman -Qm` output)
- [ ] Evidence is linked below — an AUR comment, mailing-list post, PKGBUILD diff, or writeup, not just suspicion
- [ ] Checked it isn't already in `package_list.txt`, `chaos_rat_packages.txt`, `malicious_russian_spam_packages.txt`, or `community_reports.txt`

**Evidence:** <!-- link(s) here -->

## For code changes

- [ ] Ran `bash tests/run_matching_tests.sh` (for `archcanary.sh` changes)
- [ ] Updated `--help`/man page/README if user-facing behavior changed
