### PR TITLE
fix: don't suggest overwriting a user's own yay init.lua

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Changed: the yay Lua hook template (`configs/yay-init.lua`) is now also shipped read-only to `/usr/lib/archcanary/yay-init.lua` (AUR package and `install.sh --system`), same pattern as `lynis-custom.prf`. v0.1.29 stopped seeding `~/.config/yay/init.lua` automatically (correctly — it's a per-user path no install step should reach, and the hook is opt-in) but left AUR-only installs with no local copy to `cp` from at all. `archcanary --doctor` now resolves the fix command against this path when no git clone is present.
 - Fix: `archcanary --doctor` printed no actionable guidance at all when `~/.config/yay/init.lua` was simply never installed (the common case) — just a silent `[OPT ]` line. Now prints a one-line `cp` command to enable it (falling back to a plain-language pointer at the GitHub repo when neither a git clone nor the new system template is present, rather than embedding a `# comment`-truncated, non-pasteable command — the same latent bug this also fixed in the pre-existing "outdated copy" warning).
+- Fix: the "not installed" `--doctor` fix above couldn't tell a truly missing `~/.config/yay/init.lua` from one that exists but isn't archcanary's (a hand-written yay 13.0 Lua hook, or a copy predating the marker convention) — both looked identical to `_marker`'s grep, so the "not installed" text was wrong and the suggested `cp` would have silently overwritten the user's own file if pasted. Now a third state: present-but-foreign gets its own message and a non-destructive "merge by hand" fix instead of a blind `cp`.
 
 ## v0.1.29 (2026-08-24)
 

--- a/archcanary.sh
+++ b/archcanary.sh
@@ -1038,11 +1038,16 @@ run_doctor() {
         local _lua_label="yay init.lua (archcanary hooks: upgrade-age warning, pattern block, aur-audit black/red check, install log)"
         # No local copy at all (neither a git clone nor an AUR/--system
         # install) — nothing safe to embed in a literal `cp` command.
-        local _lua_fix
+        # _lua_source_hint names the same resolved source in prose, for the
+        # "merge by hand" branch below, which can't just reuse _lua_fix
+        # verbatim since that one's a `cp` (i.e. overwrite) command.
+        local _lua_fix _lua_source_hint
         if [[ $luasrc_found -eq 1 ]]; then
             _lua_fix="cp $luasrc $yay_init_lua"
+            _lua_source_hint="$luasrc"
         else
             _lua_fix="grab configs/yay-init.lua from https://github.com/musqz/archcanary, then cp it to $yay_init_lua"
+            _lua_source_hint="configs/yay-init.lua (https://github.com/musqz/archcanary)"
         fi
         _opt_dep "lynis (system hardening auditor)" lynis lynis "post-install hardening audit"
         if [[ "$(_marker "$_ARCHCANARY_LUA_MARKER_CURRENT" "$yay_init_lua")" -eq 0 ]]; then
@@ -1051,6 +1056,15 @@ run_doctor() {
             _warn "$_lua_label (outdated)" \
                 "$_lua_fix   # merge in any of your own customizations first" \
                 "$yay_init_lua's archcanary-managed hooks are from an older version"
+        elif [[ -e $yay_init_lua ]]; then
+            # Present but no archcanary marker at all — could be the user's
+            # own hand-written yay 13.0 hooks (yay 13.0's Lua hook support is
+            # its headline feature) or a copy from before markers existed.
+            # Either way it's not ours to overwrite: no `cp` suggestion here,
+            # unlike the two branches above/below.
+            _opt "$_lua_label (present, not archcanary-managed)" \
+                "back it up, then merge in the hooks from $_lua_source_hint by hand — see docs/my-setup.md, \"yay 13.0 integration\"" \
+                "$yay_init_lua exists without archcanary's marker — not overwriting it automatically"
         else
             _opt "$_lua_label" \
                 "$_lua_fix" \

--- a/docs/my-setup.md
+++ b/docs/my-setup.md
@@ -188,7 +188,7 @@ cp configs/yay-init.lua ~/.config/yay/init.lua
 cp /usr/lib/archcanary/yay-init.lua ~/.config/yay/init.lua
 ```
 
-`archcanary --doctor` prints the exact command for your install (source: [`configs/yay-init.lua`](../configs/yay-init.lua)) and re-copy it by hand (merging in any of your own customizations) whenever `--doctor` flags your copy as outdated — nothing ever overwrites an existing `init.lua` for you. An offline backstop that fires on every AUR build:
+`archcanary --doctor` prints the exact command for your install (source: [`configs/yay-init.lua`](../configs/yay-init.lua)). Re-copy it by hand (merging in any of your own customizations) whenever `--doctor` flags your copy as outdated — nothing ever overwrites an existing `init.lua` for you, whether it's an older archcanary copy or hooks you wrote yourself. An offline backstop that fires on every AUR build:
 
 | Hook | Event | What it does |
 |------|-------|--------------|


### PR DESCRIPTION
--doctor's yay-init.lua check couldn't tell "truly missing" from "present but not archcanary's" (a hand-written yay 13.0 Lua hook, or a copy predating the marker convention) — _marker's grep returns non-zero for both, so the "not installed" branch fired either way and suggested a plain `cp` that would silently clobber the user's own file if pasted.

Add a third state: present-but-foreign gets its own message and a non-destructive "merge by hand" fix, correctly naming the resolved source (git clone / AUR system template / GitHub) instead of a hardcoded configs/yay-init.lua path that doesn't exist on an AUR-only install.

Also fixes a subject/mood mismatch in docs/my-setup.md's --doctor sentence.

## Summary

<!-- What does this PR do? For a community_reports.txt addition, the
     package name(s) plus the checklist below is enough. -->

## If this adds to `lists/community_reports.txt`

- [ ] Package name is exact (matches the AUR package name / `pacman -Qm` output)
- [ ] Evidence is linked below — an AUR comment, mailing-list post, PKGBUILD diff, or writeup, not just suspicion
- [ ] Checked it isn't already in `package_list.txt`, `chaos_rat_packages.txt`, `malicious_russian_spam_packages.txt`, or `community_reports.txt`

**Evidence:** <!-- link(s) here -->

## For code changes

- [ ] Ran `bash tests/run_matching_tests.sh` (for `archcanary.sh` changes)
- [ ] Updated `--help`/man page/README if user-facing behavior changed
