### PR TITLE
chore: set real sha256 for v0.1.30 tarball

### DIFF
--- a/packaging/.SRCINFO
+++ b/packaging/.SRCINFO
@@ -20,6 +20,6 @@ pkgbase = archcanary
 	backup = etc/archcanary/bpftool_allowlist.conf
 	backup = etc/archcanary/autostart_allowlist.conf
 	source = archcanary-0.1.30.tar.gz::https://github.com/musqz/archcanary/archive/v0.1.30.tar.gz
-	sha256sums = SKIP
+	sha256sums = 119bdc0cd3c5c5cf6fa4c776f9c7e46476d0659d14bc4cb3f56d7d64a504045f
 
 pkgname = archcanary

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -22,7 +22,7 @@ backup=('etc/archcanary/dkms_allowlist.conf'
         'etc/archcanary/autostart_allowlist.conf')
 install=archcanary.install
 source=("$pkgname-$pkgver.tar.gz::https://github.com/musqz/$pkgname/archive/v$pkgver.tar.gz")
-sha256sums=('SKIP')
+sha256sums=('119bdc0cd3c5c5cf6fa4c776f9c7e46476d0659d14bc4cb3f56d7d64a504045f')
 
 package() {
   cd "$srcdir/$pkgname-$pkgver"


### PR DESCRIPTION
## Summary
- Fill in the real sha256 for the v0.1.30 release tarball (tag pushed, tarball verified against `version.txt` before hashing)

## Test plan
- [x] Downloaded https://github.com/musqz/archcanary/archive/v0.1.30.tar.gz, confirmed it extracts and `version.txt` reads 0.1.30
- [x] `makepkg --printsrcinfo` regenerated cleanly, matches PKGBUILD

🤖 Generated with [Claude Code](https://claude.com/claude-code)