### PR TITLE
fix: run --run-lynis output filter under LC_ALL=C

### DIFF
--- a/archcanary.sh
+++ b/archcanary.sh
@@ -1106,8 +1106,12 @@ if $RUN_LYNIS; then
     # Can't use exec: pipe through sed to strip non-ASCII block chars (▆ etc.)
     # for terminal-safety across encodings. pipefail off so set -e doesn't
     # fire on lynis's own exit code before we can capture it.
+    # LC_ALL=C is required: sed's \xHH bracket-expression ranges are
+    # misinterpreted under a UTF-8 locale (the default on Arch), silently
+    # eating runs of ordinary ASCII letters/digits instead of only the
+    # intended non-ASCII bytes.
     set +o pipefail
-    lynis audit system --no-colors 2>&1 | sed 's/\x1b\[[0-9;]*[a-zA-Z]//g; s/[^\x09\x0A\x0D\x20-\x7E]//g'
+    lynis audit system --no-colors 2>&1 | LC_ALL=C sed 's/\x1b\[[0-9;]*[a-zA-Z]//g; s/[^\x09\x0A\x0D\x20-\x7E]//g'
     _lynis_exit="${PIPESTATUS[0]}"
     # Lynis exit 2 = "found suggestions/warnings" — normal for a hardening audit,
     # not a malware signal. Map to 1 (warnings), not 2 (infected).


### PR DESCRIPTION
sed's \xHH bracket-expression byte ranges get misinterpreted under a UTF-8 locale (the Arch default), silently eating runs of ordinary ASCII letters/digits from the lynis output instead of only the intended non-ASCII block characters and ANSI cursor-alignment codes. Reported as garbled `--run-lynis` output; same sed line predates the TUI rewrite (originally added for the yad GUI), so it was never locale-safe. Forcing LC_ALL=C on that one sed invocation fixes it.

## Summary

<!-- What does this PR do? For a community_reports.txt addition, the
     package name(s) plus the checklist below is enough. -->

## If this adds to `lists/community_reports.txt`

- [ ] Package name is exact (matches the AUR package name / `pacman -Qm` output)
- [ ] Evidence is linked below — an AUR comment, mailing-list post, PKGBUILD diff, or writeup, not just suspicion
- [ ] Checked it isn't already in `package_list.txt`, `chaos_rat_packages.txt`, `malicious_russian_spam_packages.txt`, or `community_reports.txt`

**Evidence:** <!-- link(s) here -->

## For code changes

- [ ] Ran `bash tests/run_matching_tests.sh` (for `archcanary.sh` changes)
- [ ] Updated `--help`/man page/README if user-facing behavior changed
