### PR TITLE
fix: exclude own test fixtures from PKGBUILD/install cache scan

### DIFF
--- a/archcanary.sh
+++ b/archcanary.sh
@@ -2818,7 +2818,16 @@ check_pkgbuild_caches() {
     done < <(
         for dir in "${cache_dirs[@]}"; do
             [[ -d "$dir" ]] || continue
-            find "$dir" \( -name "PKGBUILD" -o -name "*.install" \) -type f 2>/dev/null
+            # -path match is relative to $dir's own descendants, so this only
+            # prunes tests/fake_pkgbuilds/ when it's nested *inside* a cached
+            # AUR build (e.g. archcanary's own AUR source tree). It never
+            # matches when a test harness points PKGBUILD_CACHE_DIRS directly
+            # at a fixture dir under tests/fake_pkgbuilds/ -- that path is an
+            # ancestor of $dir there, not a descendant, so find never walks
+            # into it. Without this, archcanary scanning its own cached AUR
+            # build flags its own obfuscation-technique test fixtures as if
+            # they were a real package's malicious PKGBUILD.
+            find "$dir" \( -path '*/tests/fake_pkgbuilds' -prune \) -o \( -name "PKGBUILD" -o -name "*.install" \) -type f -print 2>/dev/null
         done
     )
 
@@ -2865,7 +2874,8 @@ check_pkgbuild_caches() {
     done < <(
         for dir in "${cache_dirs[@]}"; do
             [[ -d "$dir" ]] || continue
-            find "$dir" -name "PKGBUILD" -type f 2>/dev/null
+            # Same self-scan exclusion as the pattern-scan find above.
+            find "$dir" \( -path '*/tests/fake_pkgbuilds' -prune \) -o -name "PKGBUILD" -type f -print 2>/dev/null
         done
     )
 


### PR DESCRIPTION
check_pkgbuild_caches() recursively finds every PKGBUILD/*.install under all AUR-helper cache dirs. Since archcanary ships its own malicious-pattern test fixtures under tests/fake_pkgbuilds/, rebuilding archcanary itself from AUR (cached source persists since our yay-init.lua template sets clean_after=false) makes the scanner flag its own test data as if it were a real package's threat.

Prune any directory ending in tests/fake_pkgbuilds during the find walk. The prune only matches when that path is a descendant of the configured cache dir, so it doesn't affect the test suite itself, which points PKGBUILD_CACHE_DIRS directly at individual fixture subdirs (an ancestor relationship, never pruned).

## Summary

<!-- What does this PR do? For a community_reports.txt addition, the
     package name(s) plus the checklist below is enough. -->

## If this adds to `lists/community_reports.txt`

- [ ] Package name is exact (matches the AUR package name / `pacman -Qm` output)
- [ ] Evidence is linked below — an AUR comment, mailing-list post, PKGBUILD diff, or writeup, not just suspicion
- [ ] Checked it isn't already in `package_list.txt`, `chaos_rat_packages.txt`, `malicious_russian_spam_packages.txt`, or `community_reports.txt`

**Evidence:** <!-- link(s) here -->

## For code changes

- [ ] Ran `bash tests/run_matching_tests.sh` (for `archcanary.sh` changes)
- [ ] Updated `--help`/man page/README if user-facing behavior changed
