### PR TITLE
fix: exclude own test fixtures from PKGBUILD/install cache scan

### DIFF
--- a/archcanary.sh
+++ b/archcanary.sh
@@ -2818,7 +2818,16 @@ check_pkgbuild_caches() {
     done < <(
         for dir in "${cache_dirs[@]}"; do
             [[ -d "$dir" ]] || continue
-            find "$dir" \( -name "PKGBUILD" -o -name "*.install" \) -type f 2>/dev/null
+            # -path match is relative to $dir's own descendants, so this only
+            # prunes tests/fake_pkgbuilds/ when it's nested *inside* a cached
+            # AUR build (e.g. archcanary's own AUR source tree). It never
+            # matches when a test harness points PKGBUILD_CACHE_DIRS directly
+            # at a fixture dir under tests/fake_pkgbuilds/ -- that path is an
+            # ancestor of $dir there, not a descendant, so find never walks
+            # into it. Without this, archcanary scanning its own cached AUR
+            # build flags its own obfuscation-technique test fixtures as if
+            # they were a real package's malicious PKGBUILD.
+            find "$dir" \( -path '*/tests/fake_pkgbuilds' -prune \) -o \( -name "PKGBUILD" -o -name "*.install" \) -type f -print 2>/dev/null
         done
     )
 
@@ -2865,7 +2874,8 @@ check_pkgbuild_caches() {
     done < <(
         for dir in "${cache_dirs[@]}"; do
             [[ -d "$dir" ]] || continue
-            find "$dir" -name "PKGBUILD" -type f 2>/dev/null
+            # Same self-scan exclusion as the pattern-scan find above.
+            find "$dir" \( -path '*/tests/fake_pkgbuilds' -prune \) -o -name "PKGBUILD" -type f -print 2>/dev/null
         done
     )
 


### PR DESCRIPTION
## Summary
- \`check_pkgbuild_caches()\` recursively scans every \`PKGBUILD\`/\`*.install\` file under all AUR-helper cache dirs (yay/paru/aurutils/pikaur/trizen). Since archcanary ships its own malicious-pattern test fixtures under \`tests/fake_pkgbuilds/\`, rebuilding/reinstalling archcanary itself from AUR (the cached source persists since our \`yay-init.lua\` template sets \`clean_after = false\`) makes the scanner flag its own test data as if it were a real package's threat — a guaranteed false-positive wall of ~14+ warnings on every archcanary AUR install/upgrade.
- Prunes any directory ending in \`tests/fake_pkgbuilds\` from both \`find\` walks in \`check_pkgbuild_caches()\` (the obfuscation-pattern scan and the ELF-binary scan).
- The prune only matches when \`tests/fake_pkgbuilds\` is a *descendant* of the configured cache dir (the real-world nested case). It does not match when the test harness points \`PKGBUILD_CACHE_DIRS\` directly at a fixture subdir — there \`tests/fake_pkgbuilds\` is an *ancestor* of the scanned dir, never visited by \`find\`, so it's never pruned — meaning the existing fixture-based tests keep exercising the real detection logic unchanged.

## Test plan
- [x] \`bash -n archcanary.sh\` — syntax check
- [x] Manual simulation: fixtures nested inside a fake \`~/.cache/yay/archcanary/src/archcanary-<ver>/tests/fake_pkgbuilds/\` tree now scan clean (previously produced ~14 warnings)
- [x] Manual simulation: \`PKGBUILD_CACHE_DIRS\` pointed directly at a fixture dir (as the test harness does) still triggers the warning
- [x] Full test suite: \`bash tests/run_matching_tests.sh\` — 144 PASS, 0 FAIL (~127s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)