### PR TITLE
fix: don't warn on pacman-owned eBPF tracepoint/kprobe loaders

### DIFF
--- a/archcanary.sh
+++ b/archcanary.sh
@@ -2358,8 +2358,10 @@ check_ebpf() {
 #
 # prog show — enumerates ALL programs loaded in the kernel, including unpinned
 #   ones an eBPF rootkit keeps alive via an open fd or BPF link (not visible
-#   in /sys/fs/bpf). Warns when stealth-associated hook types are present:
-#   kprobe/kretprobe/tracepoint/raw_tracepoint/perf_event/tracing/lsm.
+#   in /sys/fs/bpf). Stealth-associated hook types (kprobe/kretprobe/tracepoint/
+#   raw_tracepoint/perf_event/tracing/lsm) are INFO when every holding process is
+#   systemd/AppArmor/SELinux, a pacman-owned binary, or an allowlisted loader;
+#   they WARN only when an unrecognized process holds them.
 #
 # perf show — lists every kprobe/kretprobe/tracepoint/uprobe with the owning
 #   PID and the exact kernel function being hooked. Flags hooks on functions
@@ -2419,10 +2421,19 @@ check_bpftool() {
                 else
                     echo "  INFO: eBPF hook types present ($non_lsm_stealth) — all loaded by systemd / AppArmor / SELinux."
                 fi
-            elif [[ -z "$non_lsm_stealth" ]]; then
-                # Resolve each loader: if /proc/<pid>/exe is a pacman-owned binary, it's a known package
-                # (e.g. VPN daemons, security tools written in Python/Go/etc.) — downgrade to INFO.
-                local all_known=true resolved_entries=()
+            else
+                # A non-systemd process holds one or more of these programs. Resolve each
+                # loader: if /proc/<pid>/exe is a pacman-owned binary (VPN daemons, process
+                # schedulers like ananicy-cpp, security tools written in Python/Go/C++) or an
+                # allowlisted basename, it's known-good — downgrade to INFO. This holds
+                # regardless of hook type: a pacman-owned tracepoint/kprobe loader is as
+                # legitimate as a pacman-owned lsm loader. A *compromised* pacman-owned
+                # package is out of scope for this heuristic — the package-list, aur-audit
+                # and pacman.log-history checks cover that; here the loader's identity is
+                # the signal. Note: bpftool prints one "pids" line per program listing its
+                # fd holders; a program kept alive only by a pinned BPF link has none, so
+                # it is not attributed to any process and does not affect this verdict.
+                local all_known=true resolved_entries=() unknown_entries=()
                 while IFS= read -r entry; do
                     entry="${entry//[[:space:]]/}"
                     [[ -z "$entry" ]] && continue
@@ -2436,35 +2447,42 @@ check_bpftool() {
                             resolved_entries+=("$entry (allowlisted)")
                         else
                             resolved_entries+=("$entry")
+                            unknown_entries+=("$entry")
                             all_known=false
                         fi
                     else
                         resolved_entries+=("$entry")
+                        unknown_entries+=("$entry")
                         all_known=false
                     fi
                 done < <(sed 's/^\s*pids\s*//' <<<"$unknown_loaders" | tr ',' '\n')
 
-                local resolved_str
+                local resolved_str unknown_str
                 resolved_str=$(IFS=', '; echo "${resolved_entries[*]}")
+                unknown_str=$(IFS=', '; echo "${unknown_entries[*]}")
 
                 if [[ "$all_known" == true ]]; then
-                    echo "  INFO: lsm eBPF programs loaded by non-systemd process (pacman-owned or allowlisted)."
+                    if [[ -z "$non_lsm_stealth" ]]; then
+                        echo "  INFO: lsm eBPF programs loaded by non-systemd process (pacman-owned or allowlisted)."
+                    else
+                        echo "  INFO: eBPF hook types present ($non_lsm_stealth) — loaded by pacman-owned or allowlisted process."
+                    fi
                     echo "  Loaders: $resolved_str"
                 else
-                    echo "  WARNING: lsm eBPF programs loaded by unknown process (expected systemd / AppArmor / SELinux)."
-                    echo "  Unknown loaders: $resolved_str"
+                    if [[ -z "$non_lsm_stealth" ]]; then
+                        echo "  WARNING: lsm eBPF programs loaded by unknown process (expected systemd / AppArmor / SELinux)."
+                    else
+                        echo "  WARNING: stealth-associated program types present: $non_lsm_stealth"
+                        echo "  These hook types are used by eBPF rootkits to hide PIDs/files/processes."
+                        echo "  Review: sudo bpftool prog show ; sudo bpftool link show"
+                        echo "  (Legitimate if you run bpftrace/bcc/sysprof/Falco — confirm the source.)"
+                    fi
+                    echo "  Unknown loaders: $unknown_str"
                     echo "  Recognize this loader? Mark it known-good:"
                     echo "    pkexec /usr/lib/archcanary/root-helper --allowlist-add=bpftool:<loader-basename>"
                     echo "  If this looks like a false positive, report it at https://github.com/musqz/archcanary/issues"
                     worst_ret=1
                 fi
-            else
-                local warn_types="${non_lsm_stealth:-$stealth}"
-                echo "  WARNING: stealth-associated program types present: $warn_types"
-                echo "  These hook types are used by eBPF rootkits to hide PIDs/files/processes."
-                echo "  Review: sudo bpftool prog show ; sudo bpftool link show"
-                echo "  (Legitimate if you run bpftrace/bcc/sysprof/Falco — confirm the source.)"
-                worst_ret=1
             fi
         else
             echo "  Clean: only non-stealth program types (cgroup/net) loaded."

--- a/tests/run_matching_tests.sh
+++ b/tests/run_matching_tests.sh
@@ -1325,7 +1325,8 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# Test 14: check_bpftool — unknown LSM loader detection + allowlist
+# Test 14: check_bpftool — unknown loader detection + allowlist (lsm and
+#          non-lsm hook types both resolve via pacman -Qo / the allowlist)
 # ---------------------------------------------------------------------------
 test_check_bpftool_allowlist() {
     local base_args=(
@@ -1390,9 +1391,92 @@ SCRIPT
         fail "check_bpftool: allowlisted lsm loader → expected INFO+exit0, got rc=$rc, out: $out"
     fi
 
-    kill "$loader_pid" 2>/dev/null || true
-    wait "$loader_pid" 2>/dev/null || true
-    rm -f "$fake_bpftool" "$allow_file"
+    # Sub-test C: a non-lsm stealth type (tracepoint) held by a pacman-owned
+    # binary — the ananicy-cpp case — resolves to INFO, exit 0. Uses a real
+    # coreutils `sleep` so `/proc/<pid>/exe` is genuinely pacman-owned.
+    local pac_pid fake_bpftool_tp
+    sleep 30 &
+    pac_pid=$!
+    sleep 0.3
+    fake_bpftool_tp=$(mktemp)
+    cat > "$fake_bpftool_tp" <<SCRIPT
+#!/bin/sh
+if [ "\$1" = "prog" ]; then
+  cat <<PROGS
+7: tracepoint  name watch_exec  tag abcdef1234567890  gpl
+        loaded_at 2026-08-30T12:00:00+0200  uid 0
+        xlated 200B  jited 200B  memlock 4096B
+        pids sleep($pac_pid)
+PROGS
+fi
+SCRIPT
+    chmod +x "$fake_bpftool_tp"
+    rc=0
+    out=$(BPFTOOL_CMD="$fake_bpftool_tp" \
+        "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
+    if [[ $rc -eq 0 && "$out" == *"INFO: eBPF hook types present (tracepoint)"* && "$out" != *"WARNING"* ]]; then
+        pass "check_bpftool: pacman-owned tracepoint loader → INFO only, exit 0"
+    else
+        fail "check_bpftool: pacman-owned tracepoint loader → expected INFO+exit0, got rc=$rc, out: $out"
+    fi
+
+    # Sub-test D: the same tracepoint program held by an unknown (non-pacman)
+    # binary → WARNING naming the hook type, exit 1.
+    local fake_bpftool_tp_unknown
+    fake_bpftool_tp_unknown=$(mktemp)
+    cat > "$fake_bpftool_tp_unknown" <<SCRIPT
+#!/bin/sh
+if [ "\$1" = "prog" ]; then
+  cat <<PROGS
+7: tracepoint  name watch_exec  tag abcdef1234567890  gpl
+        loaded_at 2026-08-30T12:00:00+0200  uid 0
+        xlated 200B  jited 200B  memlock 4096B
+        pids test-loader($loader_pid)
+PROGS
+fi
+SCRIPT
+    chmod +x "$fake_bpftool_tp_unknown"
+    rc=0
+    out=$(BPFTOOL_CMD="$fake_bpftool_tp_unknown" \
+        "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
+    if [[ $rc -eq 1 && "$out" == *"stealth-associated program types present: tracepoint"* \
+          && "$out" == *"test-loader"* ]]; then
+        pass "check_bpftool: unknown tracepoint loader → WARNING (exit 1)"
+    else
+        fail "check_bpftool: unknown tracepoint loader → expected WARNING+exit1, got rc=$rc, out: $out"
+    fi
+
+    # Sub-test E: a tracepoint prog held by BOTH a pacman-owned and an unknown
+    # process → WARNING, but the "Unknown loaders" line lists only the unresolved
+    # one (regression guard: a resolved pacman-owned loader must not be labelled
+    # unknown).
+    local fake_bpftool_mixed unk_line
+    fake_bpftool_mixed=$(mktemp)
+    cat > "$fake_bpftool_mixed" <<SCRIPT
+#!/bin/sh
+if [ "\$1" = "prog" ]; then
+  cat <<PROGS
+7: tracepoint  name watch_exec  tag abcdef1234567890  gpl
+        loaded_at 2026-08-30T12:00:00+0200  uid 0
+        xlated 200B  jited 200B  memlock 4096B
+        pids sleep($pac_pid),test-loader($loader_pid)
+PROGS
+fi
+SCRIPT
+    chmod +x "$fake_bpftool_mixed"
+    rc=0
+    out=$(BPFTOOL_CMD="$fake_bpftool_mixed" \
+        "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
+    unk_line=$(grep 'Unknown loaders:' <<<"$out" || true)
+    if [[ $rc -eq 1 && "$unk_line" == *"test-loader"* && "$unk_line" != *"sleep("* ]]; then
+        pass "check_bpftool: WARNING 'Unknown loaders' excludes resolved pacman-owned loaders"
+    else
+        fail "check_bpftool: mixed loaders → expected only the unknown one listed, got rc=$rc line: $unk_line"
+    fi
+
+    kill "$loader_pid" "$pac_pid" 2>/dev/null || true
+    wait "$loader_pid" "$pac_pid" 2>/dev/null || true
+    rm -f "$fake_bpftool" "$allow_file" "$fake_bpftool_tp" "$fake_bpftool_tp_unknown" "$fake_bpftool_mixed"
     rm -rf "$tmpdir"
 }
 


### PR DESCRIPTION
## Summary

`check_bpftool`'s "stealth-associated program types" branch fired a blanket `WARNING` (exit 1) whenever a non-lsm hook type (`kprobe`/`kretprobe`/`tracepoint`/`raw_tracepoint`/`perf_event`/`tracing`) was present **and** any non-systemd process held a BPF program. Unlike the lsm-only branch (PRs #47/#49/#50/#53), it never resolved the holding process against `pacman -Qo` or the bpftool allowlist — so `bpftool_allowlist.conf` / `--allowlist-add=bpftool:` had no effect on it and there was no way to silence a legitimate finding.

**Reported on the Arch forum** ([thread](https://bbs.archlinux.org/), `made-lief` / CachyOS): `ananicy-cpp` — an auto-nice daemon, installed by default on CachyOS — attaches eBPF tracepoints to `sched_process_exec` / `sched_process_fork` to apply scheduling rules. The `perf show` sub-check already reports *"No hooks on rootkit-associated functions"* for it, but the prog-type heuristic still produced:

```
WARNING: stealth-associated program types present: tracepoint,tracing
```

and a failed `archcanary.service` after every pacman transaction, with the allowlist doing nothing.

### Change

- Merge the lsm-only and non-lsm branches into the same loader-resolution path. Any stealth hook type held **only** by pacman-owned or allowlisted processes → `INFO` (exit 0). An unrecognized holder → still `WARNING` (exit 1), now with the loader names and the `--allowlist-add=bpftool:` hint (previously lsm-only).
- The `perf show` sub-check is unchanged and still flags kprobes/tracepoints on rootkit target functions (`getdents`, `sys_kill`, `tcp_v4_connect`, …) regardless of who loaded them.
- The `WARNING`'s `Unknown loaders:` line now lists only the unresolved processes, not the pacman-owned ones resolved alongside them (was a latent bug in the lsm branch too).

### Before / after (reporter's scenario, `tracepoint`+`tracing` held by pacman-owned `ananicy-cpp`)

```
- WARNING: stealth-associated program types present: tracepoint,tracing   → RESULT: WARNINGS (exit 1)
+ INFO: eBPF hook types present (tracepoint,tracing) — loaded by pacman-owned or allowlisted process   → RESULT: CLEAN (exit 0)
```

### Known gaps (pre-existing, not addressed here)

Surfaced by `/code-review`; documenting rather than expanding scope:

1. **Type detection is global, holder attribution is per-`pids`-line.** A stealth program kept alive only by a pinned BPF link has no `pids` line, so it is not attributed to any process and does not affect the verdict. Properly closing this needs per-block `prog show` parsing plus `bpftool link show` enumeration — a separate change.
2. **A holder of a non-stealth (cgroup/net) program can still land in the resolve loop**, so a benign non-pacman process could be named in a `WARNING` alongside stealth types it doesn't actually hold. Pre-existing on the lsm path; this PR widens it to non-lsm types. Same mitigation (allowlist the loader) applies.

A follow-up doing block-level `type ↔ holder` correlation would resolve both.

## For code changes

- [x] Ran `bash tests/run_matching_tests.sh` — **147 PASS, 0 FAIL** (3 new `check_bpftool` sub-cases: pacman-owned tracepoint loader → INFO; unknown tracepoint loader → WARNING; `Unknown loaders` excludes resolved loaders)
- [x] No `--help` / man / README change — the WARNING↔INFO threshold moved, no new flags or documented behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)
