### PR TITLE
chore: set real sha256 for v0.1.32 tarball

### DIFF
--- a/packaging/.SRCINFO
+++ b/packaging/.SRCINFO
@@ -19,6 +19,6 @@ pkgbase = archcanary
 	backup = etc/archcanary/bpftool_allowlist.conf
 	backup = etc/archcanary/autostart_allowlist.conf
 	source = archcanary-0.1.32.tar.gz::https://github.com/musqz/archcanary/archive/v0.1.32.tar.gz
-	sha256sums = SKIP
+	sha256sums = 61f49e8ef54ad7bb2465d8d99f14af63ba2a68dfdb03f834cf535eb0746ec15e
 
 pkgname = archcanary

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -21,7 +21,7 @@ backup=('etc/archcanary/dkms_allowlist.conf'
         'etc/archcanary/autostart_allowlist.conf')
 install=archcanary.install
 source=("$pkgname-$pkgver.tar.gz::https://github.com/musqz/$pkgname/archive/v$pkgver.tar.gz")
-sha256sums=('SKIP')
+sha256sums=('61f49e8ef54ad7bb2465d8d99f14af63ba2a68dfdb03f834cf535eb0746ec15e')
 
 package() {
   cd "$srcdir/$pkgname-$pkgver"


### PR DESCRIPTION
Post-tag hash for **v0.1.32** (tag `v0.1.32` → `60a4198`, already pushed, not moved).

`sha256sums` in `PKGBUILD` + `.SRCINFO`: `SKIP` → `61f49e8ef54ad7bb2465d8d99f14af63ba2a68dfdb03f834cf535eb0746ec15e`

Verified against three fetches of `https://github.com/musqz/archcanary/archive/v0.1.32.tar.gz` (stable), and the tarball's `version.txt` reads `0.1.32`.

After this merges: copy `PKGBUILD` + `.SRCINFO` to the AUR clone and push (`archcanary.install` unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)