### PR TITLE
chore: set real sha256 for v0.1.33 tarball

### DIFF
--- a/packaging/.SRCINFO
+++ b/packaging/.SRCINFO
@@ -19,6 +19,6 @@ pkgbase = archcanary
 	backup = etc/archcanary/bpftool_allowlist.conf
 	backup = etc/archcanary/autostart_allowlist.conf
 	source = archcanary-0.1.33.tar.gz::https://github.com/musqz/archcanary/archive/v0.1.33.tar.gz
-	sha256sums = SKIP
+	sha256sums = 9ffbfe84eb572afd69720a341bade5d988efc41a18bfec2f1793f39023ada424
 
 pkgname = archcanary

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -21,7 +21,7 @@ backup=('etc/archcanary/dkms_allowlist.conf'
         'etc/archcanary/autostart_allowlist.conf')
 install=archcanary.install
 source=("$pkgname-$pkgver.tar.gz::https://github.com/musqz/$pkgname/archive/v$pkgver.tar.gz")
-sha256sums=('SKIP')
+sha256sums=('9ffbfe84eb572afd69720a341bade5d988efc41a18bfec2f1793f39023ada424')
 
 package() {
   cd "$srcdir/$pkgname-$pkgver"


### PR DESCRIPTION
Release PR 2 of 2 for v0.1.33.

`sha256sums` in `packaging/PKGBUILD` and `packaging/.SRCINFO`: `SKIP` → `9ffbfe84eb572afd69720a341bade5d988efc41a18bfec2f1793f39023ada424`

Verification:
- Hash stable across 3 separate fetches of `https://github.com/musqz/archcanary/archive/v0.1.33.tar.gz`
- `version.txt` inside the tarball reads `0.1.33`
- `makepkg --verifysource` → `archcanary-0.1.33.tar.gz ... Passed`

Tag `v0.1.33` stays on the #249 merge commit (`8415f27`) — not moved.

After merge: copy `PKGBUILD` + `.SRCINFO` into `~/AUR/archcanary` and push to the AUR remote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0175emdTfes4rPFx111fMTHP